### PR TITLE
feat: detect workouts edited on Hevy since sync, offer re-sync

### DIFF
--- a/src/hevy2garmin/db.py
+++ b/src/hevy2garmin/db.py
@@ -80,10 +80,11 @@ def mark_synced(
     title: str = "",
     calories: int | None = None,
     avg_hr: int | None = None,
+    hevy_updated_at: str | None = None,
     **kw,
 ) -> None:
     """Record a successfully synced workout."""
-    return get_db().mark_synced(hevy_id, garmin_activity_id, title, calories, avg_hr)
+    return get_db().mark_synced(hevy_id, garmin_activity_id, title, calories, avg_hr, hevy_updated_at)
 
 
 def unsync(hevy_id: str, **kw) -> bool:

--- a/src/hevy2garmin/db_interface.py
+++ b/src/hevy2garmin/db_interface.py
@@ -24,8 +24,13 @@ class Database(ABC):
         title: str = "",
         calories: int | None = None,
         avg_hr: int | None = None,
+        hevy_updated_at: str | None = None,
     ) -> None:
         """Record a successfully synced workout."""
+
+    @abstractmethod
+    def get_stale_synced(self, workouts: list[dict]) -> list[str]:
+        """Return hevy_ids of synced workouts edited on Hevy since sync."""
 
     @abstractmethod
     def get_synced_count(self) -> int:

--- a/src/hevy2garmin/db_postgres.py
+++ b/src/hevy2garmin/db_postgres.py
@@ -83,6 +83,11 @@ class PostgresDatabase(Database):
                         subcategory INTEGER NOT NULL DEFAULT 0
                     )
                 """)
+                # Migration: add hevy_updated_at if missing
+                try:
+                    cur.execute("ALTER TABLE synced_workouts ADD COLUMN hevy_updated_at TEXT")
+                except Exception:
+                    conn.rollback()
                 cur.execute("""
                     CREATE TABLE IF NOT EXISTS app_cache (
                         key TEXT PRIMARY KEY,
@@ -127,23 +132,46 @@ class PostgresDatabase(Database):
         title: str = "",
         calories: int | None = None,
         avg_hr: int | None = None,
+        hevy_updated_at: str | None = None,
     ) -> None:
         with self._get_conn() as conn:
             with conn.cursor() as cur:
                 cur.execute(
                     """
-                    INSERT INTO synced_workouts (hevy_id, garmin_activity_id, title, calories, avg_hr)
-                    VALUES (%s, %s, %s, %s, %s)
+                    INSERT INTO synced_workouts (hevy_id, garmin_activity_id, title, calories, avg_hr, hevy_updated_at)
+                    VALUES (%s, %s, %s, %s, %s, %s)
                     ON CONFLICT (hevy_id) DO UPDATE SET
                         garmin_activity_id = EXCLUDED.garmin_activity_id,
                         title = EXCLUDED.title,
                         calories = EXCLUDED.calories,
                         avg_hr = EXCLUDED.avg_hr,
+                        hevy_updated_at = EXCLUDED.hevy_updated_at,
                         synced_at = NOW()
                     """,
-                    (hevy_id, garmin_activity_id, title, calories, avg_hr),
+                    (hevy_id, garmin_activity_id, title, calories, avg_hr, hevy_updated_at),
                 )
             conn.commit()
+
+    def get_stale_synced(self, workouts: list[dict]) -> list[str]:
+        """Return hevy_ids of synced workouts edited on Hevy since sync."""
+        if not workouts:
+            return []
+        hevy_ids = [w.get("id", "") for w in workouts]
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT hevy_id, hevy_updated_at FROM synced_workouts WHERE hevy_id = ANY(%s) AND hevy_updated_at IS NOT NULL",
+                    (hevy_ids,)
+                )
+                stored = {r["hevy_id"]: r["hevy_updated_at"] for r in cur.fetchall()}
+        stale = []
+        for w in workouts:
+            wid = w.get("id", "")
+            old_ts = stored.get(wid)
+            new_ts = w.get("updated_at") or ""
+            if old_ts and new_ts and new_ts > old_ts:
+                stale.append(wid)
+        return stale
 
     def unsync(self, hevy_id: str) -> bool:
         with self._get_conn() as conn:

