### PR TITLE
fix: clamp negative weight_kg to 0 in FIT generator

### DIFF
--- a/src/hevy2garmin/fit.py
+++ b/src/hevy2garmin/fit.py
@@ -312,7 +312,7 @@ def generate_fit(
 
         weight = s.get("weight_kg")
         if weight is not None:
-            active.weight = float(weight)
+            active.weight = max(0.0, float(weight))
 
         # Note: FIT SetMessage doesn't have a distance field.
         # Cardio data (distance_meters) is captured via set duration timing

--- a/tests/test_fit.py
+++ b/tests/test_fit.py
@@ -196,3 +196,15 @@ class TestEdgeCases:
         result = generate_fit(workout, hr_samples=None, output_path=str(tmp_path / "long.fit"), profile=sample_profile)
         assert result["duration_s"] == 10800  # 3 hours
         assert result["total_sets"] == 20
+
+    def test_negative_weight_clamped(self, sample_profile: dict, tmp_path: Path) -> None:
+        """Negative weight_kg should be clamped to 0, not written as-is."""
+        workout = {
+            "id": "neg", "title": "Bad Data", "start_time": "2026-04-01T10:00:00+00:00",
+            "end_time": "2026-04-01T10:30:00+00:00",
+            "exercises": [{"index": 0, "title": "Curl", "exercise_template_id": "X",
+                "sets": [{"index": 0, "type": "normal", "weight_kg": -5, "reps": 10}]}],
+        }
+        result = generate_fit(workout, hr_samples=None, output_path=str(tmp_path / "neg.fit"), profile=sample_profile)
+        assert result["total_sets"] == 1
+        assert (tmp_path / "neg.fit").exists()


### PR DESCRIPTION
One-liner from the hardening plan. Negative `weight_kg` values are clamped to `0.0` instead of being written to the FIT file as-is.

## Test plan
- [x] `test_negative_weight_clamped` added, 21 FIT tests passing