### PR TITLE
feat(ui): show version + changelog link in dashboard footer (#144)

### DIFF
--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -16,7 +16,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from jinja2 import Environment, FileSystemLoader
 
-from hevy2garmin import db
+from hevy2garmin import db, __version__
 from hevy2garmin.auth import auth_enabled, verify_session, sign_session, check_password, SESSION_COOKIE
 from hevy2garmin.config import is_configured, load_config, save_config
 from hevy2garmin.demo import is_demo_mode
@@ -49,6 +49,7 @@ def _render(template_name: str, **ctx) -> HTMLResponse:
     t = _jinja_env.get_template(template_name)
     ctx.setdefault("auth_enabled", auth_enabled())
     ctx.setdefault("demo_mode", is_demo_mode())
+    ctx.setdefault("version", __version__)
     return HTMLResponse(t.render(**ctx))
 
 

--- a/src/hevy2garmin/templates/base.html
+++ b/src/hevy2garmin/templates/base.html
@@ -248,6 +248,7 @@
     <footer class="footer">
         <img src="/static/favicon.svg" width="18" height="18" alt="" style="border-radius: 4px; vertical-align: -3px; margin-right: 4px;">
         <a href="https://github.com/drkostas/hevy2garmin">hevy2garmin</a> &middot; Sync Hevy workouts to Garmin Connect
+        {% if version %}&middot; <a href="https://github.com/drkostas/hevy2garmin/blob/main/CHANGELOG.md" title="View changelog">v{{ version }}</a>{% endif %}
     </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Surfaces the package version in the dashboard footer with a link to the changelog, so users can confirm exactly which build they're running after an upgrade.

Multiple users on the [r/Hevy thread](https://reddit.com/r/Hevy/comments/1sfu9id) (u/lozbrown, u/bojanmkd, u/Joucifer) couldn't tell whether their update actually landed. This closes that gap.

## Changes

- `server.py`: import `__version__` and inject it once via `_render()` context (`ctx.setdefault("version", __version__)`) so it's available on every page.
- `base.html`: footer now shows `· vX.Y.Z` linked to `CHANGELOG.md`.

The version comes from `importlib.metadata`, so it's accurate on every pip / Vercel / Docker install (no hardcoding).

## Test plan

- [x] `pytest` — 173 passed, 7 skipped
- [x] Server imports cleanly with `__version__` available
- [x] Playwright: footer renders `hevy2garmin · Sync Hevy workouts to Garmin Connect · v0.4.0`, version links to CHANGELOG.md (verified in DOM + screenshot)

Closes #144
