### PR TITLE
feat: settings page — merge mode, description, advanced params

### DIFF
--- a/src/hevy2garmin/merge.py
+++ b/src/hevy2garmin/merge.py
@@ -240,7 +240,7 @@ def build_exercise_sets_payload(
 # Orchestrator
 # ---------------------------------------------------------------------------
 
-def attempt_merge(client, hevy_workout: dict, database) -> MergeResult:
+def attempt_merge(client, hevy_workout: dict, database, overlap_threshold: float = 0.70, max_drift_minutes: int = 20) -> MergeResult:
     """Try to merge Hevy exercise data into a matching Garmin activity.
 
     Returns MergeResult with merged=True if successful, or merged=False
@@ -252,7 +252,7 @@ def attempt_merge(client, hevy_workout: dict, database) -> MergeResult:
         return MergeResult(merged=False, fallback_reason="Circuit breaker: too many PUT failures")
 
     # Find matching activity
-    match = find_matching_garmin_activity(client, hevy_workout)
+    match = find_matching_garmin_activity(client, hevy_workout, overlap_threshold=overlap_threshold, max_drift_minutes=max_drift_minutes)
     if not match:
         return MergeResult(merged=False, fallback_reason="No matching Garmin activity found")
 

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -794,6 +794,10 @@ async def settings_save(
     working_set_seconds: int = Form(40), warmup_set_seconds: int = Form(25),
     rest_between_sets_seconds: int = Form(75), rest_between_exercises_seconds: int = Form(120),
     hr_fusion_enabled: str = Form("off"),
+    merge_mode: str = Form("off"),
+    description_enabled: str = Form("off"),
+    merge_overlap_pct: int = Form(70),
+    merge_max_drift_min: int = Form(20),
 ):
     config = load_config()
     if hevy_api_key:
@@ -807,6 +811,10 @@ async def settings_save(
         rest_between_exercises_seconds=rest_between_exercises_seconds,
     )
     config.setdefault("hr_fusion", {})["enabled"] = hr_fusion_enabled == "on"
+    config["merge_mode"] = merge_mode == "on"
+    config["description_enabled"] = description_enabled == "on"
+    config["merge_overlap_pct"] = max(50, min(95, merge_overlap_pct))
+    config["merge_max_drift_min"] = max(5, min(60, merge_max_drift_min))
     save_config(config)
 
     # Persist settings to DB on cloud (filesystem is read-only on Vercel)
@@ -816,6 +824,12 @@ async def settings_save(
             _db.set_app_config("user_profile", config["user_profile"])
             _db.set_app_config("timing", config["timing"])
             _db.set_app_config("hr_fusion", config.get("hr_fusion", {}))
+            _db.set_app_config("merge_settings", {
+                "merge_mode": config["merge_mode"],
+                "description_enabled": config["description_enabled"],
+                "merge_overlap_pct": config["merge_overlap_pct"],
+                "merge_max_drift_min": config["merge_max_drift_min"],
+            })
         except Exception as e:
             logger.warning("Failed to persist settings to DB: %s", e)
 

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -114,6 +114,9 @@ def sync(
         logger.info("Authenticated successfully")
 
     merge_mode = cfg.get("merge_mode", True)
+    merge_overlap_pct = cfg.get("merge_overlap_pct", 70) / 100.0  # convert % to decimal
+    merge_max_drift_min = cfg.get("merge_max_drift_min", 20)
+    description_enabled = cfg.get("description_enabled", True)
     stats = {"synced": 0, "skipped": 0, "failed": 0, "total": len(workouts), "unmapped": [], "merged": 0, "merge_fallback": 0}
 
     if merge_mode:
@@ -142,7 +145,7 @@ def sync(
         try:
             # ── Merge mode: try to enhance a watch-recorded activity ──
             if merge_mode and garmin_client and not dry_run:
-                merge_result = attempt_merge(garmin_client, workout, db)
+                merge_result = attempt_merge(garmin_client, workout, db, overlap_threshold=merge_overlap_pct, max_drift_minutes=merge_max_drift_min)
                 if merge_result.merged:
                     db.mark_synced(
                         hevy_id=wid,
@@ -184,12 +187,13 @@ def sync(
 
                 if activity_id:
                     rename_activity(garmin_client, activity_id, title)
-                    desc = generate_description(
-                        workout,
-                        calories=result.get("calories"),
-                        avg_hr=result.get("avg_hr"),
-                    )
-                    set_description(garmin_client, activity_id, desc)
+                    if description_enabled:
+                        desc = generate_description(
+                            workout,
+                            calories=result.get("calories"),
+                            avg_hr=result.get("avg_hr"),
+                        )
+                        set_description(garmin_client, activity_id, desc)
 
                 sync_method = "upload_fallback" if merge_mode else "upload"
                 db.mark_synced(

--- a/src/hevy2garmin/templates/settings.html
+++ b/src/hevy2garmin/templates/settings.html
@@ -161,6 +161,43 @@
         </p>
     </div>
 
+    <!-- Enhance Watch Activities Section -->
+    <div class="card section">
+        <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px;">
+            <div style="display: flex; align-items: center; gap: 8px;">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#fbbf24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+                <span class="card-title">Enhance Watch Activities</span>
+            </div>
+            <label style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
+                <input type="hidden" name="merge_mode" value="off">
+                <input type="checkbox" name="merge_mode" value="on" {{ 'checked' if config.get('merge_mode', True) }} style="width: 18px; height: 18px; accent-color: var(--accent);">
+                <span style="font-size: 13px; color: var(--text-secondary);">Enabled</span>
+            </label>
+        </div>
+        <p class="section-description">
+            When you start a <strong>Strength Training</strong> activity on your Garmin watch at the gym, hevy2garmin will detect it and push your Hevy exercise data into that activity instead of creating a new one.
+            You get 1-second HR sampling, training effect, EPOC, and recovery data. If no matching watch activity is found, it falls back to the normal upload.
+        </p>
+    </div>
+
+    <!-- Activity Description Section -->
+    <div class="card section">
+        <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px;">
+            <div style="display: flex; align-items: center; gap: 8px;">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--text-muted)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
+                <span class="card-title">Activity Description</span>
+            </div>
+            <label style="display: flex; align-items: center; gap: 8px; cursor: pointer;">
+                <input type="hidden" name="description_enabled" value="off">
+                <input type="checkbox" name="description_enabled" value="on" {{ 'checked' if config.get('description_enabled', True) }} style="width: 18px; height: 18px; accent-color: var(--accent);">
+                <span style="font-size: 13px; color: var(--text-secondary);">Enabled</span>
+            </label>
+        </div>
+        <p class="section-description">
+            Adds a summary of your exercises, sets, reps, weights, and calories to the Garmin activity description. Visible in Garmin Connect and connected apps like Strava.
+        </p>
+    </div>
+
     <!-- Advanced Section (FIT Timing) -->
     <div class="card section">
         <details class="advanced-section">
@@ -169,6 +206,26 @@
                 Advanced
             </summary>
             <div class="advanced-content">
+                <!-- Merge Mode Parameters -->
+                <p class="section-description" style="margin-top: 0; font-weight: 600; color: var(--text-secondary);">Watch Activity Matching</p>
+                <p class="section-description">How closely a Garmin watch activity must match a Hevy workout to be enhanced. Lower overlap = more lenient matching, higher = stricter.</p>
+                <div class="form-grid">
+                    <div class="form-group">
+                        <label class="form-label" for="merge_overlap_pct">Overlap Threshold (%)</label>
+                        <input class="form-input" type="number" id="merge_overlap_pct" name="merge_overlap_pct" value="{{ config.get('merge_overlap_pct', 70) }}" min="50" max="95" step="5">
+                        <div class="form-hint">Minimum temporal overlap between watch and Hevy workout (default 70%)</div>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label" for="merge_max_drift_min">Start Time Tolerance (minutes)</label>
+                        <input class="form-input" type="number" id="merge_max_drift_min" name="merge_max_drift_min" value="{{ config.get('merge_max_drift_min', 20) }}" min="5" max="60" step="5">
+                        <div class="form-hint">Max difference between Hevy and Garmin start times (default 20 min)</div>
+                    </div>
+                </div>
+
+                <hr style="border: none; border-top: 1px solid var(--border); margin: 20px 0;">
+
+                <!-- FIT Timing -->
+                <p class="section-description" style="font-weight: 600; color: var(--text-secondary);">FIT File Timing</p>
                 <p class="section-description">Controls how set durations are estimated in the FIT file when exact timing is not available from Hevy.</p>
                 <div class="form-grid">
                     <div class="form-group">

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -366,7 +366,7 @@ class TestSyncIntegration:
         mock_gclient.return_value = MagicMock()
         mock_db.is_synced.return_value = False
         call_count = [0]
-        def alt(c, w, d):
+        def alt(c, w, d, **kwargs):
             call_count[0] += 1
             return MergeResult(merged=True, activity_id=111) if call_count[0] == 1 else MergeResult(merged=False, fallback_reason="No match")
         mock_merge.side_effect = alt


### PR DESCRIPTION
Closes #115

## Summary

- **Enhance Watch Activities** toggle on settings page (merge_mode, default ON)
- **Activity Description** toggle (description_enabled, default ON)
- **Advanced section**: configurable match overlap threshold (50-95%) and start time tolerance (5-60 min)
- Backend persists merge settings to config.json (local) and DB (Vercel)
- sync.py passes configurable params to attempt_merge and respects description toggle

## Test plan

- [x] 148 passed, 7 skipped
- [x] Existing merge + sync integration tests pass with new params