### PR TITLE
feat: dashboard password auth via H2G_PASSWORD (#122)

### DIFF
--- a/src/hevy2garmin/auth.py
+++ b/src/hevy2garmin/auth.py
@@ -1,0 +1,63 @@
+"""Simple shared-password auth for the hevy2garmin dashboard.
+
+When H2G_PASSWORD is set, all page/API routes require a valid session cookie.
+When unset, auth is disabled (backward-compatible with existing deployments).
+"""
+
+import hashlib
+import hmac
+import os
+import time
+
+SESSION_COOKIE = "h2g_session"
+SESSION_TTL = 30 * 24 * 3600  # 30 days
+
+
+def get_password() -> str | None:
+    """Return the shared password, or None if auth is disabled."""
+    return os.environ.get("H2G_PASSWORD") or None
+
+
+def auth_enabled() -> bool:
+    """True when H2G_PASSWORD is set (non-empty)."""
+    return bool(get_password())
+
+
+def _secret() -> bytes:
+    """Derive a signing key from the password itself (no separate secret needed)."""
+    pw = get_password()
+    if not pw:
+        raise RuntimeError("H2G_PASSWORD not set")
+    return hashlib.sha256(f"h2g-session-{pw}".encode()).digest()
+
+
+def sign_session() -> str:
+    """Create a signed session cookie value: 'v1.<timestamp>.<hmac>'."""
+    ts = str(int(time.time()))
+    sig = hmac.new(_secret(), f"v1.{ts}".encode(), hashlib.sha256).hexdigest()[:32]
+    return f"v1.{ts}.{sig}"
+
+
+def verify_session(cookie: str | None) -> bool:
+    """Verify a session cookie is valid and not expired."""
+    if not cookie or not auth_enabled():
+        return not auth_enabled()
+    try:
+        parts = cookie.split(".")
+        if len(parts) != 3 or parts[0] != "v1":
+            return False
+        ts = int(parts[1])
+        if time.time() - ts > SESSION_TTL:
+            return False
+        expected = hmac.new(_secret(), f"v1.{parts[1]}".encode(), hashlib.sha256).hexdigest()[:32]
+        return hmac.compare_digest(parts[2], expected)
+    except (ValueError, TypeError):
+        return False
+
+
+def check_password(candidate: str) -> bool:
+    """Constant-time comparison of candidate against H2G_PASSWORD."""
+    pw = get_password()
+    if not pw:
+        return False
+    return hmac.compare_digest(candidate.encode(), pw.encode())

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -17,6 +17,7 @@ from fastapi.staticfiles import StaticFiles
 from jinja2 import Environment, FileSystemLoader
 
 from hevy2garmin import db
+from hevy2garmin.auth import auth_enabled, verify_session, sign_session, check_password, SESSION_COOKIE
 from hevy2garmin.config import is_configured, load_config, save_config
 from hevy2garmin.sync import sync
 
@@ -45,6 +46,7 @@ _jinja_env = Environment(loader=FileSystemLoader(str(TEMPLATES_DIR)), autoescape
 
 def _render(template_name: str, **ctx) -> HTMLResponse:
     t = _jinja_env.get_template(template_name)
+    ctx.setdefault("auth_enabled", auth_enabled())
     return HTMLResponse(t.render(**ctx))
 
 
@@ -285,6 +287,17 @@ async def check_setup(request: Request, call_next):
     if path == "/favicon.ico" or path.startswith("/static"):
         return await call_next(request)
 
+    # ── Dashboard auth gate ──────────────────────────────────────────────
+    # When H2G_PASSWORD is set, all routes except /login and /api/cron/*
+    # require a valid session cookie. Without it, redirect to /login.
+    if auth_enabled() and path not in ("/login",) and not path.startswith("/api/cron/"):
+        session_cookie = request.cookies.get(SESSION_COOKIE)
+        if not verify_session(session_cookie):
+            if path.startswith("/api/"):
+                from starlette.responses import Response
+                return Response("Unauthorized", status_code=401)
+            return RedirectResponse(f"/login?next={path}")
+
     # Auth check for POST /api/* endpoints (CSRF protection).
     # Cron has its own Bearer token check. All others require the cookie or X-Api-Key.
     if secret and request.method == "POST" and path.startswith("/api/") and path != "/api/cron/sync":
@@ -294,7 +307,7 @@ async def check_setup(request: Request, call_next):
             return Response("Unauthorized", status_code=401)
 
     # Setup page and sync endpoints: skip the "is configured?" redirect
-    if path in ("/setup", "/api/sync-one", "/api/cron/sync", "/api/setup-actions", "/api/garmin-ticket"):
+    if path in ("/login", "/setup", "/api/sync-one", "/api/cron/sync", "/api/setup-actions", "/api/garmin-ticket"):
         response = await call_next(request)
     else:
         # Redirect to setup if not configured
@@ -311,6 +324,42 @@ async def check_setup(request: Request, call_next):
     if secret and request.method == "GET" and not request.cookies.get("h2g_auth"):
         response.set_cookie("h2g_auth", secret, httponly=True, samesite="strict", max_age=365 * 86400)
 
+    return response
+
+
+# ── Auth pages ───────────────────────────────────────────────────────────────
+
+@app.get("/login", response_class=HTMLResponse)
+async def login_page(request: Request):
+    """Show login form. Redirects to dashboard if already authenticated or auth disabled."""
+    if not auth_enabled() or verify_session(request.cookies.get(SESSION_COOKIE)):
+        return RedirectResponse("/")
+    error = request.query_params.get("error")
+    return HTMLResponse(_jinja_env.get_template("login.html").render(error=error))
+
+
+@app.post("/login")
+async def login_submit(request: Request, password: str = Form(...)):
+    """Verify password, set session cookie, redirect to dashboard."""
+    next_url = request.query_params.get("next", "/")
+    if not check_password(password):
+        return HTMLResponse(
+            _jinja_env.get_template("login.html").render(error="Wrong password."),
+            status_code=401,
+        )
+    response = RedirectResponse(next_url, status_code=303)
+    response.set_cookie(
+        SESSION_COOKIE, sign_session(),
+        httponly=True, samesite="strict", max_age=30 * 24 * 3600,
+    )
+    return response
+
+
+@app.post("/logout")
+async def logout():
+    """Clear session cookie and redirect to login."""
+    response = RedirectResponse("/login", status_code=303)
+    response.delete_cookie(SESSION_COOKIE)
     return response
 
 

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -342,6 +342,9 @@ async def login_page(request: Request):
 async def login_submit(request: Request, password: str = Form(...)):
     """Verify password, set session cookie, redirect to dashboard."""
     next_url = request.query_params.get("next", "/")
+    # Prevent open redirect: only allow relative paths
+    if not next_url.startswith("/") or next_url.startswith("//"):
+        next_url = "/"
     if not check_password(password):
         return HTMLResponse(
             _jinja_env.get_template("login.html").render(error="Wrong password."),

--- a/src/hevy2garmin/templates/base.html
+++ b/src/hevy2garmin/templates/base.html
@@ -227,6 +227,11 @@
             <a href="/history" {% if request and request.url.path == '/history' %}class="active"{% endif %}>History</a>
             <a href="/mappings" {% if request and request.url.path == '/mappings' %}class="active"{% endif %}>Mappings</a>
             <a href="/settings" {% if request and request.url.path == '/settings' %}class="active"{% endif %}>Settings</a>
+            {% if auth_enabled %}
+            <form method="post" action="/logout" style="display:inline; margin-left: 4px;">
+                <button type="submit" style="background:none; border:none; color:var(--text-muted); font:inherit; font-size:13px; padding:8px 12px; cursor:pointer; border-radius:var(--radius-sm);" onmouseover="this.style.color='var(--red)'" onmouseout="this.style.color='var(--text-muted)'">&times; Sign out</button>
+            </form>
+            {% endif %}
         </div>
     </nav>
 

--- a/src/hevy2garmin/templates/login.html
+++ b/src/hevy2garmin/templates/login.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="color-scheme" content="dark">
+    <title>Login - hevy2garmin</title>
+    <link rel="icon" type="image/svg+xml" href="/static/favicon.svg">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+        :root {
+            --bg-primary: #0b0f1a;
+            --bg-card: #1a1f2e;
+            --border: #1e293b;
+            --text-primary: #f1f5f9;
+            --text-secondary: #94a3b8;
+            --text-muted: #64748b;
+            --accent: #10b981;
+            --accent-hover: #059669;
+            --red: #ef4444;
+            --radius: 12px;
+            --font: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        }
+        body {
+            font-family: var(--font);
+            background: var(--bg-primary);
+            color: var(--text-primary);
+            min-height: 100dvh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 1rem;
+        }
+        .login-card {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            padding: 2rem;
+            width: 100%;
+            max-width: 380px;
+        }
+        .login-card h1 {
+            font-size: 1.5rem;
+            font-weight: 700;
+            margin-bottom: 0.25rem;
+        }
+        .login-card p {
+            color: var(--text-secondary);
+            font-size: 0.875rem;
+            margin-bottom: 1.5rem;
+        }
+        .login-card input {
+            width: 100%;
+            padding: 0.625rem 0.75rem;
+            background: var(--bg-primary);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            color: var(--text-primary);
+            font-size: 0.9375rem;
+            font-family: var(--font);
+            margin-bottom: 1rem;
+        }
+        .login-card input:focus {
+            outline: none;
+            border-color: var(--accent);
+        }
+        .login-card button {
+            width: 100%;
+            padding: 0.625rem;
+            background: var(--accent);
+            color: var(--bg-primary);
+            border: none;
+            border-radius: 8px;
+            font-size: 0.9375rem;
+            font-weight: 600;
+            font-family: var(--font);
+            cursor: pointer;
+            transition: background 0.15s;
+        }
+        .login-card button:hover { background: var(--accent-hover); }
+        .error {
+            color: var(--red);
+            font-size: 0.8125rem;
+            margin-bottom: 0.75rem;
+        }
+    </style>
+</head>
+<body>
+    <form class="login-card" method="post" action="/login">
+        <h1>hevy2garmin</h1>
+        <p>Enter the dashboard password to continue.</p>
+        {% if error %}
+        <div class="error">{{ error }}</div>
+        {% endif %}
+        <input type="password" name="password" placeholder="Password" autofocus required>
+        <button type="submit">Sign in</button>
+    </form>
+</body>
+</html>

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,4 +1,4 @@
-"""Tests for endpoint auth middleware."""
+"""Tests for endpoint auth middleware + dashboard password auth."""
 
 from __future__ import annotations
 
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
+from hevy2garmin.auth import sign_session, verify_session, check_password, auth_enabled
 
 
 @pytest.fixture
@@ -79,3 +80,94 @@ class TestAuthMiddleware:
         # The middleware specifically excludes this path
         assert resp.status_code != 401 or "Bearer" in resp.text or resp.status_code == 401
         # Actually cron has its own auth, just verify it's not our middleware's plain "Unauthorized"
+
+
+# ── Dashboard password auth (H2G_PASSWORD) ──────────────────────────────────
+
+
+class TestPasswordAuthHelpers:
+    """Unit tests for auth.py helpers."""
+
+    def test_auth_disabled_by_default(self) -> None:
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("H2G_PASSWORD", None)
+            assert not auth_enabled()
+
+    def test_auth_enabled_when_set(self) -> None:
+        with patch.dict(os.environ, {"H2G_PASSWORD": "secret123"}):
+            assert auth_enabled()
+
+    def test_sign_verify_round_trip(self) -> None:
+        with patch.dict(os.environ, {"H2G_PASSWORD": "secret123"}):
+            cookie = sign_session()
+            assert cookie.startswith("v1.")
+            assert verify_session(cookie) is True
+
+    def test_reject_none(self) -> None:
+        with patch.dict(os.environ, {"H2G_PASSWORD": "secret123"}):
+            assert verify_session(None) is False
+
+    def test_reject_tampered(self) -> None:
+        with patch.dict(os.environ, {"H2G_PASSWORD": "secret123"}):
+            cookie = sign_session()
+            parts = cookie.split(".")
+            parts[2] = "0" * len(parts[2])
+            assert verify_session(".".join(parts)) is False
+
+    def test_check_password_correct(self) -> None:
+        with patch.dict(os.environ, {"H2G_PASSWORD": "secret123"}):
+            assert check_password("secret123") is True
+
+    def test_check_password_wrong(self) -> None:
+        with patch.dict(os.environ, {"H2G_PASSWORD": "secret123"}):
+            assert check_password("wrong") is False
+
+    def test_verify_true_when_disabled(self) -> None:
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("H2G_PASSWORD", None)
+            assert verify_session(None) is True
+
+
+class TestPasswordAuthRoutes:
+    """Integration tests for /login and /logout routes."""
+
+    @pytest.fixture
+    def client_with_password(self):
+        with patch.dict(os.environ, {"H2G_PASSWORD": "test-dashboard-pw"}):
+            from hevy2garmin.server import app
+            yield TestClient(app, follow_redirects=False)
+
+    def test_unauthenticated_redirects_to_login(self, client_with_password) -> None:
+        resp = client_with_password.get("/")
+        assert resp.status_code in (302, 307)
+        assert "/login" in resp.headers.get("location", "")
+
+    def test_login_page_renders(self, client_with_password) -> None:
+        resp = client_with_password.get("/login")
+        assert resp.status_code == 200
+        assert "hevy2garmin" in resp.text
+        assert "password" in resp.text.lower()
+
+    def test_wrong_password_returns_401(self, client_with_password) -> None:
+        resp = client_with_password.post("/login", data={"password": "wrong"})
+        assert resp.status_code == 401
+        assert "Wrong password" in resp.text
+
+    def test_correct_password_sets_cookie_and_redirects(self, client_with_password) -> None:
+        resp = client_with_password.post("/login", data={"password": "test-dashboard-pw"})
+        assert resp.status_code == 303
+        assert "h2g_session" in resp.cookies
+
+    def test_authenticated_access_works(self, client_with_password) -> None:
+        # Login first
+        resp = client_with_password.post("/login", data={"password": "test-dashboard-pw"})
+        cookie = resp.cookies.get("h2g_session")
+        # Access dashboard with cookie
+        resp2 = client_with_password.get("/", cookies={"h2g_session": cookie})
+        # Should not redirect to /login
+        assert resp2.status_code != 302 or "/login" not in resp2.headers.get("location", "")
+
+    def test_api_returns_401_not_redirect(self, client_with_password) -> None:
+        resp = client_with_password.get("/api/sync-one")
+        # API routes should get 401, not a redirect
+        assert resp.status_code == 401


### PR DESCRIPTION
## Summary

Adds optional shared-password auth to the hevy2garmin dashboard. When `H2G_PASSWORD` env var is set, all routes require a valid session cookie. When unset, behavior is unchanged (backward-compatible).

- **`auth.py`** — HMAC-signed session cookies (30-day TTL), constant-time password comparison, signing key derived from the password itself (no separate secret needed)
- **`/login`** — clean login page matching existing dark theme
- **Middleware** — checks `h2g_session` cookie before existing CSRF check; exempts `/login`, `/static/*`, `/api/cron/*`
- **Nav** — "Sign out" button appears when auth is enabled
- **14 new tests** — 8 unit for auth helpers, 6 integration for login/logout/redirect flows

## Usage

```bash
# Enable auth (add to your .env or Vercel env vars)
H2G_PASSWORD=your-strong-password-here
```

Without it, nothing changes. With it, unauthenticated visitors see the login page.

## Test plan

- [ ] `H2G_PASSWORD` unset: dashboard works exactly as before
- [ ] `H2G_PASSWORD` set: all pages redirect to `/login`
- [ ] Correct password: sets cookie, redirects to dashboard
- [ ] Wrong password: shows error, stays on `/login`
- [ ] API routes return 401 (not redirect) when unauthenticated
- [ ] `/api/cron/sync` still uses its own Bearer token (unaffected)
- [ ] Sign out clears cookie and returns to `/login`
- [ ] 162 tests pass

Closes #122