### PR TITLE
fix: exercise mapping not persisting after reload (#124)

### DIFF
--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -862,9 +862,10 @@ async def api_save_mapping(request: Request):
         _db = db.get_db()
         if hasattr(_db, 'save_custom_mapping'):
             _db.save_custom_mapping(hevy_name, category, subcategory)
-    else:
-        from hevy2garmin.mapper import save_custom_mapping
-        save_custom_mapping(hevy_name, category, subcategory)
+    # Always update in-memory cache (+ filesystem fallback).
+    # Without this, _custom_mappings stays stale until process restart.
+    from hevy2garmin.mapper import save_custom_mapping
+    save_custom_mapping(hevy_name, category, subcategory)
 
     global _unmapped_cache
     _unmapped_cache = None


### PR DESCRIPTION
## Summary

Custom exercise mappings saved via the dashboard's /api/mapping endpoint appeared to succeed but disappeared on page reload.

**Root cause:** The POST handler saved to the database (cloud path) but skipped calling `mapper.save_custom_mapping()`, which is the only function that updates the in-memory `_custom_mappings` dict. On reload, `_ensure_custom_loaded()` saw `_custom_loaded = True` and returned stale cached data instead of re-reading from DB.

**Fix:** Call `save_custom_mapping()` unconditionally after the DB write (1 line moved from `else` to always-run). This updates the in-memory cache immediately. The filesystem write it also does is harmless on cloud (ephemeral) and useful locally.

The delete handler (`/api/mapping/delete`) already had the correct pattern — it calls `_custom_mappings.pop()` directly at line 901.

## Test plan

- [ ] Map an exercise on the dashboard, click Reload, confirm it stays mapped
- [ ] Delete a mapping, reload, confirm it's gone
- [ ] 148/148 existing tests pass

Closes #124