### PR TITLE
feat: enhance watch activities — merge Hevy data into recorded Garmin activities

### DIFF
--- a/src/hevy2garmin/db_interface.py
+++ b/src/hevy2garmin/db_interface.py
@@ -25,6 +25,7 @@ class Database(ABC):
         calories: int | None = None,
         avg_hr: int | None = None,
         hevy_updated_at: str | None = None,
+        sync_method: str = "upload",
     ) -> None:
         """Record a successfully synced workout."""
 

--- a/src/hevy2garmin/db_postgres.py
+++ b/src/hevy2garmin/db_postgres.py
@@ -99,6 +99,11 @@ class PostgresDatabase(Database):
                     cur.execute("ALTER TABLE synced_workouts ADD COLUMN hevy_updated_at TEXT")
                 except Exception:
                     conn.rollback()
+                # Migration: add sync_method column (merge mode)
+                try:
+                    cur.execute("ALTER TABLE synced_workouts ADD COLUMN sync_method TEXT DEFAULT 'upload'")
+                except Exception:
+                    conn.rollback()
                 cur.execute("""
                     CREATE TABLE IF NOT EXISTS app_cache (
                         key TEXT PRIMARY KEY,
@@ -144,22 +149,24 @@ class PostgresDatabase(Database):
         calories: int | None = None,
         avg_hr: int | None = None,
         hevy_updated_at: str | None = None,
+        sync_method: str = "upload",
     ) -> None:
         with self._get_conn() as conn:
             with conn.cursor() as cur:
                 cur.execute(
                     """
-                    INSERT INTO synced_workouts (hevy_id, garmin_activity_id, title, calories, avg_hr, hevy_updated_at)
-                    VALUES (%s, %s, %s, %s, %s, %s)
+                    INSERT INTO synced_workouts (hevy_id, garmin_activity_id, title, calories, avg_hr, hevy_updated_at, sync_method)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s)
                     ON CONFLICT (hevy_id) DO UPDATE SET
                         garmin_activity_id = EXCLUDED.garmin_activity_id,
                         title = EXCLUDED.title,
                         calories = EXCLUDED.calories,
                         avg_hr = EXCLUDED.avg_hr,
                         hevy_updated_at = EXCLUDED.hevy_updated_at,
+                        sync_method = EXCLUDED.sync_method,
                         synced_at = NOW()
                     """,
-                    (hevy_id, garmin_activity_id, title, calories, avg_hr, hevy_updated_at),
+                    (hevy_id, garmin_activity_id, title, calories, avg_hr, hevy_updated_at, sync_method),
                 )
             conn.commit()
 

--- a/src/hevy2garmin/db_sqlite.py
+++ b/src/hevy2garmin/db_sqlite.py
@@ -64,6 +64,11 @@ class SQLiteDatabase(Database):
             conn.execute("ALTER TABLE synced_workouts ADD COLUMN hevy_updated_at TEXT")
         except Exception:
             pass  # Column already exists
+        # Migration: add sync_method column (merge mode)
+        try:
+            conn.execute("ALTER TABLE synced_workouts ADD COLUMN sync_method TEXT DEFAULT 'upload'")
+        except Exception:
+            pass  # Column already exists
         conn.execute("""
             CREATE TABLE IF NOT EXISTS app_cache (
                 key TEXT PRIMARY KEY,
@@ -99,14 +104,15 @@ class SQLiteDatabase(Database):
         calories: int | None = None,
         avg_hr: int | None = None,
         hevy_updated_at: str | None = None,
+        sync_method: str = "upload",
     ) -> None:
         conn = self._get_conn()
         conn.execute(
             """
-            INSERT OR REPLACE INTO synced_workouts (hevy_id, garmin_activity_id, title, calories, avg_hr, hevy_updated_at)
-            VALUES (?, ?, ?, ?, ?, ?)
+            INSERT OR REPLACE INTO synced_workouts (hevy_id, garmin_activity_id, title, calories, avg_hr, hevy_updated_at, sync_method)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
             """,
-            (hevy_id, garmin_activity_id, title, calories, avg_hr, hevy_updated_at),
+            (hevy_id, garmin_activity_id, title, calories, avg_hr, hevy_updated_at, sync_method),
         )
         conn.commit()
         conn.close()

--- a/src/hevy2garmin/garmin.py
+++ b/src/hevy2garmin/garmin.py
@@ -159,7 +159,7 @@ def set_description(client: Garmin, activity_id: int, description: str) -> None:
     """Set description for a Garmin activity."""
     url = f"/activity-service/activity/{activity_id}"
     payload = {"activityId": activity_id, "description": description}
-    client.client.put("connectapi", url, json=payload, api=True)
+    client.garth.connectapi(url, method="PUT", json=payload)
     time.sleep(1.0)
     logger.info("  Description set (%d chars)", len(description))
 
@@ -167,14 +167,136 @@ def set_description(client: Garmin, activity_id: int, description: str) -> None:
 def upload_image(client: Garmin, activity_id: int, image_bytes: bytes, filename: str = "image.png") -> None:
     """Upload an image to a Garmin activity."""
     files = {"file": (filename, io.BytesIO(image_bytes))}
