### PR TITLE
feat: proactive EU upload consent warning

### DIFF
--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -1237,7 +1237,8 @@ async def api_sync_one(request: Request):
         if "upload consent" in err.lower() or "EU location" in err:
             return JSONResponse({
                 "synced": 0,
-                "error": "Garmin requires upload consent. Go to connect.garmin.com > Settings > Account > Privacy, enable 'Device Upload', then try again.",
+                "error": "Garmin requires upload consent. Open connect.garmin.com/modern/settings, scroll to Data, enable Device Upload, then try again.",
+                "eu_consent": True,
                 "remaining": -1, "done": False
             }, status_code=500)
 

--- a/src/hevy2garmin/templates/dashboard.html
+++ b/src/hevy2garmin/templates/dashboard.html
@@ -375,7 +375,10 @@ async function syncNow() {
                 errors++;
                 // Show user-friendly error messages
                 const err = data.error;
-                if (err.includes('Login failed') || err.includes('auth') || err.includes('OAuth') || err.includes('token')) {
+                if (data.eu_consent) {
+                    text.textContent = 'Garmin requires upload consent.';
+                    result.innerHTML = '<div class="toast toast-error">Enable Device Upload in <a href="https://connect.garmin.com/modern/settings" target="_blank" style="color: inherit; text-decoration: underline;">Garmin Settings</a> > Data, then try again.</div>';
+                } else if (err.includes('Login failed') || err.includes('auth') || err.includes('OAuth') || err.includes('token')) {
                     text.textContent = 'Garmin connection expired. Please reconnect from Setup.';
                     result.innerHTML = '<div class="toast toast-error">Garmin connection expired. <a href="/setup" style="color: inherit; text-decoration: underline;">Reconnect</a></div>';
                 } else {

--- a/src/hevy2garmin/templates/setup.html
+++ b/src/hevy2garmin/templates/setup.html
@@ -147,8 +147,12 @@ async function exchangeTicket() {
         });
         const storeData = await storeResp.json();
         if (storeData.ok) {
-            result.innerHTML = '<span style="font-size: 12px; color: var(--accent);">&#10003; Connected to Garmin!</span>';
-            setTimeout(function() { window.location.href = '/'; }, 1500);
+            result.innerHTML = '<span style="font-size: 12px; color: var(--accent);">&#10003; Connected to Garmin!</span>'
+                + '<p style="font-size: 11px; color: var(--text-muted); margin-top: 8px; line-height: 1.5;">'
+                + 'If your first sync fails with an upload error, go to '
+                + '<a href="https://connect.garmin.com/modern/settings" target="_blank" style="color: var(--accent);">Garmin Connect Settings</a>'
+                + ' > Data > enable <strong>Device Upload</strong>. This is a one-time requirement for some accounts.</p>';
+            setTimeout(function() { window.location.href = '/'; }, 5000);
         } else {
             result.innerHTML = '<span style="font-size: 12px; color: var(--red);">&#10007; ' + (storeData.error || 'Failed to save tokens') + '</span>';
         }


### PR DESCRIPTION
Closes #24 25 26

Fixes #1

- Show Device Upload hint on setup page after Garmin auth succeeds
- Dashboard shows clickable Garmin Settings link when EU consent error hits
- Server returns eu_consent flag for specific frontend handling