### PR TITLE
feat: add unsync tools — API, dashboard button, CLI

### DIFF
--- a/src/hevy2garmin/cli.py
+++ b/src/hevy2garmin/cli.py
@@ -177,6 +177,40 @@ def cmd_unmapped(args: argparse.Namespace) -> None:
         print("FIT SDK categories: https://developer.garmin.com/fit/overview/")
 
 
+def cmd_unsync(args: argparse.Namespace) -> None:
+    """Remove sync records so workouts can be re-synced."""
+    if args.all:
+        if not args.confirm:
+            print("✗ --all requires --confirm to prevent accidents")
+            sys.exit(1)
+        count = db.unsync_all()
+        print(f"✓ Removed {count} sync records. All workouts will re-appear as pending.")
+        return
+
+    if not args.hevy_id:
+        print("✗ Provide a Hevy workout ID, or use --all --confirm")
+        sys.exit(1)
+
+    garmin_id = db.get_garmin_id(args.hevy_id)
+    if not db.unsync(args.hevy_id):
+        print(f"✗ No sync record found for {args.hevy_id}")
+        sys.exit(1)
+
+    print(f"✓ Removed sync record for {args.hevy_id}")
+    if garmin_id:
+        print(f"  Garmin activity: {garmin_id}")
+
+    if args.delete and garmin_id:
+        try:
+            config = load_config()
+            from hevy2garmin.garmin import get_client
+            client = get_client(config.get("garmin_email"))
+            client.delete_activity(int(garmin_id))
+            print(f"  ✓ Deleted Garmin activity {garmin_id}")
+        except Exception as e:
+            print(f"  ✗ Failed to delete from Garmin: {e}")
+
+
 def cmd_map(args: argparse.Namespace) -> None:
     """Add a custom exercise mapping."""
     save_custom_mapping(args.exercise_name, args.category, args.subcategory)
@@ -223,6 +257,13 @@ def main() -> None:
     map_parser.add_argument("--category", type=int, required=True, help="FIT SDK exercise category")
     map_parser.add_argument("--subcategory", type=int, required=True, help="FIT SDK exercise subcategory")
 
+    # unsync
+    unsync_parser = subparsers.add_parser("unsync", help="Remove sync record(s) so workouts can be re-synced")
+    unsync_parser.add_argument("hevy_id", nargs="?", help="Hevy workout ID to unsync")
+    unsync_parser.add_argument("--all", action="store_true", help="Remove ALL sync records (requires --confirm)")
+    unsync_parser.add_argument("--confirm", action="store_true", help="Required with --all")
+    unsync_parser.add_argument("--delete", action="store_true", help="Also delete the Garmin activity")
+
     # serve
     serve_parser = subparsers.add_parser("serve", help="Start web dashboard")
     serve_parser.add_argument("-p", "--port", type=int, default=8123, help="Port (default: 8123)")
@@ -250,6 +291,7 @@ def main() -> None:
             "list": cmd_list,
             "unmapped": cmd_unmapped,
             "map": cmd_map,
+            "unsync": cmd_unsync,
         }
         commands[args.command](args)
     except RuntimeError as e:

--- a/src/hevy2garmin/db.py
+++ b/src/hevy2garmin/db.py
@@ -86,6 +86,16 @@ def mark_synced(
     return get_db().mark_synced(hevy_id, garmin_activity_id, title, calories, avg_hr)
 
 
+def unsync(hevy_id: str, **kw) -> bool:
+    """Remove a sync record. Returns True if a record was deleted."""
+    return get_db().unsync(hevy_id)
+
+
+def unsync_all(**kw) -> int:
+    """Remove all sync records. Returns count of deleted records."""
+    return get_db().unsync_all()
+
+
 def get_synced_count(**kw) -> int:
     """Get total number of synced workouts."""
     return get_db().get_synced_count()

--- a/src/hevy2garmin/db_interface.py
+++ b/src/hevy2garmin/db_interface.py
@@ -58,6 +58,14 @@ class Database(ABC):
         """Cache HR data for a workout."""
 
     @abstractmethod
+    def unsync(self, hevy_id: str) -> bool:
+        """Remove a sync record. Returns True if a record was deleted."""
+
+    @abstractmethod
+    def unsync_all(self) -> int:
+        """Remove all sync records. Returns count of deleted records."""
+
+    @abstractmethod
     def get_app_config(self, key: str) -> dict | None:
         """Get a JSON value from the generic key-value app cache."""
 

--- a/src/hevy2garmin/db_postgres.py
+++ b/src/hevy2garmin/db_postgres.py
@@ -145,6 +145,22 @@ class PostgresDatabase(Database):
                 )
             conn.commit()
 
