### PR TITLE
fix: sync lock, warmup descriptions, Hevy auth error handling

### DIFF
--- a/src/hevy2garmin/garmin.py
+++ b/src/hevy2garmin/garmin.py
@@ -204,13 +204,17 @@ def generate_description(workout: dict, calories: int | None = None, avg_hr: int
         lines.append("")
         for ex in exercises:
             name = ex.get("title") or ex.get("name", "Unknown")
-            sets = [s for s in ex.get("sets", []) if s.get("type") == "normal"]
-            if sets:
-                weights = [s.get("weight_kg") or s.get("weight", 0) for s in sets]
-                reps = [s.get("reps", 0) for s in sets]
+            all_sets = ex.get("sets", [])
+            normal = [s for s in all_sets if s.get("type") == "normal"]
+            warmup = [s for s in all_sets if s.get("type") == "warmup"]
+            if normal:
+                weights = [s.get("weight_kg") or s.get("weight", 0) for s in normal]
+                reps = [s.get("reps", 0) for s in normal]
                 top_weight = max(weights) if weights else 0
                 top_reps = max(reps) if reps else 0
-                lines.append(f"• {name}: {len(sets)} sets · {top_weight:.1f}kg × {top_reps}")
+                lines.append(f"• {name}: {len(normal)} sets · {top_weight:.1f}kg × {top_reps}")
+            elif warmup:
+                lines.append(f"• {name}: {len(warmup)} warmup sets")
 
     lines.append("\n— synced by hevy2garmin")
     return "\n".join(lines)

--- a/src/hevy2garmin/hevy.py
+++ b/src/hevy2garmin/hevy.py
@@ -12,6 +12,10 @@ from urllib3.util.retry import Retry
 
 logger = logging.getLogger("hevy2garmin")
 
+
+class HevyAuthError(Exception):
+    """Raised when the Hevy API rejects the API key (401/403)."""
+
 DEFAULT_BASE_URL = "https://api.hevyapp.com/v1"
 API_CALL_DELAY = 0.5
 
@@ -47,6 +51,11 @@ class HevyClient:
         """Make a GET request with rate limiting."""
         url = f"{self.base_url}{path}"
         resp = self.session.get(url, params=params, timeout=30)
+        if resp.status_code in (401, 403):
+            raise HevyAuthError(
+                "Hevy API key is invalid or expired. "
+                "Check your Hevy Pro subscription and regenerate the key at hevy.com/settings."
+            )
         resp.raise_for_status()
         # Log rate-limit headers when approaching the limit
         remaining = resp.headers.get("X-RateLimit-Remaining") or resp.headers.get("x-ratelimit-remaining")

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -55,6 +55,7 @@ app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
 
 _autosync_timer: threading.Timer | None = None
 _autosync_lock = threading.Lock()
+_sync_executing = threading.Lock()  # Prevents concurrent sync execution
 _last_sync_time: datetime | None = None
 _unmapped_cache: list[tuple[str, int]] | None = None
 _unmapped_cache_time: float = 0
@@ -109,11 +110,28 @@ def _run_autosync() -> None:
     if not auto_cfg.get("enabled", False):
         return
 
+    if not _sync_executing.acquire(blocking=False):
+        logger.info("Auto-sync: skipped — another sync is running")
+        _schedule_autosync(auto_cfg.get("interval_minutes", 30))
+        return
+
     logger.info("Auto-sync: running scheduled sync")
+    hevy_auth_failed = False
     try:
         result = sync(limit=10, dry_run=False)
     except Exception as e:
+        from hevy2garmin.hevy import HevyAuthError
+        if isinstance(e, HevyAuthError):
+            logger.error("Auto-sync: Hevy API key invalid — disabling auto-sync. %s", e)
+            config["auto_sync"]["enabled"] = False
+            save_config(config)
+            hevy_auth_failed = True
         result = {"synced": 0, "skipped": 0, "failed": 1, "error": str(e)}
+    finally:
+        _sync_executing.release()
+
+    if hevy_auth_failed:
+        return  # Don't reschedule
 
     _last_sync_time = datetime.now(timezone.utc)
     _record_sync_log(result, trigger="auto")
@@ -1274,6 +1292,19 @@ async def api_sync_one(request: Request):
     """Sync exactly 1 unsynced workout. Returns JSON with status."""
     from fastapi.responses import JSONResponse
 
+    if not _sync_executing.acquire(blocking=False):
+        return JSONResponse({"error": "Sync already running", "busy": True})
+
+    try:
+        return await _do_sync_one(request)
+    finally:
+        _sync_executing.release()
+
+
+async def _do_sync_one(request: Request):
+    """Inner sync logic, called with _sync_executing lock held."""
+    from fastapi.responses import JSONResponse
+
     config = load_config()
     hevy_api_key = config.get("hevy_api_key")
 
@@ -1377,6 +1408,11 @@ async def api_sync_one(request: Request):
     except Exception as e:
         logger.error("Sync failed for %s: %s", unsynced.get("title", "?"), str(e)[:300])
         err = str(e)
+
+        # Hevy API key invalid — hard stop, point to setup
+        from hevy2garmin.hevy import HevyAuthError
+        if isinstance(e, HevyAuthError):
+            return JSONResponse({"synced": 0, "error": "Hevy API key is invalid or expired. Go to Setup to enter a new key.", "remaining": -1, "done": False}, status_code=401)
 
         # Auth errors are hard stops — user needs to reconnect
         if "Login failed" in err or "OAuth" in err or "token" in err:

--- a/src/hevy2garmin/templates/dashboard.html
+++ b/src/hevy2garmin/templates/dashboard.html
@@ -387,6 +387,11 @@ async function syncNow() {
             const resp = await fetch('/api/sync-one', { method: 'POST' });
             const data = await resp.json();
 
+            if (data.busy) {
+                text.textContent = 'Another sync is already running. Please wait.';
+                break;
+            }
+
             if (data.error && !data.title) {
                 errors++;
                 // Show user-friendly error messages
@@ -394,6 +399,9 @@ async function syncNow() {
                 if (data.eu_consent) {
                     text.textContent = 'Garmin requires upload consent.';
                     result.innerHTML = '<div class="toast toast-error">Enable Device Upload in <a href="https://connect.garmin.com/modern/settings" target="_blank" style="color: inherit; text-decoration: underline;">Garmin Settings</a> > Data, then try again.</div>';
+                } else if (err.includes('Hevy API key')) {
+                    text.textContent = 'Hevy API key expired. Enter a new key in Setup.';
+                    result.innerHTML = '<div class="toast toast-error">Hevy API key invalid. <a href="/setup" style="color: inherit; text-decoration: underline;">Go to Setup</a></div>';
                 } else if (err.includes('Login failed') || err.includes('auth') || err.includes('OAuth') || err.includes('token')) {
                     text.textContent = 'Garmin connection expired. Please reconnect from Setup.';
                     result.innerHTML = '<div class="toast toast-error">Garmin connection expired. <a href="/setup" style="color: inherit; text-decoration: underline;">Reconnect</a></div>';


### PR DESCRIPTION
Closes #51 52 59 60 61 62 63

Closes #50, #51, #52, #59, #60, #61, #62, #63

## Summary
Three sync reliability fixes for real-world user profiles:

### 1. Sync execution lock (#50)
- `_sync_executing = threading.Lock()` prevents concurrent syncs
- `api_sync_one` acquires lock; returns `{"busy": true}` if another sync is running
- `_run_autosync` skips gracefully if lock is held
- Dashboard JS handles `data.busy` with "Another sync is already running" message

### 2. Warmup set descriptions (#62)
- `generate_description()` was silently skipping exercises with only warmup sets
- Now shows "Bench Press: 2 warmup sets" for warmup-only exercises

### 3. Hevy API key expiry (#59)
- New `HevyAuthError` exception raised on HTTP 401/403 from Hevy API
- `_do_sync_one` catches it and returns clear "API key expired" message with link to /setup
- Auto-sync disables itself on `HevyAuthError` to stop retrying with a dead key
- Dashboard JS shows the auth error distinctly from Garmin auth errors

## Test plan
- [x] `pytest tests/` → 99 passed
- [x] Smoke test: warmup-only exercise shows "1 warmup sets" in description
- [x] HevyAuthError import and raise works
- [x] `_sync_executing` lock import verified
- [ ] Manual: start auto-sync + manual sync simultaneously → should get "busy" message