### PR TITLE
fix: garminconnect 0.3.x compat, web sync merge mode, mask credentials

### DIFF
--- a/src/hevy2garmin/db.py
+++ b/src/hevy2garmin/db.py
@@ -84,7 +84,7 @@ def mark_synced(
     **kw,
 ) -> None:
     """Record a successfully synced workout."""
-    return get_db().mark_synced(hevy_id, garmin_activity_id, title, calories, avg_hr, hevy_updated_at)
+    return get_db().mark_synced(hevy_id, garmin_activity_id, title, calories, avg_hr, hevy_updated_at, **kw)
 
 
 def unsync(hevy_id: str, **kw) -> bool:

--- a/src/hevy2garmin/db.py
+++ b/src/hevy2garmin/db.py
@@ -84,6 +84,7 @@ def mark_synced(
     **kw,
 ) -> None:
     """Record a successfully synced workout."""
+    kw.pop("db_path", None)  # consumed by test dispatcher, not by backends
     return get_db().mark_synced(hevy_id, garmin_activity_id, title, calories, avg_hr, hevy_updated_at, **kw)
 
 

--- a/src/hevy2garmin/garmin.py
+++ b/src/hevy2garmin/garmin.py
@@ -159,7 +159,7 @@ def set_description(client: Garmin, activity_id: int, description: str) -> None:
     """Set description for a Garmin activity."""
     url = f"/activity-service/activity/{activity_id}"
     payload = {"activityId": activity_id, "description": description}
-    client.garth.connectapi(url, method="PUT", json=payload)
+    client.connectapi(url, method="PUT", json=payload)
     time.sleep(1.0)
     logger.info("  Description set (%d chars)", len(description))
 
@@ -167,7 +167,7 @@ def set_description(client: Garmin, activity_id: int, description: str) -> None:
 def upload_image(client: Garmin, activity_id: int, image_bytes: bytes, filename: str = "image.png") -> None:
     """Upload an image to a Garmin activity."""
     files = {"file": (filename, io.BytesIO(image_bytes))}
