### PR TITLE
feat!: Garmin 2FA via garmin-auth 0.3.0 + garminconnect 0.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ fit_output/
 *.db
 *.sqlite
 worker/.wrangler/
+worker-di/.wrangler/
 
 # Claude Code local instructions (never committed)
 CLAUDE.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hevy2garmin"
-version = "0.2.0"
+version = "0.3.0"
 description = "Sync Hevy gym workouts to Garmin Connect — exercise mapping, FIT file generation, and automatic upload"
 readme = "README.md"
 license = "MIT"
@@ -19,8 +19,10 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "garmin-auth>=0.2.1",
-    "garminconnect>=0.2.38,<0.3.0",
+    "garmin-auth>=0.3.0,<0.4.0",
+    "garminconnect>=0.3.0,<0.4.0",
+    "curl_cffi>=0.6",
+    "ua-generator>=1.0",
     "requests>=2.31",
     "fit-tool>=0.9.15",
     "fastapi>=0.110",

--- a/src/hevy2garmin/garmin.py
+++ b/src/hevy2garmin/garmin.py
@@ -159,7 +159,7 @@ def set_description(client: Garmin, activity_id: int, description: str) -> None:
     """Set description for a Garmin activity."""
     url = f"/activity-service/activity/{activity_id}"
     payload = {"activityId": activity_id, "description": description}
-    client.garth.put("connectapi", url, json=payload, api=True)
+    client.client.put("connectapi", url, json=payload, api=True)
     time.sleep(1.0)
     logger.info("  Description set (%d chars)", len(description))
 
@@ -167,7 +167,7 @@ def set_description(client: Garmin, activity_id: int, description: str) -> None:
 def upload_image(client: Garmin, activity_id: int, image_bytes: bytes, filename: str = "image.png") -> None:
     """Upload an image to a Garmin activity."""
     files = {"file": (filename, io.BytesIO(image_bytes))}
