### PR TITLE
perf: cache workouts page in DB to eliminate Hevy API calls

### DIFF
--- a/src/hevy2garmin/db_interface.py
+++ b/src/hevy2garmin/db_interface.py
@@ -56,3 +56,11 @@ class Database(ABC):
     @abstractmethod
     def cache_hr(self, hevy_id: str, data: dict) -> None:
         """Cache HR data for a workout."""
+
+    @abstractmethod
+    def get_app_config(self, key: str) -> dict | None:
+        """Get a JSON value from the generic key-value app cache."""
+
+    @abstractmethod
+    def set_app_config(self, key: str, value: dict) -> None:
+        """Store a JSON value in the generic key-value app cache."""

--- a/src/hevy2garmin/db_sqlite.py
+++ b/src/hevy2garmin/db_sqlite.py
@@ -48,6 +48,13 @@ class SQLiteDatabase(Database):
                 cached_at TEXT DEFAULT (datetime('now'))
             )
         """)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS app_cache (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL,
+                updated_at TEXT DEFAULT (datetime('now'))
+            )
+        """)
         conn.commit()
         return conn
 
@@ -141,6 +148,25 @@ class SQLiteDatabase(Database):
         conn.execute(
             "INSERT OR REPLACE INTO hr_cache (hevy_id, data) VALUES (?, ?)",
             (hevy_id, json.dumps(data)),
+        )
+        conn.commit()
+        conn.close()
+
+    def get_app_config(self, key: str) -> dict | None:
+        conn = self._get_conn()
+        row = conn.execute(
+            "SELECT value FROM app_cache WHERE key = ?", (key,)
+        ).fetchone()
+        conn.close()
+        if row:
+            return json.loads(row[0])
+        return None
+
+    def set_app_config(self, key: str, value: dict) -> None:
+        conn = self._get_conn()
+        conn.execute(
+            "INSERT OR REPLACE INTO app_cache (key, value, updated_at) VALUES (?, ?, datetime('now'))",
+            (key, json.dumps(value)),
         )
         conn.commit()
         conn.close()

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -66,10 +66,9 @@ def _get_unmapped_exercises() -> list[tuple[str, int]]:
     # Try DB cache first (instant)
     try:
         _db = db.get_db()
-        if hasattr(_db, 'get_app_config'):
-            cached = _db.get_app_config("unmapped_exercises")
-            if cached and isinstance(cached, dict):
-                return sorted(cached.items(), key=lambda x: -x[1])
+        cached = _db.get_app_config("unmapped_exercises")
+        if cached and isinstance(cached, dict):
+            return sorted(cached.items(), key=lambda x: -x[1])
     except Exception:
         pass
 
@@ -268,15 +267,14 @@ async def dashboard(request: Request):
     try:
         # Try cached count from DB first (instant), fall back to Hevy API
         _db = db.get_db()
-        cached = _db.get_app_config("hevy_total") if hasattr(_db, 'get_app_config') else None
+        cached = _db.get_app_config("hevy_total")
         if cached and isinstance(cached, dict):
             hevy_total = cached.get("count", 0)
         else:
             from hevy2garmin.hevy import HevyClient
             hevy = HevyClient(api_key=config.get("hevy_api_key"))
             hevy_total = hevy.get_workout_count()
-            if hasattr(_db, 'set_app_config'):
-                _db.set_app_config("hevy_total", {"count": hevy_total})
+            _db.set_app_config("hevy_total", {"count": hevy_total})
     except Exception:
         pass
     mapping_count = 0
@@ -443,16 +441,23 @@ async def workouts_page(request: Request):
     fetch_error = None
     try:
         from hevy2garmin.hevy import HevyClient
-        from hevy2garmin.garmin import get_client
-        from hevy2garmin.matcher import fetch_garmin_activities, match_workouts_to_garmin
 
-        data = HevyClient(api_key=config.get("hevy_api_key")).get_workouts(page=page, page_size=10)
-        workouts_raw = data.get("workouts", [])
-        page_count = data.get("page_count", 1)
+        _db = db.get_db()
+        cache_key = f"hevy_workouts_page_{page}"
+
+        # Try DB cache first (populated during sync). Fall back to Hevy API on miss.
+        cached = _db.get_app_config(cache_key)
+        if cached:
+            workouts_raw = cached.get("workouts", [])
+            page_count = cached.get("page_count", 1)
+        else:
+            data = HevyClient(api_key=config.get("hevy_api_key")).get_workouts(page=page, page_size=10)
+            workouts_raw = data.get("workouts", [])
+            page_count = data.get("page_count", 1)
+            _db.set_app_config(cache_key, {"workouts": workouts_raw, "page_count": page_count})
 
         # Batch check sync status (1 query instead of N)
         hevy_ids = [w.get("id", "") for w in workouts_raw]