--- a/src/hevy2garmin/db_sqlite.py
+++ b/src/hevy2garmin/db_sqlite.py
@@ -48,6 +48,11 @@ class SQLiteDatabase(Database):
                 cached_at TEXT DEFAULT (datetime('now'))
             )
         """)
+        # Migration: add hevy_updated_at if missing
+        try:
+            conn.execute("ALTER TABLE synced_workouts ADD COLUMN hevy_updated_at TEXT")
+        except Exception:
+            pass  # Column already exists
         conn.execute("""
             CREATE TABLE IF NOT EXISTS app_cache (
                 key TEXT PRIMARY KEY,
@@ -82,17 +87,40 @@ class SQLiteDatabase(Database):
         title: str = "",
         calories: int | None = None,
         avg_hr: int | None = None,
+        hevy_updated_at: str | None = None,
     ) -> None:
         conn = self._get_conn()
         conn.execute(
             """
-            INSERT OR REPLACE INTO synced_workouts (hevy_id, garmin_activity_id, title, calories, avg_hr)
-            VALUES (?, ?, ?, ?, ?)
+            INSERT OR REPLACE INTO synced_workouts (hevy_id, garmin_activity_id, title, calories, avg_hr, hevy_updated_at)
+            VALUES (?, ?, ?, ?, ?, ?)
             """,
-            (hevy_id, garmin_activity_id, title, calories, avg_hr),
+            (hevy_id, garmin_activity_id, title, calories, avg_hr, hevy_updated_at),
         )
         conn.commit()
         conn.close()
+
+    def get_stale_synced(self, workouts: list[dict]) -> list[str]:
+        """Return hevy_ids of synced workouts edited on Hevy since sync."""
+        if not workouts:
+            return []
+        conn = self._get_conn()
+        placeholders = ",".join("?" for _ in workouts)
+        hevy_ids = [w.get("id", "") for w in workouts]
+        rows = conn.execute(
+            f"SELECT hevy_id, hevy_updated_at FROM synced_workouts WHERE hevy_id IN ({placeholders}) AND hevy_updated_at IS NOT NULL",
+            hevy_ids,
+        ).fetchall()
+        conn.close()
+        stored = {r[0]: r[1] for r in rows}
+        stale = []
+        for w in workouts:
+            wid = w.get("id", "")
+            old_ts = stored.get(wid)
+            new_ts = w.get("updated_at") or ""
+            if old_ts and new_ts and new_ts > old_ts:
+                stale.append(wid)
+        return stale
 
     def unsync(self, hevy_id: str) -> bool:
         conn = self._get_conn()

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -479,6 +479,8 @@ async def workouts_page(request: Request):
         synced_map = _db.get_synced_ids(hevy_ids) if hasattr(_db, 'get_synced_ids') else {
             wid: db.get_garmin_id(wid) for wid in hevy_ids if db.is_synced(wid)
         }
+        # Check for workouts edited on Hevy since last sync
+        stale_ids = set(_db.get_stale_synced(workouts_raw))
 
         # Get profile for calorie calculation
         profile = config.get("user_profile", {})
@@ -494,6 +496,8 @@ async def workouts_page(request: Request):
                 gid = synced_map[w["id"]]
                 if gid:
                     w["garmin_match"] = {"garmin_id": gid, "garmin_name": w.get("title", "")}
+                if w["id"] in stale_ids:
+                    w["edited_since_sync"] = True
             else:
                 w["status"] = "pending"
 
@@ -964,7 +968,7 @@ async def api_sync_single(request: Request, workout_id: str):
             if aid:
                 rename_activity(garmin_client, aid, workout["title"])
                 set_description(garmin_client, aid, generate_description(workout, calories=result.get("calories"), avg_hr=result.get("avg_hr")))
-            db.mark_synced(hevy_id=workout_id, garmin_activity_id=str(aid) if aid else None, title=workout["title"], calories=result.get("calories"), avg_hr=result.get("avg_hr"))
+            db.mark_synced(hevy_id=workout_id, garmin_activity_id=str(aid) if aid else None, title=workout["title"], calories=result.get("calories"), avg_hr=result.get("avg_hr"), hevy_updated_at=workout.get("updated_at"))
 
         start = (workout.get("start_time") or "")[:16]
         return HTMLResponse(f'<tr><td><span class="badge badge-success">✓ Synced</span></td><td>{start}</td><td><strong>{workout["title"]}</strong></td><td>{len(workout.get("exercises", []))}</td><td></td></tr>')
@@ -1401,6 +1405,7 @@ async def _do_sync_one(request: Request):
             title=unsynced["title"],
             calories=result.get("calories"),
             avg_hr=result.get("avg_hr"),
