### PR TITLE
fix: stop renaming wrong Garmin activity on rapid sync

### DIFF
--- a/src/hevy2garmin/garmin.py
+++ b/src/hevy2garmin/garmin.py
@@ -90,22 +90,16 @@ def upload_fit(client: Garmin, fit_path: str | Path, workout_start: str | None =
     else:
         logger.info("  Upload response: %s", str(resp)[:200])
 
-    # Find the activity ID for renaming (retry with backoff if needed)
-    if not activity_id:
-        for attempt, wait in enumerate([3, 5], 1):
+    # Find the activity ID for renaming (retry with backoff if needed).
+    # Only match by start time — never grab "most recent activity" because
+    # that can pick up an unrelated run/ride and rename the wrong thing.
+    if not activity_id and workout_start:
+        for attempt, wait in enumerate([3, 5, 10], 1):
             time.sleep(wait)
-            if workout_start:
-                activity_id = find_activity_by_start_time(client, workout_start)
-            if not activity_id:
-                try:
-                    activities = _limiter.call(client.get_activities, 0, 5)
-                    if activities:
-                        activity_id = activities[0].get("activityId")
-                except Exception as e:
-                    logger.warning("  Could not find uploaded activity: %s", e)
+            activity_id = find_activity_by_start_time(client, workout_start)
             if activity_id:
                 break
-            logger.info("  Activity not found yet (attempt %d), retrying...", attempt)
+            logger.info("  Activity not found yet (attempt %d/%d), retrying...", attempt, 3)
 
     if activity_id:
         logger.info("  Found activity %s", activity_id)

--- a/src/hevy2garmin/templates/setup.html
+++ b/src/hevy2garmin/templates/setup.html
@@ -104,6 +104,10 @@
             Save &amp; Continue
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
         </button>
+
+        <p style="font-size: 11px; color: var(--text-muted); margin-top: 12px; line-height: 1.6; text-align: center;">
+            If your Garmin account is connected to Strava, synced workouts will also appear there.
+        </p>
     </form>
 </div>
 


### PR DESCRIPTION
Closes #37 38 39

Closes #36
Closes #37
Closes #38
Closes #39

## Summary
User reported all 3 synced workouts mapped to the same Garmin activity — an existing mountain bike ride. Root cause: the `get_activities[0]` fallback grabbed whatever was most recent on Garmin, not the uploaded workout.

- Remove the dangerous `get_activities[0]` fallback
- Only match by start time (`find_activity_by_start_time`)
- Add a 3rd retry at 10s (was 3s, 5s) for slow Garmin indexing
- If no match: skip rename. "Strength Training" default is better than corrupting an existing activity.
- Add Strava sync note to setup page

## Test plan
- [x] `pytest tests/` — 96 passed
- [x] Code review: no remaining `get_activities` calls in the upload path
- [ ] Manual test: upload 3 workouts rapidly, verify each gets its own activity or stays unnamed