+    def unsync(self, hevy_id: str) -> bool:
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM synced_workouts WHERE hevy_id = %s", (hevy_id,))
+                deleted = cur.rowcount > 0
+            conn.commit()
+        return deleted
+
+    def unsync_all(self) -> int:
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM synced_workouts")
+                count = cur.rowcount
+            conn.commit()
+        return count
+
     def get_synced_count(self) -> int:
         with self._get_conn() as conn:
             with conn.cursor() as cur:

--- a/src/hevy2garmin/db_sqlite.py
+++ b/src/hevy2garmin/db_sqlite.py
@@ -94,6 +94,22 @@ class SQLiteDatabase(Database):
         conn.commit()
         conn.close()
 
+    def unsync(self, hevy_id: str) -> bool:
+        conn = self._get_conn()
+        cur = conn.execute("DELETE FROM synced_workouts WHERE hevy_id = ?", (hevy_id,))
+        deleted = cur.rowcount > 0
+        conn.commit()
+        conn.close()
+        return deleted
+
+    def unsync_all(self) -> int:
+        conn = self._get_conn()
+        cur = conn.execute("DELETE FROM synced_workouts")
+        count = cur.rowcount
+        conn.commit()
+        conn.close()
+        return count
+
     def get_synced_count(self) -> int:
         conn = self._get_conn()
         count = conn.execute("SELECT COUNT(*) FROM synced_workouts").fetchone()[0]

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -945,6 +945,61 @@ async def api_sync_single(request: Request, workout_id: str):
         return HTMLResponse(f'<td colspan="5" style="color: var(--pico-del-color);">Failed: {e}</td>')
 
 
+@app.post("/api/unsync/{hevy_id}")
+async def api_unsync(request: Request, hevy_id: str):
+    """Remove a workout's sync record so it can be re-synced."""
+    from fastapi.responses import JSONResponse
+
+    garmin_id = db.get_garmin_id(hevy_id)
+    deleted = db.unsync(hevy_id)
+    if not deleted:
+        return JSONResponse({"ok": False, "error": "Not found"}, status_code=404)
+
+    # Optionally delete the Garmin activity too
+    form = await request.form()
+    delete_garmin = form.get("delete_garmin") in ("true", "1", True)
+    garmin_deleted = False
+    if delete_garmin and garmin_id:
+        try:
+            config = load_config()
+            from hevy2garmin.garmin import get_client
+            client = get_client(config.get("garmin_email"))
+            client.delete_activity(int(garmin_id))
+            garmin_deleted = True
+            logger.info("Deleted Garmin activity %s for hevy workout %s", garmin_id, hevy_id)
+        except Exception as e:
+            logger.warning("Failed to delete Garmin activity %s: %s", garmin_id, e)
+
+    # Clear cached workout pages so the workouts page reflects the change
+    _db = db.get_db()
+    for page in range(1, 11):
+        _db.set_app_config(f"hevy_workouts_page_{page}", {})
+
+    logger.info("Unsynced workout %s (garmin_id=%s, garmin_deleted=%s)", hevy_id, garmin_id, garmin_deleted)
+    return JSONResponse({"ok": True, "garmin_deleted": garmin_deleted})
+
+
+@app.post("/api/unsync-all")
+async def api_unsync_all(request: Request):
+    """Remove ALL sync records. Does not delete from Garmin."""
+    from fastapi.responses import JSONResponse
+
+    form = await request.form()
+    confirm = form.get("confirm", "")
+    if confirm != "RESET":
+        return JSONResponse({"ok": False, "error": "Send confirm=RESET to proceed"}, status_code=400)
+
+    count = db.unsync_all()
+
+    # Clear cached workout pages
+    _db = db.get_db()
+    for page in range(1, 11):
+        _db.set_app_config(f"hevy_workouts_page_{page}", {})
+
+    logger.info("Unsynced all %d workouts", count)
+    return JSONResponse({"ok": True, "count": count})
+
+
 @app.post("/api/toggle-autosync", response_class=HTMLResponse)
 async def api_toggle_autosync(request: Request):
     form = await request.form()

--- a/src/hevy2garmin/templates/workouts.html
+++ b/src/hevy2garmin/templates/workouts.html
@@ -149,6 +149,15 @@
                     Garmin
                 </a>
                 {% endif %}
