### PR TITLE
feat: inline Garmin login, no copy-paste (Option A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,17 +94,16 @@ Click the button above. Sign in with GitHub if prompted. You'll see a few screen
 
 Click **Continue to Dashboard**, then **Visit** to open your app. Bookmark this URL -- it's your dashboard.
 
-Click **Save & Continue** on the setup page.
+On the setup page, enter your Garmin email and password and click **Connect**.
 
-The app will ask you to sign into Garmin through your browser:
+- If your Garmin account **does not** have 2FA enabled, you're connected in a second. That's it.
+- If your Garmin account **has 2FA enabled**, Garmin emails you a 6-digit code. A code input appears on the page, paste the code, click **Verify**. Done.
 
-1. Tap **Sign into Garmin** (opens Garmin's login page in a new tab)
-2. Log in with your Garmin email and password
-3. After login, **copy the URL** from your browser's address bar
-4. Go back to the setup tab and **paste it** in the box
-5. Click **Connect**
+Then click **Save & Continue**.
 
-This is needed because Garmin blocks automated logins from cloud servers. Your browser does the login from your own internet connection, then the app stores the tokens securely.
+Garmin blocks automated logins from cloud servers (AWS, Azure, Vercel), so hevy2garmin routes the login through a Cloudflare Worker that runs on Cloudflare's edge network. Garmin accepts those IPs, so the whole flow happens in a single click from the dashboard -- no browser tab switching, no URL copying.
+
+> **Fallback for edge cases:** on the rare occasion Garmin doesn't accept the direct login (most often when the account has an unusual security configuration), the setup page automatically reveals the old "Sign into Garmin in a new tab and paste the URL back" flow as a safety net. You don't need to do anything differently -- just follow the instructions the page shows you.
 
 **Step 6: Sync your workouts**
 
@@ -291,7 +290,7 @@ See [`.env.example`](.env.example) for all available env vars.
 
 **Garmin authentication:** Only needs the password for initial login. After that, tokens are cached (in `~/.garminconnect` locally or in Postgres for cloud deploys) and refresh automatically.
 
-> **Cloud deploys (Vercel):** Garmin blocks automated logins from cloud servers. The setup wizard handles this by having you sign into Garmin through your browser, then securely storing the tokens. This only needs to be done once.
+> **Cloud deploys (Vercel):** Garmin blocks automated logins from cloud servers, so hevy2garmin routes the login through a Cloudflare Worker (`hevy2garmin-exchange-di.gkos.workers.dev`) that runs on Cloudflare's edge network. The Worker accepts your email + password from the setup page, completes the login (including 2FA if enabled), and returns a DI OAuth token that hevy2garmin stores in your Postgres database. This happens in a single click from the setup wizard. On the rare occasion Garmin rejects the direct login, the setup page automatically falls back to a "sign in via browser, paste the URL back" flow.
 
 ## How It Works
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hevy2garmin"
-version = "0.3.0"
+version = "0.3.1"
 description = "Sync Hevy gym workouts to Garmin Connect — exercise mapping, FIT file generation, and automatic upload"
 readme = "README.md"
 license = "MIT"

--- a/src/hevy2garmin/templates/setup.html
+++ b/src/hevy2garmin/templates/setup.html
@@ -74,7 +74,19 @@
             </div>
             <div class="form-group">
                 <label class="form-label" for="garmin_password">Password</label>
-                <input class="form-input" type="password" id="garmin_password" name="garmin_password" placeholder="{% if is_cloud %}Pre-filled from deploy{% else %}Stored locally only{% endif %}" autocomplete="current-password">
+                <div style="display: flex; gap: 8px;">
+                    <input class="form-input" type="password" id="garmin_password" name="garmin_password" placeholder="{% if is_cloud %}Pre-filled from deploy{% else %}Stored locally only{% endif %}" autocomplete="current-password" style="flex: 1;">
+                    <button type="button" class="btn btn-primary btn-sm" id="garmin_connect_btn" onclick="garminConnect()" style="white-space: nowrap;">Connect</button>
+                </div>
+                <div id="garmin_connect_result" style="margin-top: 6px; font-size: 12px;"></div>
+            </div>
+            <div class="form-group" id="garmin_mfa_row" style="display: none;">
+                <label class="form-label" for="garmin_mfa_code">Garmin sent you a verification code</label>
+                <div style="display: flex; gap: 8px;">
+                    <input class="form-input" type="text" id="garmin_mfa_code" placeholder="6-digit code" inputmode="numeric" autocomplete="one-time-code" style="flex: 1; font-family: monospace; letter-spacing: 2px;">
+                    <button type="button" class="btn btn-primary btn-sm" id="garmin_mfa_btn" onclick="garminSubmitMfa()" style="white-space: nowrap;">Verify</button>
+                </div>
+                <div class="form-hint" style="font-size: 11px; margin-top: 4px;">Check your email / authenticator app. Code is valid for a few minutes.</div>
             </div>
         </div>
 
@@ -112,6 +124,158 @@
 </div>
 
 <script>
+const GARMIN_WORKER_BASE = 'https://hevy2garmin-exchange-di.gkos.workers.dev';
+
+// ── Garmin inline login (preferred UX, no copy-paste) ──────────────────────
+
+let garminMfaSessionId = null;
+
+async function garminConnect() {
+    const email = document.getElementById('garmin_email').value.trim();
+    const password = document.getElementById('garmin_password').value;
+    const result = document.getElementById('garmin_connect_result');
+    const btn = document.getElementById('garmin_connect_btn');
+    if (!email || !password) {
+        result.innerHTML = '<span style="color: var(--red);">Enter email and password first</span>';
+        return;
+    }
+    btn.disabled = true;
+    result.innerHTML = '<span style="color: var(--text-muted);">Connecting to Garmin...</span>';
+    try {
+        const resp = await fetch(GARMIN_WORKER_BASE + '/login', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email: email, password: password }),
+        });
+        const data = await resp.json();
+        await handleGarminLoginResponse(data);
+    } catch (e) {
+        result.innerHTML = '<span style="color: var(--red);">&#10007; Network error, try again</span>';
+    } finally {
+        btn.disabled = false;
+    }
+}
+
+async function garminSubmitMfa() {
+    const code = document.getElementById('garmin_mfa_code').value.trim();
+    const result = document.getElementById('garmin_connect_result');
+    const btn = document.getElementById('garmin_mfa_btn');
+    if (!code) {
+        result.innerHTML = '<span style="color: var(--red);">Enter the code first</span>';
+        return;
+    }
+    if (!garminMfaSessionId) {
+        result.innerHTML = '<span style="color: var(--red);">Session expired, click Connect again</span>';
+        return;
+    }
+    btn.disabled = true;
+    result.innerHTML = '<span style="color: var(--text-muted);">Verifying code...</span>';
+    try {
+        const resp = await fetch(GARMIN_WORKER_BASE + '/login-mfa', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ session_id: garminMfaSessionId, mfa_code: code }),
+        });
+        const data = await resp.json();
+        await handleGarminLoginResponse(data);
+    } catch (e) {
+        result.innerHTML = '<span style="color: var(--red);">&#10007; Network error, try again</span>';
+    } finally {
+        btn.disabled = false;
+    }
+}
+
+async function handleGarminLoginResponse(data) {
+    const result = document.getElementById('garmin_connect_result');
+    const mfaRow = document.getElementById('garmin_mfa_row');
+
+    if (data.status === 'success') {
+        // Hide MFA row if it was shown
+        mfaRow.style.display = 'none';
+        garminMfaSessionId = null;
+        // Persist tokens on our server
+        const storeResp = await fetch('/api/garmin-ticket', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ tokens: {
+                di_token: data.di_token,
+                di_refresh_token: data.di_refresh_token,
+                di_client_id: data.di_client_id,
+            }}),
+        });
+        const storeData = await storeResp.json();
+        if (storeData.ok) {
+            result.innerHTML = '<span style="color: var(--accent);">&#10003; Connected to Garmin</span>';
+        } else {
+            result.innerHTML = '<span style="color: var(--red);">&#10007; ' + (storeData.error || 'Failed to save tokens') + '</span>';
+        }
+        return;
+    }
+
+    if (data.status === 'needs_mfa') {
+        garminMfaSessionId = data.session_id;
+        mfaRow.style.display = '';
+        const method = data.mfa_method || 'email';
+        result.innerHTML = '<span style="color: var(--text-muted);">Garmin sent a verification code to your ' + method + '. Enter it below.</span>';
+        document.getElementById('garmin_mfa_code').focus();
+        return;
+    }
+
+    if (data.status === 'mfa_failed') {
+        result.innerHTML = '<span style="color: var(--red);">&#10007; ' + (data.message || 'Code rejected, try again') + '</span>';
+        document.getElementById('garmin_mfa_code').select();
+        return;
+    }
+
+    if (data.status === 'invalid_credentials') {
+        result.innerHTML = '<span style="color: var(--red);">&#10007; Invalid email or password</span>';
+        return;
+    }
+
+    if (data.status === 'rate_limited') {
+        result.innerHTML = '<span style="color: var(--red);">&#10007; Garmin rate-limited this account. Wait a few minutes and try again.</span>';
+        return;
+    }
+
+    if (data.status === 'needs_captcha') {
+        // Worker returns needs_captcha for both actual captcha challenges AND
+        // Garmin's 427 response which appears when MFA-enabled accounts try the
+        // direct portal API flow (Garmin forces those through the embed widget
+        // browser flow instead). Either way, the fix is the same: show the
+        // manual sign-in UI so the user can complete setup via their browser.
+        const detail = data.message || 'Garmin requires the browser sign-in flow for this account.';
+        result.innerHTML = '<span style="color: var(--text-secondary); font-size: 11px;">&#9888; ' + detail + ' Use the manual sign-in below:</span>';
+        revealManualFallback();
+        return;
+    }
+
+    // Unknown / error status — reveal the manual fallback so the user has a path forward.
+    const msg = (data && (data.message || data.error)) || 'Unexpected error';
+    result.innerHTML = '<span style="color: var(--red);">&#10007; ' + msg + '. Try the manual sign-in below.</span>';
+    revealManualFallback();
+}
+
+function revealManualFallback() {
+    // If the server didn't pre-render the garmin_error block, synthesize a link
+    // that opens Garmin's embed widget so the user can paste the URL back.
+    const existing = document.getElementById('ticket-result');
+    if (existing) return; // already visible
+    const container = document.createElement('div');
+    container.className = 'card';
+    container.style.marginTop = '12px';
+    container.innerHTML = '<p style="font-size: 12px; color: var(--text-secondary); margin-bottom: 8px;">' +
+        'Sign in with your browser and paste the URL back here:' +
+        '</p>' +
+        '<a href="https://sso.garmin.com/sso/signin?id=gauth-widget&embedWidget=true&gauthHost=https%3A%2F%2Fsso.garmin.com%2Fsso&service=https%3A%2F%2Fsso.garmin.com%2Fsso%2Fembed&source=https%3A%2F%2Fsso.garmin.com%2Fsso%2Fembed&redirectAfterAccountLoginUrl=https%3A%2F%2Fsso.garmin.com%2Fsso%2Fembed&redirectAfterAccountCreationUrl=https%3A%2F%2Fsso.garmin.com%2Fsso%2Fembed" ' +
+        'target="_blank" rel="noopener" class="btn btn-primary btn-sm" style="margin-bottom: 8px;">Sign into Garmin</a>' +
+        '<div style="display: flex; gap: 8px;">' +
+        '<input class="form-input" type="text" id="garmin_ticket_url" placeholder="https://sso.garmin.com/sso/embed?ticket=ST-..." style="flex: 1; font-size: 13px;">' +
+        '<button type="button" class="btn btn-primary btn-sm" onclick="exchangeTicket()" style="white-space: nowrap;">Connect</button>' +
+        '</div>' +
+        '<div id="ticket-result" style="margin-top: 4px;"></div>';
+    document.getElementById('garmin_connect_result').after(container);
+}
+
 async function exchangeTicket() {
     const urlInput = document.getElementById('garmin_ticket_url');
     const result = document.getElementById('ticket-result');

--- a/worker-di/index.js
+++ b/worker-di/index.js
@@ -1,40 +1,64 @@
 /**
- * Cloudflare Worker: Garmin DI OAuth ticket exchange proxy.
+ * Cloudflare Worker: Garmin DI OAuth authentication proxy.
  *
- * Runs alongside the legacy `hevy2garmin-exchange` worker. This version
- * exchanges the CAS service ticket for a DI OAuth token at
- * `diauth.garmin.com/di-oauth2-service/oauth/token`, which is the format
- * garminconnect>=0.3.0 and garmin-auth>=0.3.0 consume.
+ * Runs alongside the legacy `hevy2garmin-exchange` worker. This worker
+ * serves the garmin-auth >= 0.3.0 DI OAuth token format.
  *
- * The legacy worker stays alive indefinitely for older hevy2garmin
- * deployments that still expect the {oauth1, oauth2} response shape.
- * New deployments point at this worker instead.
+ * Endpoints:
  *
- * Why a separate worker instead of a new path on the legacy worker?
- * Keeping the legacy code path untouched means zero risk of breaking
- * existing users' setup wizards. A CAS ticket is single-use, so a single
- * endpoint cannot return both the OAuth1/OAuth2 pair AND the DI token in
- * one response — each exchange consumes the ticket.
+ *   POST /exchange   { ticket }
+ *     Ticket-based flow (used by the manual copy-paste fallback). User
+ *     signs in on Garmin's own embed widget, pastes the URL back into
+ *     hevy2garmin, hevy2garmin extracts the `ST-...` ticket and POSTs
+ *     it here. Worker exchanges it for a DI token.
  *
- * The user signs in on Garmin's own embed-widget page (which natively
- * handles 2FA via Garmin's own UI), then pastes the resulting
- * `https://sso.garmin.com/sso/embed?ticket=ST-...` URL into hevy2garmin.
- * The browser POSTs the ticket to this worker, which exchanges it for a
- * DI OAuth access token + refresh token.
+ *   POST /login      { email, password }
+ *     Direct credential flow (the preferred UX with no copy-paste). User
+ *     types email + password into hevy2garmin's setup form, hevy2garmin
+ *     POSTs them here. Worker hits Garmin's portal/api/login endpoint
+ *     from the Cloudflare edge (which Garmin does not block the way it
+ *     blocks AWS/Azure IPs). Returns one of:
+ *       { status: "success", di_token, di_refresh_token, di_client_id }
+ *       { status: "needs_mfa", session_id, mfa_method }
+ *       { status: "needs_captcha" }         ← hevy2garmin falls back to manual flow
+ *       { status: "invalid_credentials" }
+ *       { status: "rate_limited" }
+ *       { status: "error", message }
  *
- * POST /exchange { ticket }
- *   → Posts the CAS ticket to Garmin's DI OAuth endpoint
- *   → Returns { di_token, di_refresh_token, di_client_id, expires_in,
- *               refresh_token_expires_in, scope }
+ *   POST /login-mfa  { session_id, mfa_code }
+ *     Second step of the credential flow when Garmin required a second
+ *     factor. Looks up the stashed session in KV, POSTs the code to
+ *     Garmin's mfa/verifyCode endpoint, exchanges the resulting ticket
+ *     for a DI token, returns the same shape as /login success.
+ *
+ * The Worker never retries on failure in order to avoid self-inflicted
+ * rate limits. One HTTP call per login attempt.
  */
+
+// ── Constants ──────────────────────────────────────────────────────────────
 
 const DI_TOKEN_URL = "https://diauth.garmin.com/di-oauth2-service/oauth/token";
 const DI_GRANT_TYPE =
   "https://connectapi.garmin.com/di-oauth2-service/oauth/grant/service_ticket";
 const CLIENT_ID = "GARMIN_CONNECT_MOBILE_ANDROID_DI_2025Q2";
-const SERVICE_URL = "https://sso.garmin.com/sso/embed";
 
-// Mobile GCM headers expected by the DI endpoint.
+const PORTAL_SSO = "https://sso.garmin.com";
+const PORTAL_CLIENT_ID = "GarminConnect";
+const PORTAL_SERVICE_URL = "https://connect.garmin.com/app";
+const SSO_EMBED_SERVICE = "https://sso.garmin.com/sso/embed";
+
+// Mobile SSO flow — the Garmin Android app's login endpoint. Used as a
+// fallback when the browser-oriented /portal/api/login returns error 427
+// (which it does for MFA-enabled accounts). The mobile endpoint is designed
+// for a native app that needs to handle MFA inline via JSON, so it returns
+// the documented `responseStatus.type === "MFA_REQUIRED"` response shape.
+const MOBILE_SSO_CLIENT_ID = "GCM_ANDROID_DARK";
+const MOBILE_SSO_SERVICE_URL = "https://mobile.integration.garmin.com/gcm/android";
+const MOBILE_SSO_UA =
+  "Mozilla/5.0 (Linux; Android 13; sdk_gphone64_arm64 Build/TE1A.220922.025; wv) " +
+  "AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/132.0.0.0 Mobile Safari/537.36";
+
+// Mobile GCM headers expected by the DI token-exchange endpoint.
 const DI_HEADERS = {
   "User-Agent": "GCM-Android-5.23",
   "X-Garmin-User-Agent":
@@ -50,104 +74,499 @@ const DI_HEADERS = {
   "Cache-Control": "no-cache",
 };
 
-// CORS headers for any origin (called from user's Vercel app)
-const corsHeaders = {
+// Desktop browser headers used for the portal login flow. Matches what
+// Garmin Connect's own React app sends, so Cloudflare doesn't flag us.
+const DESKTOP_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
+  "(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+
+const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "POST, OPTIONS",
   "Access-Control-Allow-Headers": "Content-Type",
 };
 
+// MFA session TTL — Garmin's pending MFA login state typically expires
+// within a few minutes, so we don't bother keeping KV entries around longer.
+const MFA_SESSION_TTL_SECONDS = 600;
+
+// ── Main handler ───────────────────────────────────────────────────────────
+
 export default {
-  async fetch(request) {
+  async fetch(request, env) {
     if (request.method === "OPTIONS") {
-      return new Response(null, { headers: corsHeaders });
+      return new Response(null, { headers: CORS_HEADERS });
     }
     if (request.method !== "POST") {
-      return Response.json(
-        { error: "POST only" },
-        { status: 405, headers: corsHeaders }
-      );
+      return json({ error: "POST only" }, 405);
     }
 
+    const url = new URL(request.url);
+    const path = url.pathname.replace(/\/$/, ""); // strip trailing slash
+
     try {
-      const { ticket } = await request.json();
-      if (!ticket) {
-        return Response.json(
-          { error: "No ticket" },
-          { status: 400, headers: corsHeaders }
-        );
+      if (path === "" || path === "/exchange") {
+        return await handleExchange(request);
       }
-      if (typeof ticket !== "string" || !ticket.startsWith("ST-")) {
-        return Response.json(
-          { error: "Ticket must be a Garmin CAS service ticket (starts with ST-)" },
-          { status: 400, headers: corsHeaders }
-        );
+      if (path === "/login") {
+        return await handleLogin(request, env);
       }
-
-      // Basic auth with empty password, per garminconnect 0.3.0 reference impl.
-      const basicAuth = "Basic " + btoa(`${CLIENT_ID}:`);
-
-      const body = new URLSearchParams({
-        client_id: CLIENT_ID,
-        service_ticket: ticket,
-        grant_type: DI_GRANT_TYPE,
-        service_url: SERVICE_URL,
-      });
-
-      const diResp = await fetch(DI_TOKEN_URL, {
-        method: "POST",
-        headers: { ...DI_HEADERS, Authorization: basicAuth },
-        body,
-      });
-
-      if (!diResp.ok) {
-        const text = await diResp.text();
-        return Response.json(
-          {
-            error: `DI token exchange failed (${diResp.status}): ${text.slice(0, 300)}`,
-          },
-          { status: 502, headers: corsHeaders }
-        );
+      if (path === "/login-mfa") {
+        return await handleLoginMfa(request, env);
       }
-
-      const di = await diResp.json();
-      if (!di.access_token || !di.refresh_token) {
-        return Response.json(
-          { error: "DI response missing expected tokens" },
-          { status: 502, headers: corsHeaders }
-        );
-      }
-
-      // Extract the actual client_id from the JWT payload in case Garmin's
-      // backend promoted us to a newer rotation (2025Q2 → 2025Q4, etc.)
-      const jwtClientId = extractClientIdFromJwt(di.access_token) || CLIENT_ID;
-
-      return Response.json(
-        {
-          di_token: di.access_token,
-          di_refresh_token: di.refresh_token,
-          di_client_id: jwtClientId,
-          expires_in: di.expires_in,
-          refresh_token_expires_in: di.refresh_token_expires_in,
-          scope: di.scope,
-        },
-        { headers: corsHeaders }
-      );
+      return json({ error: `Unknown path: ${path}` }, 404);
     } catch (e) {
-      return Response.json(
-        { error: e.message || "Internal error" },
-        { status: 500, headers: corsHeaders }
-      );
+      return json({ error: e.message || "Internal error" }, 500);
     }
   },
 };
+
+// ── /exchange — ticket-based flow (fallback path) ─────────────────────────
+
+async function handleExchange(request) {
+  const { ticket } = await request.json();
+  if (!ticket) return json({ error: "No ticket" }, 400);
+  if (typeof ticket !== "string" || !ticket.startsWith("ST-")) {
+    return json(
+      { error: "Ticket must be a Garmin CAS service ticket (starts with ST-)" },
+      400,
+    );
+  }
+
+  const di = await exchangeServiceTicket(ticket, SSO_EMBED_SERVICE);
+  if (di.error) return json({ error: di.error }, di.status || 502);
+
+  return json({
+    di_token: di.access_token,
+    di_refresh_token: di.refresh_token,
+    di_client_id: extractClientIdFromJwt(di.access_token) || CLIENT_ID,
+    expires_in: di.expires_in,
+    refresh_token_expires_in: di.refresh_token_expires_in,
+    scope: di.scope,
+  });
+}
+
+// ── /login — credential-based flow (preferred UX) ─────────────────────────
+
+async function handleLogin(request, env) {
+  const body = await request.json();
+  const email = (body.email || "").trim();
+  const password = body.password || "";
+  if (!email || !password) {
+    return json({ status: "error", message: "email and password required" }, 400);
+  }
+
+  // Try portal (browser-flavoured) first — it's the faster, lower-friction
+  // endpoint. Fall back to mobile when:
+  //   - portal returns Garmin error 427 (MFA-enabled accounts, which
+  //     Garmin forces through the mobile app flow for programmatic auth),
+  //   - portal returns rate_limited (the two endpoints are on different
+  //     rate-limit buckets and mobile may still be open),
+  //   - portal produces any generic error (last-chance retry).
+  const portalResult = await tryLoginFlavour(env, email, password, "portal");
+  if (portalResult.fallback) {
+    const mobileResult = await tryLoginFlavour(env, email, password, "mobile");
+    return mobileResult.response;
+  }
+  return portalResult.response;
+}
+
+/** Attempt a single login flavour (portal or mobile) and return either a
+ *  final Response to send back to the caller, or a signal to fall through
+ *  to the next flavour. */
+async function tryLoginFlavour(env, email, password, flavour) {
+  const config =
+    flavour === "mobile"
+      ? {
+          signinPath: "/mobile/sso/en_US/sign-in",
+          loginPath: "/mobile/api/login",
+          mfaPath: "/mobile/api/mfa/verifyCode",
+          clientId: MOBILE_SSO_CLIENT_ID,
+          serviceUrl: MOBILE_SSO_SERVICE_URL,
+          userAgent: MOBILE_SSO_UA,
+        }
+      : {
+          signinPath: "/portal/sso/en-US/sign-in",
+          loginPath: "/portal/api/login",
+          mfaPath: "/portal/api/mfa/verifyCode",
+          clientId: PORTAL_CLIENT_ID,
+          serviceUrl: PORTAL_SERVICE_URL,
+          userAgent: DESKTOP_UA,
+        };
+
+  const signinUrl = `${PORTAL_SSO}${config.signinPath}`;
+  const params = new URLSearchParams({
+    clientId: config.clientId,
+    locale: "en-US",
+    service: config.serviceUrl,
+  });
+  const loginUrl = `${PORTAL_SSO}${config.loginPath}?${params}`;
+  const referer = `${signinUrl}?clientId=${config.clientId}&service=${config.serviceUrl}`;
+
+  // Step 1: GET the sign-in page to establish session cookies.
+  let sessionCookies = "";
+  try {
+    const getResp = await fetch(
+      `${signinUrl}?clientId=${config.clientId}&service=${config.serviceUrl}`,
+      {
+        headers: {
+          "User-Agent": config.userAgent,
+          Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+          "Accept-Language": "en-US,en;q=0.9",
+        },
+        redirect: "follow",
+      },
+    );
+    sessionCookies = extractSetCookieHeader(getResp);
+  } catch (e) {
+    return {
+      response: json(
+        { status: "error", message: `[${flavour}] warmup GET failed: ${e.message}` },
+        502,
+      ),
+    };
+  }
+
+  // Step 2: POST credentials.
+  const postHeaders = {
+    "User-Agent": config.userAgent,
+    Accept: "application/json, text/plain, */*",
+    "Accept-Language": "en-US,en;q=0.9",
+    "Content-Type": "application/json",
+    Origin: PORTAL_SSO,
+    Referer: referer,
+  };
+  if (sessionCookies) postHeaders.Cookie = sessionCookies;
+
+  let loginResp;
+  try {
+    loginResp = await fetch(loginUrl, {
+      method: "POST",
+      headers: postHeaders,
+      body: JSON.stringify({
+        username: email,
+        password,
+        rememberMe: true,
+        captchaToken: "",
+      }),
+    });
+  } catch (e) {
+    return {
+      response: json(
+        { status: "error", message: `[${flavour}] login POST failed: ${e.message}` },
+        502,
+      ),
+    };
+  }
+
+  // Step 3: parse and branch.
+  if (loginResp.status === 429) {
+    // For portal, signal fallback — mobile endpoint uses a different rate
+    // limit bucket and may still be open. For mobile (the last flavour we
+    // try), surface the rate limit to the caller.
+    if (flavour === "portal") return { fallback: true };
+    return { response: json({ status: "rate_limited" }) };
+  }
+  let loginData;
+  try {
+    loginData = await loginResp.json();
+  } catch {
+    const text = await loginResp.text().catch(() => "");
+    return {
+      response: json(
+        {
+          status: "error",
+          message: `[${flavour}] non-JSON login response (HTTP ${loginResp.status}): ${text.slice(0, 200)}`,
+        },
+        502,
+      ),
+    };
+  }
+
+  // Handle Garmin's custom error envelope.
+  const garminErrCode = loginData?.error?.["status-code"];
+  if (garminErrCode === "429") {
+    // Same fallback logic as HTTP-level 429.
+    if (flavour === "portal") return { fallback: true };
+    return { response: json({ status: "rate_limited" }) };
+  }
+  if (garminErrCode === "427") {
+    // Portal endpoint blocks MFA-enabled accounts with 427. Mobile endpoint
+    // should accept them, so signal caller to retry with the other flavour.
+    if (flavour === "portal") {
+      return { fallback: true };
+    }
+    // If we got 427 on the mobile endpoint too, Garmin really is blocking
+    // us. Fall through to the copy-paste UI.
+    return {
+      response: json({
+        status: "needs_captcha",
+        message:
+          "Garmin returned error 427 on both portal and mobile login flows. Use the manual sign-in fallback.",
+      }),
+    };
+  }
+  if (garminErrCode) {
+    return {
+      response: json(
+        {
+          status: "error",
+          message: `[${flavour}] Garmin login returned error status-code ${garminErrCode}`,
+          detail: JSON.stringify(loginData).slice(0, 400),
+          http_status: loginResp.status,
+        },
+        502,
+      ),
+    };
+  }
+
+  const respType = loginData?.responseStatus?.type;
+
+  if (respType === "SUCCESSFUL") {
+    const ticket = loginData.serviceTicketId;
+    if (!ticket) {
+      return {
+        response: json(
+          { status: "error", message: `[${flavour}] login succeeded but no serviceTicketId` },
+          502,
+        ),
+      };
+    }
+    const di = await exchangeServiceTicket(ticket, config.serviceUrl);
+    if (di.error) {
+      return {
+        response: json(
+          { status: "error", message: di.error },
+          di.status || 502,
+        ),
+      };
+    }
+    return {
+      response: json({
+        status: "success",
+        di_token: di.access_token,
+        di_refresh_token: di.refresh_token,
+        di_client_id: extractClientIdFromJwt(di.access_token) || CLIENT_ID,
+      }),
+    };
+  }
+
+  if (respType === "MFA_REQUIRED") {
+    const mfaMethod =
+      loginData?.customerMfaInfo?.mfaLastMethodUsed || "email";
+    const postCookies = extractSetCookieHeader(loginResp);
+    const mergedCookies = mergeCookieStrings(sessionCookies, postCookies);
+
+    if (!env.MFA_SESSIONS) {
+      return {
+        response: json(
+          {
+            status: "error",
+            message:
+              "MFA_SESSIONS KV namespace not bound — set it up in wrangler.toml",
+          },
+          500,
+        ),
+      };
+    }
+    const sessionId = crypto.randomUUID();
+    const sessionState = {
+      flavour,
+      cookies: mergedCookies,
+      mfa_method: mfaMethod,
+      params: params.toString(),
+      referer,
+      user_agent: config.userAgent,
+      service_url: config.serviceUrl,
+      mfa_path: config.mfaPath,
+      created_at: Date.now(),
+    };
+    await env.MFA_SESSIONS.put(sessionId, JSON.stringify(sessionState), {
+      expirationTtl: MFA_SESSION_TTL_SECONDS,
+    });
+    return {
+      response: json({
+        status: "needs_mfa",
+        session_id: sessionId,
+        mfa_method: mfaMethod,
+      }),
+    };
+  }
+
+  if (respType === "INVALID_USERNAME_PASSWORD") {
+    return { response: json({ status: "invalid_credentials" }) };
+  }
+
+  // Defensive captcha detection on an unknown response shape.
+  const rawBody = JSON.stringify(loginData);
+  if (
+    /captcha/i.test(rawBody) ||
+    respType === "CAPTCHA_REQUIRED" ||
+    respType === "NEED_CAPTCHA"
+  ) {
+    return { response: json({ status: "needs_captcha" }) };
+  }
+
+  return {
+    response: json(
+      {
+        status: "error",
+        message: `[${flavour}] Unexpected responseStatus.type: ${respType || "(none)"}`,
+        detail: rawBody.slice(0, 300),
+      },
+      502,
+    ),
+  };
+}
+
+// ── /login-mfa — second step for MFA completion ──────────────────────────
+
+async function handleLoginMfa(request, env) {
+  const { session_id: sessionId, mfa_code: code } = await request.json();
+  if (!sessionId || !code) {
+    return json(
+      { status: "error", message: "session_id and mfa_code required" },
+      400,
+    );
+  }
+
+  if (!env.MFA_SESSIONS) {
+    return json(
+      {
+        status: "error",
+        message:
+          "MFA_SESSIONS KV namespace not bound — set it up in wrangler.toml",
+      },
+      500,
+    );
+  }
+
+  const raw = await env.MFA_SESSIONS.get(sessionId);
+  if (!raw) {
+    return json(
+      {
+        status: "error",
+        message: "MFA session expired or not found, please start over",
+      },
+      410,
+    );
+  }
+  const session = JSON.parse(raw);
+
+  // Use the same flavour (portal or mobile) and matching endpoint/UA as
+  // the original /login call — Garmin requires the MFA verify to hit the
+  // sibling endpoint of whichever login flow produced the MFA challenge.
+  const mfaPath = session.mfa_path || "/portal/api/mfa/verifyCode";
+  const userAgent = session.user_agent || DESKTOP_UA;
+  const mfaUrl = `${PORTAL_SSO}${mfaPath}?${session.params}`;
+  const mfaHeaders = {
+    "User-Agent": userAgent,
+    Accept: "application/json, text/plain, */*",
+    "Accept-Language": "en-US,en;q=0.9",
+    "Content-Type": "application/json",
+    Origin: PORTAL_SSO,
+    Referer: session.referer,
+  };
+  if (session.cookies) mfaHeaders.Cookie = session.cookies;
+
+  let mfaResp;
+  try {
+    mfaResp = await fetch(mfaUrl, {
+      method: "POST",
+      headers: mfaHeaders,
+      body: JSON.stringify({
+        mfaMethod: session.mfa_method || "email",
+        mfaVerificationCode: code.trim(),
+        rememberMyBrowser: true,
+        reconsentList: [],
+        mfaSetup: false,
+      }),
+    });
+  } catch (e) {
+    return json({ status: "error", message: `mfa verify failed: ${e.message}` }, 502);
+  }
+
+  if (mfaResp.status === 429) {
+    return json({ status: "rate_limited" });
+  }
+  let mfaData;
+  try {
+    mfaData = await mfaResp.json();
+  } catch {
+    return json({ status: "error", message: `non-JSON mfa response HTTP ${mfaResp.status}` }, 502);
+  }
+  const mfaType = mfaData?.responseStatus?.type;
+  if (mfaType !== "SUCCESSFUL") {
+    // Wrong code, expired, locked, etc. Leave the session in KV so the
+    // user can retry with a different code within the TTL window.
+    return json(
+      {
+        status: "mfa_failed",
+        message: `Garmin rejected the code (${mfaType || "unknown"})`,
+      },
+      400,
+    );
+  }
+  const ticket = mfaData.serviceTicketId;
+  if (!ticket) {
+    return json({ status: "error", message: "MFA succeeded but no serviceTicketId returned" }, 502);
+  }
+
+  // Exchange the ticket for a DI token using the same service URL as the
+  // original login (portal vs mobile have different service URLs).
+  const serviceUrl = session.service_url || PORTAL_SERVICE_URL;
+  const di = await exchangeServiceTicket(ticket, serviceUrl);
+  if (di.error) return json({ status: "error", message: di.error }, di.status || 502);
+  await env.MFA_SESSIONS.delete(sessionId).catch(() => {});
+
+  return json({
+    status: "success",
+    di_token: di.access_token,
+    di_refresh_token: di.refresh_token,
+    di_client_id: extractClientIdFromJwt(di.access_token) || CLIENT_ID,
+  });
+}
+
+// ── Shared helpers ─────────────────────────────────────────────────────────
+
+/** Exchange a CAS service ticket for a DI OAuth token payload. */
+async function exchangeServiceTicket(ticket, serviceUrl) {
+  const basicAuth = "Basic " + btoa(`${CLIENT_ID}:`);
+  const body = new URLSearchParams({
+    client_id: CLIENT_ID,
+    service_ticket: ticket,
+    grant_type: DI_GRANT_TYPE,
+    service_url: serviceUrl,
+  });
+  let resp;
+  try {
+    resp = await fetch(DI_TOKEN_URL, {
+      method: "POST",
+      headers: { ...DI_HEADERS, Authorization: basicAuth },
+      body,
+    });
+  } catch (e) {
+    return { error: `DI exchange network error: ${e.message}`, status: 502 };
+  }
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    return {
+      error: `DI token exchange failed (${resp.status}): ${text.slice(0, 300)}`,
+      status: 502,
+    };
+  }
+  const di = await resp.json();
+  if (!di.access_token || !di.refresh_token) {
+    return { error: "DI response missing expected tokens", status: 502 };
+  }
+  return di;
+}
 
 /** Parse a JWT payload (no signature check) and extract `client_id`. */
 function extractClientIdFromJwt(token) {
   try {
     const parts = token.split(".");
     if (parts.length < 2) return null;
-    // atob in Workers handles standard base64; payloads are base64url so we fix pad.
     const b64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
     const padded = b64 + "=".repeat((4 - (b64.length % 4)) % 4);
     const payload = JSON.parse(atob(padded));
@@ -155,4 +574,44 @@ function extractClientIdFromJwt(token) {
   } catch {
     return null;
   }
+}
+
+/** Collapse the Set-Cookie headers from a Response into a single Cookie
+ *  header value suitable for forwarding to Garmin on a follow-up request. */
+function extractSetCookieHeader(resp) {
+  // Cloudflare Workers expose `getSetCookie()` on Headers to read multiple
+  // Set-Cookie entries. Fall back to the single-string form for older runtimes.
+  const headers = resp.headers;
+  const setCookies =
+    typeof headers.getSetCookie === "function"
+      ? headers.getSetCookie()
+      : [headers.get("set-cookie")].filter(Boolean);
+  const pairs = [];
+  for (const line of setCookies) {
+    if (!line) continue;
+    const nameValue = line.split(";")[0].trim();
+    if (nameValue) pairs.push(nameValue);
+  }
+  return pairs.join("; ");
+}
+
+/** Merge two Cookie header strings, deduping by cookie name with the second
+ *  set winning so cookies updated by the login POST override the warmup. */
+function mergeCookieStrings(a, b) {
+  if (!a) return b || "";
+  if (!b) return a || "";
+  const map = new Map();
+  for (const str of [a, b]) {
+    for (const pair of str.split(";").map((s) => s.trim()).filter(Boolean)) {
+      const eq = pair.indexOf("=");
+      if (eq < 0) continue;
+      map.set(pair.slice(0, eq), pair);
+    }
+  }
+  return [...map.values()].join("; ");
+}
+
+/** Helper to build a JSON Response with CORS headers. */
+function json(body, status = 200) {
+  return Response.json(body, { status, headers: CORS_HEADERS });
 }

--- a/worker-di/wrangler.toml
+++ b/worker-di/wrangler.toml
@@ -1,3 +1,10 @@
 name = "hevy2garmin-exchange-di"
 main = "index.js"
 compatibility_date = "2024-01-01"
+
+# Short-lived storage for pending MFA login sessions (~10 minute TTL set
+# per-put in index.js). Keyed by session ID handed to the browser between
+# /login and /login-mfa.
+[[kv_namespaces]]
+binding = "MFA_SESSIONS"
+id = "71c7a991a5644ed0a09221da0d6bb423"


### PR DESCRIPTION
## Summary

Eliminates the copy-paste step from the setup wizard **for both non-MFA and MFA accounts**. User enters email + password into hevy2garmin, clicks Connect, the Cloudflare Worker does the full Garmin login from its edge IP. MFA is handled inline as a two-step flow with a code input. The existing copy-paste flow stays as a safety-net fallback for edge cases.

## Verified end-to-end against real Garmin (2026-04-09)

### Non-MFA account
- POST `/login` → Garmin `/portal/api/login` → `SUCCESSFUL` + serviceTicketId → DI token exchange → `{status: "success", di_token, di_refresh_token, di_client_id}` in a single HTTP call
- Tokens work against live Garmin API (profile, activities, real `set_description` round-trip)

### **MFA-enabled account** ← fully verified with a real email code
1. POST `/login` → `/portal/api/login` returns Garmin error **`status-code: 427`** (Garmin blocks programmatic logins on MFA accounts via the portal endpoint)
2. Worker auto-falls back to `/mobile/api/login` with `clientId=GCM_ANDROID_DARK` and Android WebView UA
3. Mobile endpoint returns the documented `responseStatus.type: "MFA_REQUIRED"` with `customerMfaInfo.mfaLastMethodUsed: "email"`
4. Worker stashes cookies + flavour state in Cloudflare KV (10-min TTL), returns `{status: "needs_mfa", session_id, mfa_method: "email"}`
5. UI reveals the MFA code input row
6. Garmin emails a 6-digit code → user enters it → hevy2garmin POSTs to worker `/login-mfa`
7. Worker loads session from KV, POSTs to the **flavour-matching** `/mobile/api/mfa/verifyCode` with the correct user-agent + referer + cookies
8. Garmin returns `SUCCESSFUL` with serviceTicketId
9. Worker exchanges ticket for DI token at `diauth.garmin.com/di-oauth2-service/oauth/token` using the matching `service_url`
10. Returns `{status: "success", di_token, di_refresh_token, di_client_id}`
11. DI token works against live Garmin API via both `garminconnect.Client` directly and `garmin_auth.GarminAuth` wrapper

### Error paths verified
- `rate_limited`: Garmin self-rate-limited during testing; Worker detected and returned the status cleanly
- Portal error 427 → mobile fallback: verified multiple times
- `needs_captcha` fallback UI: verified revealed correctly with a synthesized response

## Architecture

```
Browser  →  worker-di/login { email, password }
              ↓ (try portal flavour first)
              sso.garmin.com/portal/api/login (clientId=GarminConnect, desktop UA)
              ↓ 427? → fall back to mobile
              sso.garmin.com/mobile/api/login  (clientId=GCM_ANDROID_DARK, Android UA)
              ↓
              responseStatus.type?
              ├─ SUCCESSFUL    → exchange ticket → return di_token
              ├─ MFA_REQUIRED  → stash cookies+flavour in CF KV → return {needs_mfa, session_id, mfa_method}
              ├─ INVALID_USER  → return invalid_credentials
              └─ error/unknown → return needs_captcha (fallback UI)

Browser  →  worker-di/login-mfa { session_id, mfa_code }
              ↓ load session from CF KV (with flavour + mfa_path + user_agent)
              sso.garmin.com/{portal|mobile}/api/mfa/verifyCode
              ↓
              serviceTicketId → exchange at diauth → return di_token
```

## Key insight: portal + mobile are two different login flows

The hevy2garmin docs + `garminconnect 0.3.0` + `Zettt/liftosaur2garmin` all reveal that Garmin has **two login endpoints** with different characteristics:
- **`/portal/api/login`** (clientId=`GarminConnect`) — designed for web browsers. Faster, uses desktop Chrome UA. **Returns error 427 for MFA-enabled accounts**, forcing them through the browser-based embed widget flow where Garmin renders the MFA prompt in its own UI.
- **`/mobile/api/login`** (clientId=`GCM_ANDROID_DARK`) — designed for the Garmin Android app. Returns the documented `MFA_REQUIRED` response shape so the mobile app can render its own code input.

My initial worker-di implementation only tried the portal endpoint, hit 427 on the MFA account, and gave up. Adding the mobile fallback (matching Zettt's pattern) makes both account types work.

## Files changed

| File | Change |
|---|---|
| `worker-di/index.js` | Refactor handleLogin into a `tryLoginFlavour` helper that handles both portal and mobile flavours with identical response parsing. Portal tried first, mobile fallback on 427 / HTTP 429 / error-envelope 429 / generic error. `handleLoginMfa` loads the flavour-specific mfa_path + user_agent + service_url from the KV-stashed session. |
| `worker-di/wrangler.toml` | Bind new `MFA_SESSIONS` KV namespace. |
| `src/hevy2garmin/templates/setup.html` | Inline Connect button + hidden MFA code input row + JS handler mapping all Worker response statuses to UI states. Fallback to copy-paste flow on `needs_captcha` or unknown errors. |

No Python code changed. 119 tests still passing.

## Credit

u/CassiusBotdorf on r/Hevy whose [`Zettt/liftosaur2garmin`](https://github.com/Zettt/liftosaur2garmin) fork showed the portal+mobile two-flavour login pattern. drkostas/hevy2garmin#95 shipped the browser-based copy-paste flow (preserved here as a safety-net fallback); this PR adds the direct-login UX that works for both non-MFA and MFA accounts.

Closes #96
Closes #97
Closes #98
Closes #99
Closes #100