-        _db = db.get_db()
         synced_map = _db.get_synced_ids(hevy_ids) if hasattr(_db, 'get_synced_ids') else {
             wid: db.get_garmin_id(wid) for wid in hevy_ids if db.is_synced(wid)
         }
@@ -705,10 +710,9 @@ async def settings_save(
     if db.get_database_url():
         try:
             _db = db.get_db()
-            if hasattr(_db, 'set_app_config'):
-                _db.set_app_config("user_profile", config["user_profile"])
-                _db.set_app_config("timing", config["timing"])
-                _db.set_app_config("hr_fusion", config.get("hr_fusion", {}))
+            _db.set_app_config("user_profile", config["user_profile"])
+            _db.set_app_config("timing", config["timing"])
+            _db.set_app_config("hr_fusion", config.get("hr_fusion", {}))
         except Exception as e:
             logger.warning("Failed to persist settings to DB: %s", e)
 
@@ -1167,8 +1171,7 @@ async def api_sync_one(request: Request):
     total_count = hevy.get_workout_count()
     # Cache total for dashboard
     _db = db.get_db()
-    if hasattr(_db, 'set_app_config'):
-        _db.set_app_config("hevy_total", {"count": total_count})
+    _db.set_app_config("hevy_total", {"count": total_count})
     synced_count = db.get_synced_count()
     remaining = max(0, total_count - synced_count)
 
@@ -1181,6 +1184,11 @@ async def api_sync_one(request: Request):
         workouts = data.get("workouts", [])
         if not workouts:
             break
+        # Refresh the workouts-page cache while we already have the data
+        _db.set_app_config(
+            f"hevy_workouts_page_{page}",
+            {"workouts": workouts, "page_count": data.get("page_count", 1)},
+        )
         for w in workouts:
             if not unsynced and not db.is_synced(w["id"]) and w["id"] not in _failed_ids:
                 unsynced = w
@@ -1196,7 +1204,7 @@ async def api_sync_one(request: Request):
             break
         page += 1
     # Update unmapped cache in DB
-    if unmapped_found and hasattr(_db, 'set_app_config'):
+    if unmapped_found:
         _db.set_app_config("unmapped_exercises", unmapped_found)
 
     if not unsynced:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -74,6 +74,25 @@ class TestSyncTracking:
         assert recent[0]["calories"] == 250
         assert recent[0]["avg_hr"] == 95
 
+    def test_app_config_roundtrip(self, tmp_path: Path) -> None:
+        db = SQLiteDatabase(tmp_path / "test.db")
+        assert db.get_app_config("missing") is None
+        db.set_app_config("settings", {"theme": "dark", "n": 42})
+        assert db.get_app_config("settings") == {"theme": "dark", "n": 42}
+        # Overwrite
+        db.set_app_config("settings", {"theme": "light"})
+        assert db.get_app_config("settings") == {"theme": "light"}
+
+    def test_app_config_caches_workout_pages(self, tmp_path: Path) -> None:
+        """The workouts-page cache key pattern used by the server."""
+        db = SQLiteDatabase(tmp_path / "test.db")
+        page_data = {"workouts": [{"id": "a"}, {"id": "b"}], "page_count": 3}
+        db.set_app_config("hevy_workouts_page_1", page_data)
+        got = db.get_app_config("hevy_workouts_page_1")
+        assert got["page_count"] == 3
+        assert len(got["workouts"]) == 2
+        assert got["workouts"][0]["id"] == "a"
+
 
 @pytest.mark.skipif(not os.environ.get("DATABASE_URL"), reason="DATABASE_URL not set")
 class TestPostgresBackend:


### PR DESCRIPTION
Closes #30 31 32

Closes #3

## Summary
- Workouts page used to call the Hevy API on every load. Now it reads from a generic key-value `app_cache` table populated during sync.
- Cache hits = **zero outbound Hevy API calls** for `/workouts`. Cache misses fall back to the Hevy API and self-populate.
- Brings SQLite (local) to parity with Postgres (cloud) — caching used to silently no-op on local installs.

## Changes
- `db_interface.py` — `get_app_config` / `set_app_config` are now abstract methods (both backends must implement them)
- `db_sqlite.py` — adds `app_cache` table + matching methods
- `server.py`:
  - `workouts_page` reads `hevy_workouts_page_{page}` from the cache first, falls back to the Hevy API on miss and self-populates
  - `api_sync_one` refreshes the cache while it's already paginating through workouts
  - Drops 5 now-unnecessary `hasattr(_db, 'set_app_config')` / `'get_app_config'` defensive checks
- `tests/test_db.py` — two new tests covering app_config roundtrip and the workouts-page cache key pattern

## Test plan
- [x] `pytest tests/` → 79 passed, 7 skipped (was 77)
- [x] End-to-end smoke test of cache miss → populate → hit on a fresh SQLite DB
- [ ] After merge: verify on the Vercel deploy that `/workouts` no longer hits the Hevy API on warm loads (check function logs)