-    client.garth.connectapi(
+    client.connectapi(
         f"/activity-service/activity/{activity_id}/image",
         method="POST",
         files=files,
@@ -295,7 +295,7 @@ def push_exercise_sets(client: Garmin, activity_id: int, payload: dict) -> None:
     """
     url = f"/activity-service/activity/{activity_id}/exerciseSets"
     time.sleep(1.0)  # manual rate limit
-    client.garth.connectapi(url, method="PUT", json=payload)
+    client.connectapi(url, method="PUT", json=payload)
     logger.info("  Pushed %d exercise sets to activity %s", len(payload.get("exerciseSets", [])), activity_id)
 
 

--- a/src/hevy2garmin/garmin.py
+++ b/src/hevy2garmin/garmin.py
@@ -159,7 +159,7 @@ def set_description(client: Garmin, activity_id: int, description: str) -> None:
     """Set description for a Garmin activity."""
     url = f"/activity-service/activity/{activity_id}"
     payload = {"activityId": activity_id, "description": description}
-    client.connectapi(url, method="PUT", json=payload)
+    client.client.request("PUT", "connectapi", url, json=payload)
     time.sleep(1.0)
     logger.info("  Description set (%d chars)", len(description))
 
@@ -167,9 +167,9 @@ def set_description(client: Garmin, activity_id: int, description: str) -> None:
 def upload_image(client: Garmin, activity_id: int, image_bytes: bytes, filename: str = "image.png") -> None:
     """Upload an image to a Garmin activity."""
     files = {"file": (filename, io.BytesIO(image_bytes))}
-    client.connectapi(
+    client.client.request(
+        "POST", "connectapi",
         f"/activity-service/activity/{activity_id}/image",
-        method="POST",
         files=files,
     )
     time.sleep(1.0)
@@ -295,7 +295,7 @@ def push_exercise_sets(client: Garmin, activity_id: int, payload: dict) -> None:
     """
     url = f"/activity-service/activity/{activity_id}/exerciseSets"
     time.sleep(1.0)  # manual rate limit
-    client.connectapi(url, method="PUT", json=payload)
+    client.client.request("PUT", "connectapi", url, json=payload)
     logger.info("  Pushed %d exercise sets to activity %s", len(payload.get("exerciseSets", [])), activity_id)
 
 

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -1141,7 +1141,10 @@ async def api_toggle_autosync(request: Request):
     form = await request.form()
     enabled_raw = form.get("enabled", "false")
     enabled = enabled_raw in ("true", "True", "1", True)
-    interval = int(form.get("interval", 120))
+    try:
+        interval = int(form.get("interval", 120))
+    except (ValueError, TypeError):
+        interval = 120
     if interval not in (30, 60, 120, 240, 360, 720, 1440):
         interval = 120
 
@@ -1388,7 +1391,10 @@ async def api_setup_actions(request: Request):
     interval = 120
     try:
         form = await request.form()
-        interval = int(form.get("interval", 120))
+        raw_interval = form.get("interval", 120)
+        interval = int(raw_interval)
+    except (ValueError, TypeError):
+        interval = 120
     except Exception:
         pass
     ok, msg = await _setup_github_actions(interval_minutes=interval)

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -1479,8 +1479,34 @@ async def _do_sync_one(request: Request):
     # Sync this one workout
     try:
         from hevy2garmin.garmin import find_activity_by_start_time
+        from hevy2garmin.merge import attempt_merge
         garmin_client = get_client(config.get("garmin_email"))
         workout_start = unsynced.get("start_time")
+        merge_mode = config.get("merge_mode", True)
+        sync_method = "upload"
+
+        # Merge mode: try to enhance a watch-recorded activity with Hevy data
+        if merge_mode:
+            merge_result = attempt_merge(garmin_client, unsynced, db.get_db())
+            if merge_result.merged:
+                aid = merge_result.activity_id
+                result = {"calories": 0, "avg_hr": None}
+                # Generate FIT just for calorie estimate
+                with tempfile.TemporaryDirectory() as tmp:
+                    fit_path = f"{tmp}/{unsynced['id']}.fit"
+                    result = generate_fit(unsynced, hr_samples=None, output_path=fit_path)
+                sync_method = "merge"
+                db.mark_synced(
+                    hevy_id=unsynced["id"],
+                    garmin_activity_id=str(aid),
+                    title=unsynced["title"],
+                    calories=result.get("calories"),
+                    avg_hr=result.get("avg_hr"),
+                    hevy_updated_at=unsynced.get("updated_at"),
+                    sync_method=sync_method,
+                )
+                remaining = hevy.get_workout_count() - db.get_synced_count()
+                return JSONResponse({"synced": 1, "title": unsynced["title"], "remaining": max(0, remaining), "done": remaining <= 0})
 
         # Dedup: check if this workout already exists on Garmin before uploading.
         # Prevents duplicates when a prior sync uploaded successfully but crashed
@@ -1499,6 +1525,7 @@ async def _do_sync_one(request: Request):
             rename_activity(garmin_client, aid, unsynced["title"])
             desc = generate_description(unsynced, calories=result.get("calories"), avg_hr=result.get("avg_hr"))
             set_description(garmin_client, aid, desc)
+            sync_method = "upload_fallback"
         else:
             with tempfile.TemporaryDirectory() as tmp:
                 fit_path = f"{tmp}/{unsynced['id']}.fit"
@@ -1517,6 +1544,7 @@ async def _do_sync_one(request: Request):
             calories=result.get("calories"),
             avg_hr=result.get("avg_hr"),
             hevy_updated_at=unsynced.get("updated_at"),
+            sync_method=sync_method,
         )
 
         remaining = hevy.get_workout_count() - db.get_synced_count()

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -804,6 +804,8 @@ async def settings_save(
         config["hevy_api_key"] = hevy_api_key
     if garmin_email:
         config["garmin_email"] = garmin_email
+    if garmin_password:
+        config["garmin_password"] = garmin_password
     config["user_profile"].update(weight_kg=weight_kg, birth_year=birth_year, sex=sex, vo2max=vo2max)
     config["timing"].update(
         working_set_seconds=working_set_seconds, warmup_set_seconds=warmup_set_seconds,

--- a/src/hevy2garmin/templates/settings.html
+++ b/src/hevy2garmin/templates/settings.html
@@ -53,11 +53,8 @@
             <span class="card-title">Credentials</span>
         </div>
         <div class="form-group">
-            <label class="form-label">Hevy API Key</label>
-            <div style="display: flex; align-items: center; gap: 8px;">
-                <span style="font-size: 13px; color: var(--text-muted);">{{ '••••••••' + config.get('hevy_api_key', '')[-4:] if config.get('hevy_api_key') else 'Not configured' }}</span>
-                <a href="/setup" class="btn btn-secondary btn-sm" style="font-size: 12px;">Change in Setup</a>
-            </div>
+            <label class="form-label" for="hevy_api_key">Hevy API Key</label>
+            <input class="form-input" type="password" id="hevy_api_key" name="hevy_api_key" placeholder="Leave blank to keep current">
         </div>
         <div class="form-grid">
             <div class="form-group">

--- a/src/hevy2garmin/templates/settings.html
+++ b/src/hevy2garmin/templates/settings.html
@@ -59,7 +59,7 @@
         <div class="form-grid">
             <div class="form-group">
                 <label class="form-label" for="garmin_email">Garmin Email</label>
-                <input class="form-input" type="email" id="garmin_email" name="garmin_email" value="{{ config.get('garmin_email', '') }}">
+                <input class="form-input" type="password" id="garmin_email" name="garmin_email" placeholder="Leave blank to keep current">
             </div>
             <div class="form-group">
                 <label class="form-label" for="garmin_password">Garmin Password</label>

--- a/src/hevy2garmin/templates/settings.html
+++ b/src/hevy2garmin/templates/settings.html
@@ -53,10 +53,10 @@
             <span class="card-title">Credentials</span>
         </div>
         <div class="form-group">
-            <label class="form-label" for="hevy_api_key">Hevy API Key</label>
-            <input class="form-input" type="text" id="hevy_api_key" name="hevy_api_key" value="{{ config.get('hevy_api_key', '') }}" placeholder="Your Hevy API key">
-            <div class="form-hint">
-                <a href="https://hevy.com/settings" target="_blank" rel="noopener">hevy.com/settings</a> &rarr; Integrations &amp; API &rarr; Generate API Key
+            <label class="form-label">Hevy API Key</label>
+            <div style="display: flex; align-items: center; gap: 8px;">
+                <span style="font-size: 13px; color: var(--text-muted);">{{ '••••••••' + config.get('hevy_api_key', '')[-4:] if config.get('hevy_api_key') else 'Not configured' }}</span>
+                <a href="/setup" class="btn btn-secondary btn-sm" style="font-size: 12px;">Change in Setup</a>
             </div>
         </div>
         <div class="form-grid">

--- a/src/hevy2garmin/templates/setup.html
+++ b/src/hevy2garmin/templates/setup.html
@@ -51,7 +51,7 @@
             <div class="form-group">
                 <label class="form-label" for="hevy_api_key">API Key</label>
                 <div style="display: flex; gap: 8px;">
-                    <input class="form-input" type="text" id="hevy_api_key" name="hevy_api_key" placeholder="Paste your Hevy API key" value="{{ config.get('hevy_api_key', '') }}" required autocomplete="off" style="flex: 1;">
+                    <input class="form-input" type="password" id="hevy_api_key" name="hevy_api_key" placeholder="{{ '••••••••' ~ config.get('hevy_api_key', '')[-4:] if config.get('hevy_api_key') else 'Paste your Hevy API key' }}" {{ '' if config.get('hevy_api_key') else 'required' }} autocomplete="off" style="flex: 1;">
                     <button type="button" class="btn btn-secondary btn-sm" onclick="validateHevyKey()" style="white-space: nowrap;">Test Key</button>
                 </div>
                 <div id="hevy-validate-result" style="margin-top: 4px;"></div>

--- a/src/hevy2garmin/templates/setup.html
+++ b/src/hevy2garmin/templates/setup.html
@@ -70,7 +70,7 @@
             <div class="card-title" style="margin-bottom: 16px;">2. Garmin Connect</div>
             <div class="form-group">
                 <label class="form-label" for="garmin_email">Email</label>
-                <input class="form-input" type="email" id="garmin_email" name="garmin_email" placeholder="your@email.com" value="{{ config.get('garmin_email', '') }}" autocomplete="email">
+                <input class="form-input" type="password" id="garmin_email" name="garmin_email" placeholder="{{ '••••••••' ~ config.get('garmin_email', '')[-4:] if config.get('garmin_email') else 'your@email.com' }}" autocomplete="email">
             </div>
             <div class="form-group">
                 <label class="form-label" for="garmin_password">Password</label>


### PR DESCRIPTION
## Summary

- **Fix garminconnect 0.3.x API breaking changes**: `client.garth` was renamed to `client.client` in garminconnect 0.3.x. Updated `set_description`, `upload_image`, and `push_exercise_sets` to use `client.client.request()` for non-GET calls (since `connectapi()` hardcodes GET and causes a duplicate `method` argument error)
- **Add merge mode to web/cron sync path**: The `api_sync_one` endpoint was missing merge mode entirely — when an existing activity was found on Garmin, it only renamed and set description but never pushed exercise sets from Hevy. Now calls `attempt_merge()` first, matching the CLI sync behavior
- **Fix interval parsing crash**: The autosync toggle sent `"undefined"` as the interval value from JS, causing `int("undefined")` to crash. Added try/except fallback to default (120)
- **Mask credentials on public pages**: Hevy API key, Garmin email, and Garmin password are now all `type="password"` inputs on both setup and settings pages, preventing exposure in HTML source
- **Fix `db.mark_synced` wrapper**: Was silently dropping `sync_method` kwarg — now passes `**kw` through to the underlying DB implementation

## Test plan
- [ ] Verify sync works end-to-end (merge mode path: watch activity gets Hevy exercise sets)
- [ ] Verify sync works end-to-end (upload fallback path: no watch activity, FIT file uploaded)
- [ ] Verify autosync toggle works when interval is undefined
- [ ] Verify setup and settings pages don't expose credentials in HTML source
- [ ] Verify existing credentials are preserved when submitting blank fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)