### PR TITLE
test: add description generation edge case tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,60 @@ See [`.env.example`](.env.example) for all available env vars.
 
 > **Cloud deploys (Vercel):** Garmin blocks automated logins from cloud servers, so hevy2garmin routes the login through a Cloudflare Worker (`hevy2garmin-exchange-di.gkos.workers.dev`) that runs on Cloudflare's edge network. The Worker accepts your email + password from the setup page, completes the login (including 2FA if enabled), and returns a DI OAuth token that hevy2garmin stores in your Postgres database. This happens in a single click from the setup wizard. On the rare occasion Garmin rejects the direct login, the setup page automatically falls back to a "sign in via browser, paste the URL back" flow.
 
+## Updating
+
+### Vercel (one-click deploy)
+
+Your Vercel project is linked to a GitHub repo that was created when you first deployed. To get the latest version:
+
+1. Go to your forked repo on GitHub (e.g. `github.com/your-username/hevy2garmin`)
+2. Click **Sync fork** → **Update branch** (this pulls the latest changes from the original repo)
+3. Vercel auto-deploys when your repo updates. Wait ~1 minute for the build to finish.
+4. Open your dashboard URL and reconnect Garmin if prompted (token format may change between versions)
+
+If you don't see a "Sync fork" button, your repo may have been created as a standalone copy. In that case, go to your Vercel dashboard → project → **Settings** → **Git** → change the repo URL to `drkostas/hevy2garmin`, then trigger a redeploy from the **Deployments** tab.
+
+### pip
+
+```bash
+pip install --upgrade hevy2garmin
+```
+
+### Docker
+
+```bash
+cd hevy2garmin
+git pull origin main
+docker build -t hevy2garmin .
+```
+
+### Git clone (local)
+
+```bash
+cd hevy2garmin
+git pull origin main
+pip install -e .
+```
+
+## Activity Description
+
+When hevy2garmin syncs a workout, it adds a text description to the Garmin activity summarizing your session:
+
+```
+🏋️ Push Day
+⏱️ 52 min
+🔥 387 kcal
+❤️ avg 118 bpm
+
+• Bench Press (Barbell): 3 sets · 80.0kg × 8
+• Incline Dumbbell Press: 3 sets · 28.0kg × 10
+• Cable Fly: 3 sets · 15.0kg × 12
+
+— synced by hevy2garmin
+```
+
+This is visible in the activity details on Garmin Connect and any connected apps (Strava, etc.). Cardio exercises show distance and duration instead of weight and reps.
+
 ## How It Works
 
 1. Pulls workouts from the Hevy API

--- a/tests/test_garmin_description.py
+++ b/tests/test_garmin_description.py
@@ -1,0 +1,134 @@
+"""Tests for Garmin activity description generation."""
+
+from __future__ import annotations
+
+from hevy2garmin.garmin import generate_description
+
+
+class TestDescriptionGeneration:
+    def test_standard_workout(self, sample_workout: dict) -> None:
+        desc = generate_description(sample_workout, calories=350, avg_hr=120)
+        assert "Push" in desc
+        assert "350 kcal" in desc
+        assert "avg 120 bpm" in desc
+        assert "Bench Press" in desc
+
+    def test_warmup_only_exercise(self) -> None:
+        workout = {
+            "title": "Warmup Only",
+            "start_time": "2026-04-01T20:00:00+00:00",
+            "end_time": "2026-04-01T20:10:00+00:00",
+            "exercises": [
+                {
+                    "title": "Band Pull Apart",
+                    "sets": [
+                        {"type": "warmup", "weight_kg": 0, "reps": 15},
+                        {"type": "warmup", "weight_kg": 0, "reps": 15},
+                    ],
+                }
+            ],
+        }
+        desc = generate_description(workout)
+        assert "Band Pull Apart" in desc
+        assert "warmup" in desc
+
+    def test_cardio_exercise_shows_distance(self) -> None:
+        workout = {
+            "title": "Cardio Day",
+            "start_time": "2026-04-01T20:00:00+00:00",
+            "end_time": "2026-04-01T20:30:00+00:00",
+            "exercises": [
+                {
+                    "title": "Treadmill",
+                    "sets": [
+                        {"type": "normal", "distance_meters": 5000, "duration_seconds": 1800},
+                    ],
+                }
+            ],
+        }
+        desc = generate_description(workout)
+        assert "Treadmill" in desc
+        assert "5.0km" in desc
+        assert "30min" in desc
+
+    def test_cardio_duration_only(self) -> None:
+        workout = {
+            "title": "Bike",
+            "start_time": "2026-04-01T20:00:00+00:00",
+            "end_time": "2026-04-01T20:20:00+00:00",
+            "exercises": [
+                {
+                    "title": "Stationary Bike",
+                    "sets": [
+                        {"type": "normal", "duration_seconds": 1200},
+                    ],
+                }
+            ],
+        }
+        desc = generate_description(workout)
+        assert "Stationary Bike" in desc
+        assert "20min" in desc
+
+    def test_empty_exercises(self) -> None:
+        workout = {
+            "title": "Empty",
+            "start_time": "2026-04-01T20:00:00+00:00",
+            "end_time": "2026-04-01T20:10:00+00:00",
+            "exercises": [],
+        }
+        desc = generate_description(workout)
+        assert "Empty" in desc
+        assert "hevy2garmin" in desc
+
+    def test_special_characters_in_name(self) -> None:
+        workout = {
+            "title": "Test",
+            "start_time": "2026-04-01T20:00:00+00:00",
+            "end_time": "2026-04-01T20:30:00+00:00",
+            "exercises": [
+                {
+                    "title": "André's Über-Exercise™ (50% off!)",
+                    "sets": [
+                        {"type": "normal", "weight_kg": 40, "reps": 10},
+                    ],
+                }
+            ],
+        }
+        desc = generate_description(workout)
+        assert "André's Über-Exercise™" in desc
+
+    def test_no_calories_no_hr(self) -> None:
+        workout = {
+            "title": "Minimal",
+            "start_time": "2026-04-01T20:00:00+00:00",
+            "end_time": "2026-04-01T20:10:00+00:00",
+            "exercises": [],
+        }
+        desc = generate_description(workout)
+        assert "kcal" not in desc
+        assert "bpm" not in desc
+
+    def test_mixed_cardio_and_strength(self) -> None:
+        workout = {
+            "title": "Mixed",
+            "start_time": "2026-04-01T20:00:00+00:00",
+            "end_time": "2026-04-01T21:00:00+00:00",
+            "exercises": [
+                {
+                    "title": "Bench Press",
+                    "sets": [
+                        {"type": "normal", "weight_kg": 80, "reps": 8},
+                        {"type": "normal", "weight_kg": 80, "reps": 6},
+                    ],
+                },
+                {
+                    "title": "Treadmill",
+                    "sets": [
+                        {"type": "normal", "distance_meters": 3000, "duration_seconds": 900},
+                    ],
+                },
+            ],
+        }
+        desc = generate_description(workout)
+        assert "80.0kg" in desc
+        assert "3.0km" in desc


### PR DESCRIPTION
Closes #104
Closes #108

## Summary

- Add `tests/test_garmin_description.py` with 8 tests covering description generation edge cases: warmup-only exercises, cardio with distance/duration, empty exercises, special characters, mixed cardio+strength, and no-metrics scenarios

The other sub-issues (#105-107) were already resolved in prior PRs (#86, #102, #103).

## Test plan

- [x] `PYTHONPATH=src pytest tests/ -q` — 128 passed, 7 skipped
- [x] All 8 new description tests pass
- [x] No regressions in existing tests

Closes #105