+            hevy_updated_at=unsynced.get("updated_at"),
         )
 
         remaining = hevy.get_workout_count() - db.get_synced_count()

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -171,6 +171,7 @@ def sync(
                     title=title,
                     calories=result.get("calories"),
                     avg_hr=result.get("avg_hr"),
+                    hevy_updated_at=workout.get("updated_at"),
                 )
                 stats["synced"] += 1
                 logger.info("  ✓ Synced → Garmin activity %s", activity_id)

--- a/src/hevy2garmin/templates/workouts.html
+++ b/src/hevy2garmin/templates/workouts.html
@@ -122,6 +122,12 @@
                     <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>
                     Uploaded
                 </span>
+                {% if w.edited_since_sync %}
+                <span class="badge" style="background: rgba(251,191,36,0.15); color: #fbbf24; border-color: rgba(251,191,36,0.3);">
+                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+                    Edited on Hevy
+                </span>
+                {% endif %}
                 {% elif w.status == 'matched' %}
                 <span class="badge badge-success">
                     <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>
@@ -148,6 +154,15 @@
                     <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>
                     Garmin
                 </a>
+                {% endif %}
+                {% if w.status == 'uploaded' and w.edited_since_sync %}
+                <button type="button"
+                    onclick="resyncWorkout('{{ w.id }}', this)"
+                    style="display: inline-flex; align-items: center; gap: 4px; padding: 3px 10px; border-radius: 6px; font-size: 12px; font-weight: 600; background: rgba(251,191,36,0.12); color: #fbbf24; border: none; cursor: pointer;"
+                    title="Unsync and re-upload with the latest Hevy data">
+                    <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
+                    Re-sync
+                </button>
                 {% endif %}
                 {% if w.status == 'uploaded' %}
                 <button type="button"
@@ -452,6 +467,26 @@ async function loadHRChart(hevyId, summaryEl) {
         hrChartCache[hevyId] = true;
     } catch (e) {
         container.innerHTML = '<p style="color: var(--text-muted); font-size: 13px;">Failed to load HR data: ' + e.message + '</p>';
+    }
+}
+
+async function resyncWorkout(hevyId, btn) {
+    if (!confirm('Re-sync this workout? It will be unsynced from Garmin and re-uploaded with the latest Hevy data.')) return;
+    btn.disabled = true;
+    btn.textContent = 'Re-syncing…';
+    try {
+        // Step 1: unsync
+        const unsyncResp = await fetch('/api/unsync/' + hevyId, { method: 'POST', body: new FormData() });
+        const unsyncData = await unsyncResp.json();
+        if (!unsyncData.ok) { alert('Unsync failed: ' + (unsyncData.error || 'Unknown')); btn.disabled = false; btn.textContent = 'Re-sync'; return; }
+        // Step 2: re-sync
+        const syncResp = await fetch('/api/sync/' + hevyId, { method: 'POST' });
+        if (syncResp.ok) { window.location.reload(); }
+        else { alert('Re-sync upload failed. The workout is now pending — try syncing from the dashboard.'); window.location.reload(); }
+    } catch (e) {
+        alert('Network error: ' + e.message);
+        btn.disabled = false;
+        btn.textContent = 'Re-sync';
     }
 }
 


### PR DESCRIPTION
Closes #56
Closes #57
Closes #58

## Summary
If a user edits a workout on Hevy after sync (adds sets, fixes weights, changes exercises), the Garmin version used to stay stale. Now the system detects this and offers a one-click fix.

### DB layer
- `hevy_updated_at` column added to `synced_workouts` (both SQLite + Postgres, auto-migrated)
- `mark_synced` now accepts `hevy_updated_at` parameter — all 3 sync paths updated
- `get_stale_synced(workouts)` compares Hevy's `updated_at` against stored `hevy_updated_at`

### Workouts page
- Amber "Edited on Hevy" badge on workouts where Hevy's `updated_at` is newer than our stored timestamp
- "Re-sync" button (amber): unsyncs the workout, then re-uploads with latest Hevy data in one click
- Existing "Unsync" button unchanged

### How it works
1. During sync, each workout's `updated_at` from Hevy API is stored alongside the sync record
2. When loading /workouts, `get_stale_synced()` batch-compares timestamps
3. Stale workouts get the "Edited on Hevy" badge
4. Re-sync = POST /api/unsync/{id} → POST /api/sync/{id} (reuses existing endpoints)

## Test plan
- [x] `pytest tests/` → 99 passed
- [x] Stale detection: mark_synced with old timestamp, check with newer → detected
- [x] Not stale: same timestamp → not flagged
- [x] Unknown workout → not flagged
- [ ] Manual: edit a workout on Hevy, reload /workouts, verify "Edited" badge appears