+                {% if w.status == 'uploaded' %}
+                <button type="button"
+                    onclick="unsyncWorkout('{{ w.id }}', this)"
+                    style="display: inline-flex; align-items: center; gap: 4px; padding: 3px 10px; border-radius: 6px; font-size: 12px; font-weight: 600; background: rgba(239,68,68,0.12); color: #f87171; border: none; cursor: pointer;"
+                    title="Remove sync record so this workout can be re-synced">
+                    <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M3 6h18M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+                    Unsync
+                </button>
+                {% endif %}
             </div>
             <!-- Exercise details -->
             <div style="margin-top: 4px;">
@@ -443,6 +452,28 @@ async function loadHRChart(hevyId, summaryEl) {
         hrChartCache[hevyId] = true;
     } catch (e) {
         container.innerHTML = '<p style="color: var(--text-muted); font-size: 13px;">Failed to load HR data: ' + e.message + '</p>';
+    }
+}
+
+async function unsyncWorkout(hevyId, btn) {
+    if (!confirm('Remove this sync record? The workout will re-appear as "pending" and can be synced again.\n\nThe Garmin activity won\'t be deleted — manage that from Garmin Connect if needed.')) return;
+    btn.disabled = true;
+    btn.textContent = 'Removing…';
+    try {
+        const form = new FormData();
+        const resp = await fetch('/api/unsync/' + hevyId, { method: 'POST', body: form });
+        const data = await resp.json();
+        if (data.ok) {
+            window.location.reload();
+        } else {
+            alert('Failed: ' + (data.error || 'Unknown error'));
+            btn.disabled = false;
+            btn.textContent = 'Unsync';
+        }
+    } catch (e) {
+        alert('Network error: ' + e.message);
+        btn.disabled = false;
+        btn.textContent = 'Unsync';
     }
 }
 </script>

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -74,6 +74,29 @@ class TestSyncTracking:
         assert recent[0]["calories"] == 250
         assert recent[0]["avg_hr"] == 95
 
+    def test_unsync_single(self, tmp_path: Path) -> None:
+        db = SQLiteDatabase(tmp_path / "test.db")
+        db.mark_synced("w1", garmin_activity_id="100", title="Push")
+        db.mark_synced("w2", garmin_activity_id="200", title="Pull")
+        assert db.get_synced_count() == 2
+        assert db.unsync("w1") is True
+        assert db.get_synced_count() == 1
+        assert db.is_synced("w1") is False
+        assert db.is_synced("w2") is True
+
+    def test_unsync_nonexistent(self, tmp_path: Path) -> None:
+        db = SQLiteDatabase(tmp_path / "test.db")
+        assert db.unsync("nonexistent") is False
+
+    def test_unsync_all(self, tmp_path: Path) -> None:
+        db = SQLiteDatabase(tmp_path / "test.db")
+        db.mark_synced("w1", title="Push")
+        db.mark_synced("w2", title="Pull")
+        db.mark_synced("w3", title="Legs")
+        count = db.unsync_all()
+        assert count == 3
+        assert db.get_synced_count() == 0
+
     def test_app_config_roundtrip(self, tmp_path: Path) -> None:
         db = SQLiteDatabase(tmp_path / "test.db")
         assert db.get_app_config("missing") is None


### PR DESCRIPTION
Closes #41 42 43

Closes #40
Closes #41
Closes #42
Closes #43

## Summary
Users who hit #36 (all workouts synced to the same wrong Garmin activity) had no way to recover. This adds unsync/cleanup tools across all interfaces.

### API
- `POST /api/unsync/<hevy_id>` — remove one sync record. Optional `delete_garmin=true` form param to also delete the Garmin activity.
- `POST /api/unsync-all` — remove ALL sync records. Requires `confirm=RESET` in form body.
- Both clear the workout page cache so changes reflect immediately.

### Dashboard
- Red "Unsync" button on each synced workout in the workouts page.
- Confirmation dialog explains what will happen.
- Page reloads after unsync, workout reappears as "pending".

### CLI
```bash
hevy2garmin unsync <hevy-id>            # Remove sync record
hevy2garmin unsync <hevy-id> --delete   # Also delete from Garmin
hevy2garmin unsync --all --confirm      # Clear all sync records
```

### DB layer
- `unsync(hevy_id)` and `unsync_all()` added to abstract `Database` interface.
- Implemented in both SQLite and Postgres backends.

## Test plan
- [x] `pytest tests/` → 99 passed (was 96 → +3 new unsync tests)
- [x] Manual: mark_synced → unsync → verify is_synced returns False
- [ ] After merge: verify the "Unsync" button appears on synced workouts in the dashboard