### PR TITLE
fix: merge mode toggle doesn't persist from dashboard (#130)

### DIFF
--- a/src/hevy2garmin/config.py
+++ b/src/hevy2garmin/config.py
@@ -80,10 +80,14 @@ def load_config() -> dict[str, Any]:
                                 if creds.get("password"):
                                     config["garmin_password"] = creds["password"]
                         # App settings
-                        cur.execute("SELECT key, value FROM app_cache WHERE key IN ('user_profile', 'timing', 'hr_fusion')")
+                        cur.execute("SELECT key, value FROM app_cache WHERE key IN ('user_profile', 'timing', 'hr_fusion', 'merge_settings')")
                         for row in cur.fetchall():
                             val = row["value"] if isinstance(row["value"], dict) else json.loads(row["value"])
-                            if row["key"] in config and isinstance(config[row["key"]], dict):
+                            if row["key"] == "merge_settings":
+                                # Unpack merge_settings into top-level keys
+                                for mk, mv in val.items():
+                                    config[mk] = mv
+                            elif row["key"] in config and isinstance(config[row["key"]], dict):
                                 config[row["key"]].update(val)
                             else:
                                 config[row["key"]] = val

--- a/tests/test_merge_mode_persist.py
+++ b/tests/test_merge_mode_persist.py
@@ -1,0 +1,140 @@
+"""Tests for merge_mode toggle persistence through settings form and config loader."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from hevy2garmin.config import load_config, save_config
+
+
+class TestMergeModeFilePersistence:
+    """Verify merge_mode round-trips through config file (local deployments)."""
+
+    def test_merge_mode_false_persists(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "config.json"
+        with patch("hevy2garmin.config.CONFIG_DIR", tmp_path), \
+             patch("hevy2garmin.config.CONFIG_FILE", config_file):
+            config = load_config()
+            config["merge_mode"] = False
+            save_config(config)
+
+            reloaded = load_config()
+            assert reloaded["merge_mode"] is False
+
+    def test_merge_mode_true_persists(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "config.json"
+        with patch("hevy2garmin.config.CONFIG_DIR", tmp_path), \
+             patch("hevy2garmin.config.CONFIG_FILE", config_file):
+            config = load_config()
+            config["merge_mode"] = True
+            save_config(config)
+
+            reloaded = load_config()
+            assert reloaded["merge_mode"] is True
+
+    def test_merge_mode_default_true_when_absent(self, tmp_path: Path) -> None:
+        """Without merge_mode saved, config.get('merge_mode', True) returns True."""
+        with patch("hevy2garmin.config.CONFIG_FILE", tmp_path / "missing.json"):
+            config = load_config()
+            assert config.get("merge_mode", True) is True
+
+
+class TestMergeModeDbPersistence:
+    """Verify merge_mode is loaded from DB merge_settings (cloud deployments)."""
+
+    def _make_db_loader(self, app_cache_rows: list[dict]):
+        """Return a patched load_config that simulates DB app_cache rows.
+
+        Each row dict: {"key": "...", "value": {...}}
+        The mock replaces the Postgres cursor that load_config queries.
+        """
+        import types
+
+        class FakeCursor:
+            def __init__(self, rows):
+                self._rows = rows
+                self._result = []
+
+            def execute(self, sql, params=None):
+                if "app_cache" in sql and "key IN" in sql:
+                    self._result = self._rows
+                else:
+                    self._result = []
+
+            def fetchall(self):
+                return self._result
+
+            def fetchone(self):
+                return self._result[0] if self._result else None
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        class FakeConn:
+            def __init__(self, rows):
+                self._rows = rows
+
+            def cursor(self):
+                return FakeCursor(self._rows)
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        class FakeDb:
+            def __init__(self, rows):
+                self._rows = rows
+
+            def _get_conn(self):
+                return FakeConn(self._rows)
+
+        return FakeDb(app_cache_rows)
+
+    def _patch_db(self, tmp_path, fake_db):
+        """Context manager stack to patch config file + DB layer for load_config."""
+        from contextlib import ExitStack
+        stack = ExitStack()
+        stack.enter_context(patch("hevy2garmin.config.CONFIG_FILE", tmp_path / "missing.json"))
+        stack.enter_context(patch("hevy2garmin.db.get_database_url", return_value="postgres://fake"))
+        stack.enter_context(patch("hevy2garmin.db.get_db", return_value=fake_db))
+        return stack
+
+    def test_merge_mode_false_loaded_from_db(self, tmp_path: Path) -> None:
+        fake_db = self._make_db_loader([
+            {"key": "merge_settings", "value": {"merge_mode": False, "description_enabled": True,
+                                                  "merge_overlap_pct": 70, "merge_max_drift_min": 20}},
+        ])
+
+        with self._patch_db(tmp_path, fake_db):
+            config = load_config()
+            assert config.get("merge_mode", True) is False
+
+    def test_merge_mode_true_loaded_from_db(self, tmp_path: Path) -> None:
+        fake_db = self._make_db_loader([
+            {"key": "merge_settings", "value": {"merge_mode": True, "description_enabled": True,
+                                                  "merge_overlap_pct": 70, "merge_max_drift_min": 20}},
+        ])
+
+        with self._patch_db(tmp_path, fake_db):
+            config = load_config()
+            assert config.get("merge_mode", True) is True
+
+    def test_all_merge_settings_unpacked(self, tmp_path: Path) -> None:
+        fake_db = self._make_db_loader([
+            {"key": "merge_settings", "value": {"merge_mode": False, "description_enabled": False,
+                                                  "merge_overlap_pct": 85, "merge_max_drift_min": 30}},
+        ])
+
+        with self._patch_db(tmp_path, fake_db):
+            config = load_config()
+            assert config["merge_mode"] is False
+            assert config["description_enabled"] is False
+            assert config["merge_overlap_pct"] == 85
+            assert config["merge_max_drift_min"] == 30

--- a/tests/test_merge_mode_persist.py
+++ b/tests/test_merge_mode_persist.py
@@ -50,8 +50,6 @@ class TestMergeModeDbPersistence:
         Each row dict: {"key": "...", "value": {...}}
         The mock replaces the Postgres cursor that load_config queries.
         """
-        import types
-
         class FakeCursor:
             def __init__(self, rows):
                 self._rows = rows


### PR DESCRIPTION
## Summary

**Root cause:** \`load_config()\` in \`config.py\` queried \`app_cache\` for \`user_profile\`, \`timing\`, \`hr_fusion\` but NOT \`merge_settings\`. When the sync job called \`config.get("merge_mode", True)\`, the key was never present so the default \`True\` always kicked in, regardless of what the user saved.

**Fix:** Added \`'merge_settings'\` to the SQL query in \`load_config()\` and unpack its values (\`merge_mode\`, \`description_enabled\`, \`merge_overlap_pct\`, \`merge_max_drift_min\`) into top-level config keys.

**Edge cases verified:**
- Pre-existing users with no \`merge_settings\` DB row: defaults to \`True\` (backward-compatible)
- HTML hidden-input trick ensures unchecked checkbox sends \`"off"\` (no missing-field issue)
- CLI/local config.json path was never broken (only the DB/cloud path)
- All 4 consumers of \`merge_mode\` (sync.py, server.py cron, server.py web, settings template) now read the correct value

## Test plan

- [ ] 173 tests pass (6 new tests for file + DB persistence round-trips)
- [ ] On Vercel: uncheck "Enhance Watch Activities", save, reload — stays unchecked
- [ ] Cron sync job respects the setting (logs "Merge mode: off")
- [ ] New deploy with no prior merge_settings: defaults to enabled (backward-compatible)

Closes #130