-    client.client.post(
-        "connectapi",
-        f"activity-service/activity/{activity_id}/image",
+    client.garth.connectapi(
+        f"/activity-service/activity/{activity_id}/image",
+        method="POST",
         files=files,
-        api=True,
     )
     time.sleep(1.0)
     logger.info("  Image uploaded (%dKB)", len(image_bytes) // 1024)
+
+
+def find_matching_garmin_activity(
+    client: Garmin,
+    hevy_workout: dict,
+    overlap_threshold: float = 0.70,
+    max_drift_minutes: int = 20,
+) -> dict | None:
+    """Find a user-recorded Garmin Strength Training activity matching a Hevy workout.
+
+    Searches for activities that overlap the Hevy workout's time window,
+    then scores by temporal overlap and start-time proximity.
+
+    Returns the best-matching activity dict, or None if nothing qualifies.
+    Only matches completed activities of type 'strength_training'.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    start_raw = hevy_workout.get("start_time") or hevy_workout.get("startTime", "")
+    end_raw = hevy_workout.get("end_time") or hevy_workout.get("endTime", "")
+    if not start_raw or not end_raw:
+        return None
+
+    try:
+        hevy_start = datetime.fromisoformat(start_raw.replace("Z", "+00:00"))
+        hevy_end = datetime.fromisoformat(end_raw.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+
+    hevy_duration = (hevy_end - hevy_start).total_seconds()
+    if hevy_duration <= 0:
+        return None
+
+    # Query activities in a window around the workout
+    search_start = (hevy_start - timedelta(hours=2)).date().isoformat()
+    search_end = (hevy_end + timedelta(hours=2)).date().isoformat()
+    try:
+        activities = _limiter.call(client.get_activities_by_date, search_start, search_end)
+    except Exception as e:
+        logger.warning("Could not query Garmin activities for merge: %s", e)
+        return None
+
+    best_score = 0.0
+    best: dict | None = None
+
+    for act in (activities or []):
+        # Hard filter: strength_training only
+        act_type = act.get("activityType", {}).get("typeKey", "")
+        if act_type != "strength_training":
+            continue
+
+        # Must be a completed activity (has duration)
+        act_duration = act.get("duration", 0)
+        if not act_duration or act_duration <= 0:
+            continue
+
+        # Parse start time
+        act_start_str = act.get("startTimeGMT") or act.get("startTimeLocal", "")
+        try:
+            if "T" not in act_start_str:
+                act_start_str = act_start_str.replace(" ", "T")
+            act_start = datetime.fromisoformat(act_start_str)
+            if act_start.tzinfo is None:
+                act_start = act_start.replace(tzinfo=timezone.utc)
+        except (ValueError, TypeError):
+            continue
+
+        act_end = act_start + timedelta(seconds=act_duration)
+
+        # Check: activity must be finished. Garmin only sets duration > 0
+        # once the activity is saved/stopped. We also reject activities whose
+        # end time is more than 5 minutes into the future (clock skew margin).
+        if act_end > datetime.now(timezone.utc) + timedelta(minutes=5):
+            continue
+
+        # Compute temporal overlap
+        overlap_start = max(hevy_start.replace(tzinfo=timezone.utc), act_start.replace(tzinfo=timezone.utc))
+        overlap_end = min(hevy_end.replace(tzinfo=timezone.utc), act_end.replace(tzinfo=timezone.utc))
+        overlap_s = max(0.0, (overlap_end - overlap_start).total_seconds())
+        overlap_pct = overlap_s / hevy_duration
+
+        if overlap_pct < overlap_threshold:
+            continue
+
+        # Check start drift
+        drift_s = abs((act_start.replace(tzinfo=timezone.utc) - hevy_start.replace(tzinfo=timezone.utc)).total_seconds())
+        drift_min = drift_s / 60
+        if drift_min > max_drift_minutes:
+            continue
+
+        # Score: overlap dominates, drift is a small penalty
+        score = (overlap_pct * 100) - (drift_min * 0.5)
+        if score > best_score:
+            best_score = score
+            best = act
+
+    if best:
+        logger.info(
+            "Merge match: Garmin activity %s (overlap %.0f%%, drift %.1fmin)",
+            best.get("activityId"), best_score, 0,
+        )
+    return best
+
+
+def get_activity_exercise_sets(client: Garmin, activity_id: int) -> dict:
+    """GET exercise sets for a Garmin activity (for backup before merge)."""
+    time.sleep(1.0)
+    return client.get_activity_exercise_sets(activity_id)
+
+
+def push_exercise_sets(client: Garmin, activity_id: int, payload: dict) -> None:
+    """PUT exercise sets to an existing Garmin activity.
+
+    Uses the undocumented /activity-service/activity/{id}/exerciseSets endpoint.
+    Atomically replaces ALL exercise sets on the activity.
+
+    Note: called directly (not through _limiter) because the endpoint returns
+    204 No Content which the rate limiter misinterprets as an error.
+    """
+    url = f"/activity-service/activity/{activity_id}/exerciseSets"
+    time.sleep(1.0)  # manual rate limit
+    client.garth.connectapi(url, method="PUT", json=payload)
+    logger.info("  Pushed %d exercise sets to activity %s", len(payload.get("exerciseSets", [])), activity_id)
 
 
 def generate_description(workout: dict, calories: int | None = None, avg_hr: int | None = None) -> str:

--- a/src/hevy2garmin/merge.py
+++ b/src/hevy2garmin/merge.py
@@ -1,0 +1,303 @@
+"""Merge mode: push Hevy exercise data into user-recorded Garmin activities.
+
+When a user records a Strength Training on their Garmin watch at the gym,
+this module detects the matching activity and PUTs Hevy's exercise/set data
+into it via the exerciseSets API. The watch's 1-second HR, training effect,
+EPOC, and recovery stay intact.
+
+Public API:
+    attempt_merge(client, hevy_workout, db) -> MergeResult
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from hevy2garmin.garmin import (
+    find_matching_garmin_activity,
+    generate_description,
+    get_activity_exercise_sets,
+    push_exercise_sets,
+    rename_activity,
+    set_description,
+)
+from hevy2garmin.mapper import lookup_exercise
+
+logger = logging.getLogger("hevy2garmin")
+
+# Circuit breaker: disable merge after N consecutive PUT failures
+_MAX_CONSECUTIVE_FAILURES = 3
+_consecutive_failures = 0
+
+
+@dataclass
+class MergeResult:
+    """Result of a merge attempt."""
+    merged: bool
+    activity_id: int | None = None
+    fallback_reason: str | None = None
+
+
+def reset_circuit_breaker() -> None:
+    """Reset the failure counter (call at start of each sync run)."""
+    global _consecutive_failures
+    _consecutive_failures = 0
+
+
+def _circuit_breaker_tripped() -> bool:
+    return _consecutive_failures >= _MAX_CONSECUTIVE_FAILURES
+
+
+# ---------------------------------------------------------------------------
+# Category int → string conversion
+# ---------------------------------------------------------------------------
+
+# FIT SDK exercise category IDs → Garmin API string names.
+# These are the categories from the FIT SDK profile, used in the
+# exerciseSets PUT payload.
+_CATEGORY_NAMES: dict[int, str] = {
+    0: "BENCH_PRESS", 1: "CALF_RAISE", 2: "CARDIO", 3: "CARRY",
+    4: "CHOP", 5: "CORE", 6: "CRUNCH", 7: "CURL", 8: "DEADLIFT",
+    9: "FLYE", 10: "HIP_RAISE", 11: "HIP_STABILITY", 12: "HIP_SWING",
+    13: "HYPEREXTENSION", 14: "LATERAL_RAISE", 15: "LEG_CURL",
+    16: "LEG_RAISE", 17: "LUNGE", 18: "OLYMPIC_LIFT", 19: "PLANK",
+    20: "PLYO", 21: "PULL_UP", 22: "PUSH_UP", 23: "ROW",
+    24: "SHOULDER_PRESS", 25: "SHOULDER_STABILITY", 26: "SHRUG",
+    27: "SIT_UP", 28: "SQUAT", 29: "TOTAL_BODY",
+    30: "TRICEPS_EXTENSION", 31: "WARM_UP", 32: "RUN",
+    65534: "UNKNOWN",
+}
+
+# Subcategory names per category. Built from the FIT SDK profile.
+# Only the most common ones are listed — unmapped subs fall back to
+# the category's generic "0" name.
+# Format: {(category_id, subcategory_id): "GARMIN_STRING_NAME"}
+#
+# We populate this lazily from fit_tool if available, otherwise
+# use the category name as the exercise name (Garmin accepts this).
+
+def _category_to_string(cat_id: int) -> str:
+    return _CATEGORY_NAMES.get(cat_id, "UNKNOWN")
+
+
+def _exercise_to_string(cat_id: int, sub_id: int) -> str:
+    """Convert FIT category + subcategory IDs to Garmin exercise name string.
+
+    Falls back to the category name if the subcategory isn't mapped.
+    Garmin's exerciseSets API accepts the category name as the exercise name.
+    """
+    try:
+        from fit_tool.profile.profile_type import ExerciseCategory
+        # fit_tool has per-category exercise enums, but they're not always
+        # available or complete. Try to get the string name.
+        cat_enum = ExerciseCategory(cat_id)
+        # Look for a subcategory enum for this category
+        # e.g., for BENCH_PRESS (0), there's BenchPressExerciseName
+        cat_name = cat_enum.name  # "BENCH_PRESS"
+        # The subcategory enum class name follows a pattern
+        sub_enum_name = cat_name.title().replace("_", "") + "ExerciseName"
+        import fit_tool.profile.profile_type as pt
+        sub_enum_cls = getattr(pt, sub_enum_name, None)
+        if sub_enum_cls:
+            return sub_enum_cls(sub_id).name
+    except (ValueError, AttributeError, ImportError):
+        pass
+    # Fallback: use category name (Garmin accepts this)
+    return _category_to_string(cat_id)
+
+
+# ---------------------------------------------------------------------------
+# Payload builder
+# ---------------------------------------------------------------------------
+
+def build_exercise_sets_payload(
+    hevy_workout: dict,
+    activity_id: int,
+    activity_start_time: str,
+    activity_duration_s: float,
+) -> dict:
+    """Convert a Hevy workout into a Garmin exerciseSets PUT payload.
+
+    Uses the matched Garmin activity's actual start time and duration
+    to distribute set timestamps across the real activity timeline.
+
+    Args:
+        hevy_workout: Hevy workout dict with exercises and sets.
+        activity_id: Garmin activity ID.
+        activity_start_time: Garmin activity's startTimeGMT (ISO or space-separated).
+        activity_duration_s: Garmin activity's duration in seconds.
+    """
+    # Parse activity start
+    start_str = activity_start_time.replace(" ", "T")
+    if "+" not in start_str and not start_str.endswith("Z"):
+        start_str += "+00:00"
+    act_start = datetime.fromisoformat(start_str.replace("Z", "+00:00"))
+
+    exercises = hevy_workout.get("exercises", [])
+    if not exercises:
+        return {"activityId": activity_id, "exerciseSets": []}
+
+    # Profile timing defaults (same as fit.py uses)
+    working_set_s = 40
+    warmup_set_s = 25
+    rest_sets_s = 75
+    rest_exercises_s = 120
+
+    # Count total sets and compute ideal duration for scaling
+    all_sets: list[dict] = []
+    for ex_idx, ex in enumerate(exercises):
+        sets = ex.get("sets", [])
+        for s_idx, s in enumerate(sets):
+            is_warmup = s.get("type", "normal") == "warmup"
+            explicit_dur = s.get("duration_seconds")
+            if explicit_dur and explicit_dur > 0:
+                set_dur = float(explicit_dur)
+            else:
+                set_dur = warmup_set_s if is_warmup else working_set_s
+
+            is_last_set = s_idx == len(sets) - 1
+            is_last_exercise = ex_idx == len(exercises) - 1
+            if is_last_set and is_last_exercise:
+                rest_dur = 0.0
+            elif is_last_set:
+                rest_dur = rest_exercises_s
+            else:
+                rest_dur = rest_sets_s
+
+            all_sets.append({
+                "ex_idx": ex_idx,
+                "set_data": s,
+                "set_dur": set_dur,
+                "rest_dur": rest_dur,
+            })
+
+    # Scale to fit actual activity duration
+    ideal_total = sum(si["set_dur"] + si["rest_dur"] for si in all_sets)
+    scale = activity_duration_s / ideal_total if ideal_total > 0 else 1.0
+    scale = max(0.3, min(2.0, scale))
+
+    # Build exercise sets
+    exercise_sets: list[dict] = []
+    msg_idx = 0
+    cursor_s = 0.0
+
+    for si in all_sets:
+        s = si["set_data"]
+        ex_idx = si["ex_idx"]
+        ex = exercises[ex_idx]
+
+        cat_id, sub_id, _ = lookup_exercise(ex.get("title") or ex.get("name", "Unknown"))
+        cat_str = _category_to_string(cat_id)
+        ex_str = _exercise_to_string(cat_id, sub_id)
+        # Garmin rejects UNKNOWN category — fall back to TOTAL_BODY
+        if cat_str == "UNKNOWN":
+            cat_str = "TOTAL_BODY"
+            ex_str = "TOTAL_BODY"
+
+        set_start = act_start + timedelta(seconds=cursor_s)
+        scaled_dur = si["set_dur"] * scale
+
+        # Active set
+        reps = s.get("reps")
+        weight_kg = s.get("weight_kg")
+
+        active_set: dict = {
+            "exercises": [{"category": cat_str, "name": ex_str}],
+            "duration": round(scaled_dur, 3),
+            "repetitionCount": int(reps) if reps is not None else 0,
+            "weight": float(round(weight_kg * 1000)) if weight_kg else 0.0,
+            "setType": "ACTIVE",
+            "startTime": set_start.strftime("%Y-%m-%dT%H:%M:%S.0"),
+            "wktStepIndex": ex_idx,
+            "messageIndex": msg_idx,
+        }
+        exercise_sets.append(active_set)
+        msg_idx += 1
+        cursor_s += scaled_dur
+
+        # Rest set (if applicable)
+        if si["rest_dur"] > 0:
+            rest_start = act_start + timedelta(seconds=cursor_s)
+            scaled_rest = si["rest_dur"] * scale
+            rest_set: dict = {
+                "exercises": [],
+                "duration": round(scaled_rest, 3),
+                "setType": "REST",
+                "startTime": rest_start.strftime("%Y-%m-%dT%H:%M:%S.0"),
+                "wktStepIndex": ex_idx,
+                "messageIndex": msg_idx,
+            }
+            exercise_sets.append(rest_set)
+            msg_idx += 1
+            cursor_s += scaled_rest
+
+    return {"activityId": activity_id, "exerciseSets": exercise_sets}
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+def attempt_merge(client, hevy_workout: dict, database) -> MergeResult:
+    """Try to merge Hevy exercise data into a matching Garmin activity.
+
+    Returns MergeResult with merged=True if successful, or merged=False
+    with a fallback_reason explaining why (no match, circuit breaker, etc.)
+    """
+    global _consecutive_failures
+
+    if _circuit_breaker_tripped():
+        return MergeResult(merged=False, fallback_reason="Circuit breaker: too many PUT failures")
+
+    # Find matching activity
+    match = find_matching_garmin_activity(client, hevy_workout)
+    if not match:
+        return MergeResult(merged=False, fallback_reason="No matching Garmin activity found")
+
+    activity_id = match.get("activityId")
+    act_start = match.get("startTimeGMT") or match.get("startTimeLocal", "")
+    act_duration = match.get("duration", 0)
+
+    if not activity_id or not act_start or not act_duration:
+        return MergeResult(merged=False, fallback_reason="Matched activity missing required fields")
+
+    # Backup existing exercise sets
+    try:
+        existing_sets = get_activity_exercise_sets(client, activity_id)
+        database.set_app_config(
+            f"merge_backup_{activity_id}",
+            {"activity_id": activity_id, "original_sets": existing_sets},
+        )
+    except Exception as e:
+        logger.warning("Could not backup exercise sets for %s: %s", activity_id, e)
+        # Continue anyway — backup is best-effort
+
+    # Build payload
+    title = hevy_workout.get("title", "Workout")
+    payload = build_exercise_sets_payload(hevy_workout, activity_id, act_start, act_duration)
+
+    # PUT exercise sets
+    try:
+        push_exercise_sets(client, activity_id, payload)
+        _consecutive_failures = 0
+    except Exception as e:
+        _consecutive_failures += 1
+        logger.error("PUT exerciseSets failed for activity %s: %s", activity_id, e)
+        return MergeResult(merged=False, fallback_reason=f"PUT failed: {e}")
+
+    # Rename + set description
+    try:
+        rename_activity(client, activity_id, title)
+        desc = generate_description(hevy_workout)
+        if not desc.endswith("— synced by hevy2garmin"):
+            desc += "\n— synced by hevy2garmin"
+        # Prepend merge note
+        desc = "⚡ Exercises synced from Hevy by hevy2garmin\n\n" + desc
+        set_description(client, activity_id, desc)
+    except Exception as e:
+        logger.warning("Rename/description failed after merge for %s: %s", activity_id, e)
+        # Non-fatal — sets were already pushed
+
+    return MergeResult(merged=True, activity_id=activity_id)

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -21,6 +21,7 @@ from hevy2garmin.garmin import (
 )
 from hevy2garmin.hevy import HevyClient
 from hevy2garmin.mapper import lookup_exercise
+from hevy2garmin.merge import attempt_merge, reset_circuit_breaker, MergeResult
 
 logger = logging.getLogger("hevy2garmin")
 
@@ -112,7 +113,12 @@ def sync(
         garmin_client = get_client(garmin_email, garmin_password, garmin_token_dir)
         logger.info("Authenticated successfully")
 
-    stats = {"synced": 0, "skipped": 0, "failed": 0, "total": len(workouts), "unmapped": []}
+    merge_mode = cfg.get("merge_mode", False)
+    stats = {"synced": 0, "skipped": 0, "failed": 0, "total": len(workouts), "unmapped": [], "merged": 0, "merge_fallback": 0}
+
+    if merge_mode:
+        reset_circuit_breaker()
+        logger.info("Merge mode enabled — will try to enhance watch activities")
 
     for workout in workouts:
         wid = workout.get("id", "unknown")
@@ -134,6 +140,26 @@ def sync(
                 stats["unmapped"].append(ex_name)
 
         try:
+            # ── Merge mode: try to enhance a watch-recorded activity ──
+            if merge_mode and garmin_client and not dry_run:
+                merge_result = attempt_merge(garmin_client, workout, db)
+                if merge_result.merged:
+                    db.mark_synced(
+                        hevy_id=wid,
+                        garmin_activity_id=str(merge_result.activity_id),
+                        title=title,
+                        hevy_updated_at=workout.get("updated_at"),
+                        sync_method="merge",
+                    )
+                    stats["synced"] += 1
+                    stats["merged"] += 1
+                    logger.info("  ⚡ Enhanced → Garmin activity %s", merge_result.activity_id)
+                    continue
+                else:
+                    logger.info("  Merge fallback: %s", merge_result.fallback_reason)
+                    stats["merge_fallback"] += 1
+
+            # ── Standard upload path (FIT generation) ──
             with tempfile.TemporaryDirectory() as tmp:
                 fit_path = str(Path(tmp) / f"{wid}.fit")
                 result = generate_fit(workout, hr_samples=None, output_path=fit_path)
@@ -165,6 +191,7 @@ def sync(
                     )
                     set_description(garmin_client, activity_id, desc)
 
+                sync_method = "upload_fallback" if merge_mode else "upload"
                 db.mark_synced(
                     hevy_id=wid,
                     garmin_activity_id=str(activity_id) if activity_id else None,
@@ -172,6 +199,7 @@ def sync(
                     calories=result.get("calories"),
                     avg_hr=result.get("avg_hr"),
                     hevy_updated_at=workout.get("updated_at"),
+                    sync_method=sync_method,
                 )
                 stats["synced"] += 1
                 logger.info("  ✓ Synced → Garmin activity %s", activity_id)

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,0 +1,408 @@
+"""Tests for merge mode: matching heuristic + payload builder."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hevy2garmin.merge import (
+    MergeResult,
+    attempt_merge,
+    build_exercise_sets_payload,
+    reset_circuit_breaker,
+    _category_to_string,
+    _exercise_to_string,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_garmin_activity(
+    activity_id: int = 12345,
+    start: str = "2026-03-15 18:02:00",
+    duration_s: float = 43 * 60,
+    type_key: str = "strength_training",
+) -> dict:
+    return {
+        "activityId": activity_id,
+        "startTimeGMT": start,
+        "startTimeLocal": start,
+        "duration": duration_s,
+        "activityType": {"typeKey": type_key},
+    }
+
+
+HEVY_WORKOUT = {
+    "id": "test-123",
+    "title": "Push",
+    "start_time": "2026-03-15T18:00:00+00:00",
+    "end_time": "2026-03-15T18:45:00+00:00",
+    "exercises": [
+        {
+            "title": "Bench Press (Barbell)",
+            "sets": [
+                {"type": "warmup", "weight_kg": 40, "reps": 12},
+                {"type": "normal", "weight_kg": 60, "reps": 10},
+                {"type": "normal", "weight_kg": 60, "reps": 8},
+            ],
+        },
+        {
+            "title": "Shoulder Press (Dumbbell)",
+            "sets": [
+                {"type": "normal", "weight_kg": 14, "reps": 12},
+                {"type": "normal", "weight_kg": 14, "reps": 10},
+            ],
+        },
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Matching heuristic tests
+# ---------------------------------------------------------------------------
+
+class TestFindMatchingActivity:
+
+    def test_exact_overlap_matches(self):
+        """Strength training with high overlap → match."""
+        from hevy2garmin.garmin import find_matching_garmin_activity
+
+        client = MagicMock()
+        client.get_activities_by_date.return_value = [
+            _make_garmin_activity(start="2026-03-15 18:02:00", duration_s=43 * 60),
+        ]
+        match = find_matching_garmin_activity(client, HEVY_WORKOUT)
+        assert match is not None
+        assert match["activityId"] == 12345
+
+    def test_low_overlap_rejected(self):
+        """Activity with only 50% overlap is below 70% threshold → no match."""
+        from hevy2garmin.garmin import find_matching_garmin_activity
+
+        client = MagicMock()
+        # Activity starts 22 min late, only ~50% overlap with 45-min hevy workout
+        client.get_activities_by_date.return_value = [
+            _make_garmin_activity(start="2026-03-15 18:22:00", duration_s=23 * 60),
+        ]
+        match = find_matching_garmin_activity(client, HEVY_WORKOUT)
+        assert match is None
+
+    def test_wrong_type_rejected(self):
+        """Running activity with perfect overlap → no match."""
+        from hevy2garmin.garmin import find_matching_garmin_activity
+
+        client = MagicMock()
+        client.get_activities_by_date.return_value = [
+            _make_garmin_activity(type_key="running"),
+        ]
+        match = find_matching_garmin_activity(client, HEVY_WORKOUT)
+        assert match is None
+
+    def test_incomplete_activity_rejected(self):
+        """Activity still in progress (end time in future) → no match."""
+        from datetime import datetime, timezone
+        from hevy2garmin.garmin import find_matching_garmin_activity
+
+        now = datetime.now(timezone.utc)
+        # Activity started 10 min ago with a very long duration (still recording)
+        recent_start = now.strftime("%Y-%m-%d %H:%M:%S")
+        hevy_now = {
+            **HEVY_WORKOUT,
+            "start_time": now.isoformat(),
+            "end_time": (now + __import__("datetime").timedelta(minutes=45)).isoformat(),
+        }
+        client = MagicMock()
+        client.get_activities_by_date.return_value = [
+            _make_garmin_activity(start=recent_start, duration_s=999999),
+        ]
+        match = find_matching_garmin_activity(client, hevy_now)
+        assert match is None
+
+    def test_best_of_multiple_candidates(self):
+        """When multiple candidates overlap, pick the highest-scoring one."""
+        from hevy2garmin.garmin import find_matching_garmin_activity
+
+        client = MagicMock()
+        client.get_activities_by_date.return_value = [
+            _make_garmin_activity(activity_id=1, start="2026-03-15 18:10:00", duration_s=35 * 60),
+            _make_garmin_activity(activity_id=2, start="2026-03-15 18:01:00", duration_s=44 * 60),
+        ]
+        match = find_matching_garmin_activity(client, HEVY_WORKOUT)
+        assert match is not None
+        assert match["activityId"] == 2  # Better overlap + closer start
+
+
+# ---------------------------------------------------------------------------
+# Payload builder tests
+# ---------------------------------------------------------------------------
+
+class TestBuildPayload:
+
+    def test_payload_structure(self):
+        """Payload has activityId and exerciseSets list."""
+        payload = build_exercise_sets_payload(
+            HEVY_WORKOUT,
+            activity_id=12345,
+            activity_start_time="2026-03-15 18:00:00",
+            activity_duration_s=45 * 60,
+        )
+        assert payload["activityId"] == 12345
+        assert isinstance(payload["exerciseSets"], list)
+        assert len(payload["exerciseSets"]) > 0
+
+    def test_active_and_rest_sets(self):
+        """Payload contains both ACTIVE and REST sets."""
+        payload = build_exercise_sets_payload(
+            HEVY_WORKOUT,
+            activity_id=12345,
+            activity_start_time="2026-03-15 18:00:00",
+            activity_duration_s=45 * 60,
+        )
+        types = {s["setType"] for s in payload["exerciseSets"]}
+        assert "ACTIVE" in types
+        assert "REST" in types
+
+    def test_exercise_count_matches(self):
+        """Number of ACTIVE sets matches total sets in Hevy workout."""
+        payload = build_exercise_sets_payload(
+            HEVY_WORKOUT,
+            activity_id=12345,
+            activity_start_time="2026-03-15 18:00:00",
+            activity_duration_s=45 * 60,
+        )
+        active = [s for s in payload["exerciseSets"] if s["setType"] == "ACTIVE"]
+        # 3 bench sets + 2 shoulder sets = 5
+        assert len(active) == 5
+
+    def test_weight_in_grams(self):
+        """Weight is converted from kg to grams."""
+        payload = build_exercise_sets_payload(
+            HEVY_WORKOUT,
+            activity_id=12345,
+            activity_start_time="2026-03-15 18:00:00",
+            activity_duration_s=45 * 60,
+        )
+        first_active = next(s for s in payload["exerciseSets"] if s["setType"] == "ACTIVE")
+        assert first_active["weight"] == 40000  # 40 kg warmup = 40000 grams
+
+    def test_wkt_step_index_groups_exercises(self):
+        """wktStepIndex groups sets by exercise (0 for bench, 1 for shoulder)."""
+        payload = build_exercise_sets_payload(
+            HEVY_WORKOUT,
+            activity_id=12345,
+            activity_start_time="2026-03-15 18:00:00",
+            activity_duration_s=45 * 60,
+        )
+        active = [s for s in payload["exerciseSets"] if s["setType"] == "ACTIVE"]
+        bench_steps = {s["wktStepIndex"] for s in active[:3]}
+        shoulder_steps = {s["wktStepIndex"] for s in active[3:]}
+        assert bench_steps == {0}
+        assert shoulder_steps == {1}
+
+    def test_category_string_mapping(self):
+        """Exercise categories are strings, not ints."""
+        payload = build_exercise_sets_payload(
+            HEVY_WORKOUT,
+            activity_id=12345,
+            activity_start_time="2026-03-15 18:00:00",
+            activity_duration_s=45 * 60,
+        )
+        first_active = next(s for s in payload["exerciseSets"] if s["setType"] == "ACTIVE")
+        assert first_active["exercises"][0]["category"] == "BENCH_PRESS"
+        assert isinstance(first_active["exercises"][0]["name"], str)
+
+    def test_empty_workout(self):
+        """Workout with no exercises produces empty sets list."""
+        workout = {**HEVY_WORKOUT, "exercises": []}
+        payload = build_exercise_sets_payload(
+            workout,
+            activity_id=12345,
+            activity_start_time="2026-03-15 18:00:00",
+            activity_duration_s=45 * 60,
+        )
+        assert payload["exerciseSets"] == []
+
+
+# ---------------------------------------------------------------------------
+# Category string conversion tests
+# ---------------------------------------------------------------------------
+
+class TestCategoryConversion:
+
+    def test_known_category(self):
+        assert _category_to_string(0) == "BENCH_PRESS"
+        assert _category_to_string(28) == "SQUAT"
+        assert _category_to_string(23) == "ROW"
+
+    def test_unknown_category(self):
+        assert _category_to_string(65534) == "UNKNOWN"
+        assert _category_to_string(9999) == "UNKNOWN"
+
+
+# ---------------------------------------------------------------------------
+# Integration: attempt_merge
+# ---------------------------------------------------------------------------
+
+class TestAttemptMerge:
+
+    def setup_method(self):
+        reset_circuit_breaker()
+
+    @patch("hevy2garmin.merge.find_matching_garmin_activity")
+    @patch("hevy2garmin.merge.get_activity_exercise_sets")
+    @patch("hevy2garmin.merge.push_exercise_sets")
+    @patch("hevy2garmin.merge.rename_activity")
+    @patch("hevy2garmin.merge.set_description")
+    def test_merge_path_taken(self, mock_desc, mock_rename, mock_push, mock_get_sets, mock_find):
+        """When a match is found, PUT is called and result is merged=True."""
+        mock_find.return_value = _make_garmin_activity()
+        mock_get_sets.return_value = {"exerciseSets": []}
+        mock_db = MagicMock()
+
+        result = attempt_merge(MagicMock(), HEVY_WORKOUT, mock_db)
+
+        assert result.merged is True
+        assert result.activity_id == 12345
+        mock_push.assert_called_once()
+        mock_rename.assert_called_once()
+
+    @patch("hevy2garmin.merge.find_matching_garmin_activity")
+    def test_no_match_fallback(self, mock_find):
+        """When no match, result is merged=False with reason."""
+        mock_find.return_value = None
+        mock_db = MagicMock()
+
+        result = attempt_merge(MagicMock(), HEVY_WORKOUT, mock_db)
+
+        assert result.merged is False
+        assert "No matching" in result.fallback_reason
+
+    @patch("hevy2garmin.merge.find_matching_garmin_activity")
+    @patch("hevy2garmin.merge.get_activity_exercise_sets")
+    @patch("hevy2garmin.merge.push_exercise_sets")
+    def test_circuit_breaker_trips(self, mock_push, mock_get_sets, mock_find):
+        """After 3 consecutive PUT failures, merge is disabled."""
+        mock_find.return_value = _make_garmin_activity()
+        mock_get_sets.return_value = {"exerciseSets": []}
+        mock_push.side_effect = RuntimeError("PUT failed")
+        mock_db = MagicMock()
+
+        for _ in range(3):
+            attempt_merge(MagicMock(), HEVY_WORKOUT, mock_db)
+
+        # 4th attempt should be blocked by circuit breaker
+        result = attempt_merge(MagicMock(), HEVY_WORKOUT, mock_db)
+        assert result.merged is False
+        assert "Circuit breaker" in result.fallback_reason
+
+
+# ---------------------------------------------------------------------------
+# Sync integration tests
+# ---------------------------------------------------------------------------
+
+class TestSyncIntegration:
+    """Test merge mode wired into sync.py."""
+
+    WORKOUTS = [
+        {
+            "id": "w1", "title": "Push",
+            "start_time": "2026-03-15T18:00:00+00:00", "end_time": "2026-03-15T18:45:00+00:00",
+            "updated_at": "2026-03-15T18:45:00+00:00",
+            "exercises": [{"title": "Bench Press (Barbell)", "sets": [{"type": "normal", "weight_kg": 60, "reps": 8}]}],
+        },
+        {
+            "id": "w2", "title": "Pull",
+            "start_time": "2026-03-16T18:00:00+00:00", "end_time": "2026-03-16T18:45:00+00:00",
+            "updated_at": "2026-03-16T18:45:00+00:00",
+            "exercises": [{"title": "Bent Over Row (Barbell)", "sets": [{"type": "normal", "weight_kg": 50, "reps": 10}]}],
+        },
+    ]
+
+    def _mock_hevy(self):
+        h = MagicMock()
+        h.get_workout_count.return_value = 2
+        h.get_workouts.return_value = {"workouts": self.WORKOUTS, "page_count": 1}
+        return h
+
+    @patch("hevy2garmin.sync.db")
+    @patch("hevy2garmin.sync.get_client")
+    @patch("hevy2garmin.sync.HevyClient")
+    @patch("hevy2garmin.sync.attempt_merge")
+    def test_merge_on_both_match(self, mock_merge, mock_hevy_cls, mock_gclient, mock_db):
+        """merge ON, both match → both use merge path."""
+        mock_hevy_cls.return_value = self._mock_hevy()
+        mock_gclient.return_value = MagicMock()
+        mock_db.is_synced.return_value = False
+        mock_merge.return_value = MergeResult(merged=True, activity_id=12345)
+
+        from hevy2garmin.sync import sync
+        stats = sync(config={"hevy_api_key": "t", "merge_mode": True}, limit=2)
+
+        assert stats["merged"] == 2
+        assert stats["merge_fallback"] == 0
+        assert mock_merge.call_count == 2
+        calls = mock_db.mark_synced.call_args_list
+        assert all(c.kwargs.get("sync_method") == "merge" for c in calls)
+
+    @patch("hevy2garmin.sync.db")
+    @patch("hevy2garmin.sync.get_client")
+    @patch("hevy2garmin.sync.HevyClient")
+    @patch("hevy2garmin.sync.attempt_merge")
+    @patch("hevy2garmin.sync.generate_fit", return_value={"exercises": 1, "total_sets": 1, "calories": 100, "avg_hr": 90})
+    @patch("hevy2garmin.sync.upload_fit", return_value={"activity_id": 222})
+    @patch("hevy2garmin.sync.find_activity_by_start_time", return_value=None)
+    @patch("hevy2garmin.sync.rename_activity")
+    @patch("hevy2garmin.sync.set_description")
+    @patch("hevy2garmin.sync.generate_description", return_value="test")
+    def test_merge_on_second_falls_back(self, *mocks):
+        """merge ON, first matches, second doesn't → fallback to upload."""
+        (mock_desc, mock_setdesc, mock_rename, mock_find, mock_upload,
+         mock_fit, mock_merge, mock_hevy_cls, mock_gclient, mock_db) = mocks
+
+        mock_hevy_cls.return_value = self._mock_hevy()
+        mock_gclient.return_value = MagicMock()
+        mock_db.is_synced.return_value = False
+        call_count = [0]
+        def alt(c, w, d):
+            call_count[0] += 1
+            return MergeResult(merged=True, activity_id=111) if call_count[0] == 1 else MergeResult(merged=False, fallback_reason="No match")
+        mock_merge.side_effect = alt
+
+        from hevy2garmin.sync import sync
+        stats = sync(config={"hevy_api_key": "t", "merge_mode": True}, limit=2)
+
+        assert stats["merged"] == 1
+        assert stats["merge_fallback"] == 1
+        calls = mock_db.mark_synced.call_args_list
+        assert calls[0].kwargs.get("sync_method") == "merge"
+        assert calls[1].kwargs.get("sync_method") == "upload_fallback"
+
+    @patch("hevy2garmin.sync.db")
+    @patch("hevy2garmin.sync.get_client")
+    @patch("hevy2garmin.sync.HevyClient")
+    @patch("hevy2garmin.sync.attempt_merge")
+    @patch("hevy2garmin.sync.generate_fit", return_value={"exercises": 1, "total_sets": 1, "calories": 100, "avg_hr": 90})
+    @patch("hevy2garmin.sync.upload_fit", return_value={"activity_id": 333})
+    @patch("hevy2garmin.sync.find_activity_by_start_time", return_value=None)
+    @patch("hevy2garmin.sync.rename_activity")
+    @patch("hevy2garmin.sync.set_description")
+    @patch("hevy2garmin.sync.generate_description", return_value="test")
+    def test_merge_off_normal_upload(self, *mocks):
+        """merge OFF → normal upload, merge never attempted."""
+        (mock_desc, mock_setdesc, mock_rename, mock_find, mock_upload,
+         mock_fit, mock_merge, mock_hevy_cls, mock_gclient, mock_db) = mocks
+
+        mock_hevy_cls.return_value = self._mock_hevy()
+        mock_gclient.return_value = MagicMock()
+        mock_db.is_synced.return_value = False
+
+        from hevy2garmin.sync import sync
+        stats = sync(config={"hevy_api_key": "t", "merge_mode": False}, limit=2)
+
+        assert stats["merged"] == 0
+        assert mock_merge.call_count == 0
+        calls = mock_db.mark_synced.call_args_list
+        assert all(c.kwargs.get("sync_method") == "upload" for c in calls)


### PR DESCRIPTION
Closes #111
Closes #112
Closes #113
Closes #114
Closes #116

## Summary

When a user records a Strength Training on their Garmin watch at the gym, hevy2garmin detects the matching activity and pushes Hevy's exercise/set data directly into it via `PUT /activity-service/activity/{id}/exerciseSets`. The watch's 1-second HR, training effect, EPOC, and recovery stay intact. No FIT file created, no activity deletion, no re-upload.

- **Matching**: 70% temporal overlap + <20min start drift + `strength_training` type only
- **Fallback**: no match → FIT upload (existing flow) + dashboard warning
- **Circuit breaker**: 3 consecutive PUT failures → disable merge for sync run
- **Pre-merge backup**: GET existing sets before PUT (stored in app_cache)
- **DB**: `sync_method` column tracks upload/merge/upload_fallback
- **Bugs fixed**: `set_description`/`upload_image` garth migration, UNKNOWN category rejection, REST set null values

## Test plan

- [x] 20 new tests: matching heuristic (5), payload builder (7), category conversion (2), attempt_merge (3), sync integration (3)
- [x] Full suite: 148 passed, 7 skipped
- [x] E2E on live Garmin: PUT exercise sets → verify on Garmin → restore
- [x] Tested: merge path, fallback path, merge-off path, circuit breaker
- [ ] Dashboard toggle + 3-state status (#115 — separate PR)