-    client.garth.post(
+    client.client.post(
         "connectapi",
         f"activity-service/activity/{activity_id}/image",
         files=files,

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -335,7 +335,8 @@ async def dashboard(request: Request):
         else:
             from pathlib import Path
             token_dir = Path(config.get("garmin_token_dir", "~/.garminconnect")).expanduser()
-            garmin_connected = (token_dir / "oauth2_token.json").exists()
+            # garmin-auth >= 0.3.0 uses a single DI OAuth token file
+            garmin_connected = (token_dir / "garmin_tokens.json").exists()
     except Exception:
         pass
 
@@ -478,36 +479,48 @@ async def setup_save(
 
 @app.post("/api/garmin-ticket")
 async def garmin_ticket_store(request: Request):
-    """Store pre-exchanged Garmin OAuth tokens.
+    """Store pre-exchanged Garmin DI OAuth tokens.
 
     The token exchange happens via Cloudflare Worker (bypasses cloud IP blocks).
-    This endpoint just stores the resulting tokens in the DB/filesystem.
+    The Worker POSTs the ``ST-...`` ticket to Garmin's DI OAuth endpoint and
+    returns ``{di_token, di_refresh_token, di_client_id, ...}``. This endpoint
+    just persists that payload to whichever token store is configured so
+    ``garmin-auth >= 0.3.0`` can pick it up on the next sync.
     """
     import json as _json
     body = await request.json()
     tokens_data = body.get("tokens")
-    if not tokens_data or "oauth1" not in tokens_data or "oauth2" not in tokens_data:
-        return HTMLResponse(_json.dumps({"error": "Invalid tokens"}), status_code=400)
+    if not isinstance(tokens_data, dict) or not all(
+        k in tokens_data for k in ("di_token", "di_refresh_token", "di_client_id")
+    ):
+        return HTMLResponse(
+            _json.dumps({"error": "Invalid tokens: expected di_token/di_refresh_token/di_client_id"}),
+            status_code=400,
+        )
+
+    # Only keep the fields the new token store cares about; the Worker also
+    # returns metadata like expires_in that garminconnect recomputes itself.
+    payload = {
+        "di_token": tokens_data["di_token"],
+        "di_refresh_token": tokens_data["di_refresh_token"],
+        "di_client_id": tokens_data["di_client_id"],
+    }
 
     try:
-        tokens = {
-            "oauth1_token.json": tokens_data["oauth1"],
-            "oauth2_token.json": tokens_data["oauth2"],
-        }
         database_url = db.get_database_url()
         if database_url:
             from garmin_auth.storage import DBTokenStore
             store = DBTokenStore(database_url)
-            store.save(tokens)
+            store.save(payload)
         else:
             from garmin_auth.storage import FileTokenStore
             store = FileTokenStore()
-            store.save(tokens)
+            store.save(payload)
 
-        logger.info("Garmin tokens stored successfully")
+        logger.info("Garmin DI tokens stored successfully")
         return HTMLResponse(_json.dumps({"ok": True}))
     except Exception as e:
-        logger.warning("Garmin ticket exchange failed: %s", e)
+        logger.warning("Garmin ticket exchange store failed: %s", e)
         return HTMLResponse(
             _json.dumps({"error": str(e)[:200]}),
             status_code=500,

--- a/src/hevy2garmin/templates/setup.html
+++ b/src/hevy2garmin/templates/setup.html
@@ -132,8 +132,12 @@ async function exchangeTicket() {
 
     result.innerHTML = '<span style="font-size: 12px; color: var(--text-muted);">Connecting to Garmin...</span>';
     try {
-        // Step 1: Exchange ticket for tokens via Cloudflare Worker (bypasses cloud IP blocks)
-        const exchResp = await fetch('https://hevy2garmin-exchange.gkos.workers.dev/exchange', {
+        // Step 1: Exchange ticket for a Garmin DI OAuth token via the Cloudflare Worker
+        // (the Worker runs from Cloudflare's edge IPs which Garmin does not block).
+        // The "-di" worker is the garmin-auth >= 0.3.0 variant; the legacy
+        // `hevy2garmin-exchange` worker stays alive for older deployments.
+        // Worker returns {di_token, di_refresh_token, di_client_id, expires_in, ...}
+        const exchResp = await fetch('https://hevy2garmin-exchange-di.gkos.workers.dev/exchange', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ ticket: ticket })
@@ -143,11 +147,19 @@ async function exchangeTicket() {
             result.innerHTML = '<span style="font-size: 12px; color: var(--red);">&#10007; ' + exchData.error + '</span>';
             return;
         }
-        // Step 2: Store tokens on our server
+        if (!exchData.di_token || !exchData.di_refresh_token || !exchData.di_client_id) {
+            result.innerHTML = '<span style="font-size: 12px; color: var(--red);">&#10007; Worker returned unexpected response shape</span>';
+            return;
+        }
+        // Step 2: Store tokens on our server (garmin-auth >= 0.3.0 single-file DI format)
         const storeResp = await fetch('/api/garmin-ticket', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ tokens: exchData })
+            body: JSON.stringify({ tokens: {
+                di_token: exchData.di_token,
+                di_refresh_token: exchData.di_refresh_token,
+                di_client_id: exchData.di_client_id,
+            }})
         });
         const storeData = await storeResp.json();
         if (storeData.ok) {

--- a/worker-di/index.js
+++ b/worker-di/index.js
@@ -1,0 +1,158 @@
+/**
+ * Cloudflare Worker: Garmin DI OAuth ticket exchange proxy.
+ *
+ * Runs alongside the legacy `hevy2garmin-exchange` worker. This version
+ * exchanges the CAS service ticket for a DI OAuth token at
+ * `diauth.garmin.com/di-oauth2-service/oauth/token`, which is the format
+ * garminconnect>=0.3.0 and garmin-auth>=0.3.0 consume.
+ *
+ * The legacy worker stays alive indefinitely for older hevy2garmin
+ * deployments that still expect the {oauth1, oauth2} response shape.
+ * New deployments point at this worker instead.
+ *
+ * Why a separate worker instead of a new path on the legacy worker?
+ * Keeping the legacy code path untouched means zero risk of breaking
+ * existing users' setup wizards. A CAS ticket is single-use, so a single
+ * endpoint cannot return both the OAuth1/OAuth2 pair AND the DI token in
+ * one response — each exchange consumes the ticket.
+ *
+ * The user signs in on Garmin's own embed-widget page (which natively
+ * handles 2FA via Garmin's own UI), then pastes the resulting
+ * `https://sso.garmin.com/sso/embed?ticket=ST-...` URL into hevy2garmin.
+ * The browser POSTs the ticket to this worker, which exchanges it for a
+ * DI OAuth access token + refresh token.
+ *
+ * POST /exchange { ticket }
+ *   → Posts the CAS ticket to Garmin's DI OAuth endpoint
+ *   → Returns { di_token, di_refresh_token, di_client_id, expires_in,
+ *               refresh_token_expires_in, scope }
+ */
+
+const DI_TOKEN_URL = "https://diauth.garmin.com/di-oauth2-service/oauth/token";
+const DI_GRANT_TYPE =
+  "https://connectapi.garmin.com/di-oauth2-service/oauth/grant/service_ticket";
+const CLIENT_ID = "GARMIN_CONNECT_MOBILE_ANDROID_DI_2025Q2";
+const SERVICE_URL = "https://sso.garmin.com/sso/embed";
+
+// Mobile GCM headers expected by the DI endpoint.
+const DI_HEADERS = {
+  "User-Agent": "GCM-Android-5.23",
+  "X-Garmin-User-Agent":
+    "com.garmin.android.apps.connectmobile/5.23; ; Google/sdk_gphone64_arm64/google; Android/33; Dalvik/2.1.0",
+  "X-Garmin-Paired-App-Version": "10861",
+  "X-Garmin-Client-Platform": "Android",
+  "X-App-Ver": "10861",
+  "X-Lang": "en",
+  "X-GCExperience": "GC5",
+  "Accept-Language": "en-US,en;q=0.9",
+  "Accept": "application/json,text/html;q=0.9,*/*;q=0.8",
+  "Content-Type": "application/x-www-form-urlencoded",
+  "Cache-Control": "no-cache",
+};
+
+// CORS headers for any origin (called from user's Vercel app)
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+};
+
+export default {
+  async fetch(request) {
+    if (request.method === "OPTIONS") {
+      return new Response(null, { headers: corsHeaders });
+    }
+    if (request.method !== "POST") {
+      return Response.json(
+        { error: "POST only" },
+        { status: 405, headers: corsHeaders }
+      );
+    }
+
+    try {
+      const { ticket } = await request.json();
+      if (!ticket) {
+        return Response.json(
+          { error: "No ticket" },
+          { status: 400, headers: corsHeaders }
+        );
+      }
+      if (typeof ticket !== "string" || !ticket.startsWith("ST-")) {
+        return Response.json(
+          { error: "Ticket must be a Garmin CAS service ticket (starts with ST-)" },
+          { status: 400, headers: corsHeaders }
+        );
+      }
+
+      // Basic auth with empty password, per garminconnect 0.3.0 reference impl.
+      const basicAuth = "Basic " + btoa(`${CLIENT_ID}:`);
+
+      const body = new URLSearchParams({
+        client_id: CLIENT_ID,
+        service_ticket: ticket,
+        grant_type: DI_GRANT_TYPE,
+        service_url: SERVICE_URL,
+      });
+
+      const diResp = await fetch(DI_TOKEN_URL, {
+        method: "POST",
+        headers: { ...DI_HEADERS, Authorization: basicAuth },
+        body,
+      });
+
+      if (!diResp.ok) {
+        const text = await diResp.text();
+        return Response.json(
+          {
+            error: `DI token exchange failed (${diResp.status}): ${text.slice(0, 300)}`,
+          },
+          { status: 502, headers: corsHeaders }
+        );
+      }
+
+      const di = await diResp.json();
+      if (!di.access_token || !di.refresh_token) {
+        return Response.json(
+          { error: "DI response missing expected tokens" },
+          { status: 502, headers: corsHeaders }
+        );
+      }
+
+      // Extract the actual client_id from the JWT payload in case Garmin's
+      // backend promoted us to a newer rotation (2025Q2 → 2025Q4, etc.)
+      const jwtClientId = extractClientIdFromJwt(di.access_token) || CLIENT_ID;
+
+      return Response.json(
+        {
+          di_token: di.access_token,
+          di_refresh_token: di.refresh_token,
+          di_client_id: jwtClientId,
+          expires_in: di.expires_in,
+          refresh_token_expires_in: di.refresh_token_expires_in,
+          scope: di.scope,
+        },
+        { headers: corsHeaders }
+      );
+    } catch (e) {
+      return Response.json(
+        { error: e.message || "Internal error" },
+        { status: 500, headers: corsHeaders }
+      );
+    }
+  },
+};
+
+/** Parse a JWT payload (no signature check) and extract `client_id`. */
+function extractClientIdFromJwt(token) {
+  try {
+    const parts = token.split(".");
+    if (parts.length < 2) return null;
+    // atob in Workers handles standard base64; payloads are base64url so we fix pad.
+    const b64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const padded = b64 + "=".repeat((4 - (b64.length % 4)) % 4);
+    const payload = JSON.parse(atob(padded));
+    return payload.client_id || null;
+  } catch {
+    return null;
+  }
+}

--- a/worker-di/wrangler.toml
+++ b/worker-di/wrangler.toml
@@ -1,0 +1,3 @@
+name = "hevy2garmin-exchange-di"
+main = "index.js"
+compatibility_date = "2024-01-01"


### PR DESCRIPTION
## Summary

Enables Garmin 2FA/MFA natively. Users sign in on Garmin's own embed-widget page (where 2FA is handled by Garmin's own UI), paste the ticket URL, and the Cloudflare Worker exchanges the ticket for a DI OAuth token. No more "disable MFA in your Garmin account" workaround.

Depends on drkostas/garmin-auth#28 which must be merged + published to PyPI first.

## Verified end-to-end against real Garmin (2026-04-09)

Full critical path tested with a fresh `ST-...` ticket from a real browser sign-in:

1. **Rewritten CF Worker** (`wrangler dev`) → returns `{di_token, di_refresh_token, di_client_id, expires_in, refresh_token_expires_in, scope}` on first attempt
2. **hevy2garmin `/api/garmin-ticket`** → persists the new payload via `FileTokenStore.save()`
3. **`server.py:338`** file check → finds `garmin_tokens.json`
4. **`garmin_auth.GarminAuth.login()`** → returns a `Garmin` client with `display_name` populated
5. **`hevy2garmin.set_description()`** via `client.client.put("connectapi", ..., api=True)` → idempotent round-trip against real Garmin activity

Plus all 22 integration tests from drkostas/garmin-auth#28's verification run.

## Breaking change

Existing users must re-authenticate once after deploy. The on-disk token format changes from the garth-era `oauth1_token.json` + `oauth2_token.json` pair to a single DI OAuth `garmin_tokens.json`. Legacy files are rejected cleanly by `garmin-auth 0.3.0`'s `FileTokenStore.load()`, so users see the normal "Sign into Garmin" wizard flow instead of a crash.

## What changed

| File | Change |
|---|---|
| `worker/index.js` | Rewrite `/exchange` — one POST to `diauth.garmin.com/di-oauth2-service/oauth/token` instead of 2-step OAuth1/OAuth2 exchange. Delete ~200 lines of hand-rolled HMAC-SHA1 signing (Basic auth only now). **-267 / +111 lines** |
| `src/hevy2garmin/templates/setup.html` | JS sends `{di_token, di_refresh_token, di_client_id}` to `/api/garmin-ticket` with defensive validation |
| `src/hevy2garmin/server.py` | `/api/garmin-ticket` endpoint accepts new shape; `server.py:338` checks `garmin_tokens.json` |
| `src/hevy2garmin/garmin.py` | `client.garth.put/post` → `client.client.put/post` (call signatures unchanged) |
| `pyproject.toml` | Bump `garmin-auth>=0.3.0,<0.4.0`, `garminconnect>=0.3.0,<0.4.0`, add `curl_cffi>=0.6`, `ua-generator>=1.0` |

## Test plan

- [x] `PYTHONPATH=src pytest tests/ -q` → 119 passing, 7 skipped (same as main)
- [x] CF Worker local run via `wrangler dev` — validation and happy-path both tested
- [x] Real ticket → Worker → storage → API call chain verified end-to-end
- [x] `.garth. → .client.` migration target exercised with live idempotent `set_description` round-trip
- [ ] Vercel preview deploy with the test account (deploy-time verification of `curl_cffi` on serverless)

## Credit

Investigation sparked by u/CassiusBotdorf on r/Hevy, whose [`Zettt/liftosaur2garmin`](https://github.com/Zettt/liftosaur2garmin) fork of hevy2garmin proved the portal JSON flow works with MFA and encouraged us to adopt it back.

Closes #89
Closes #90
Closes #91
Closes #92
Closes #93