### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| latest  | Yes       |
+
+## Reporting a Vulnerability
+
+If you find a security issue, please **do not** open a public issue.
+
+Instead, email **[MAINTAINER EMAIL]** with:
+
+- A description of the vulnerability
+- Steps to reproduce
+- Any relevant logs or screenshots
+
+You should expect a response within 7 days. Once confirmed, a fix will be prioritized and released as a patch version.
+
+## Credentials
+
+This project handles Garmin Connect credentials and API keys. If you believe credentials have been exposed in the repository history, please report it using the process above.


### PR DESCRIPTION
This repo doesn't have a SECURITY.md yet, so there's no clear way for someone to report a vulnerability privately. Added a minimal template. You'll want to fill in your contact email and update the supported versions.