### PR TITLE
fix(db): persist mappings + profile to Postgres on serverless (#145, #142)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- Version + changelog link in the dashboard footer ([#144](https://github.com/drkostas/hevy2garmin/issues/144)) — confirm which build you're running after an upgrade.
+
+### Fixed
+- **Serverless persistence** ([#145](https://github.com/drkostas/hevy2garmin/issues/145)) — custom exercise mappings and profile/settings now persist to Postgres on cloud deployments instead of the read-only `~/.hevy2garmin` filesystem. Fixes the 500 when saving a mapping on Vercel ([#142](https://github.com/drkostas/hevy2garmin/issues/142)), profile reverting to defaults / Pull-from-Garmin not sticking ([#139](https://github.com/drkostas/hevy2garmin/issues/139)), and the blank-dashboard crash on deploy without a database — now an actionable "set DATABASE_URL" error.
+
 ## [0.4.0]
 
 ### Added

--- a/src/hevy2garmin/config.py
+++ b/src/hevy2garmin/config.py
@@ -107,12 +107,37 @@ def load_config() -> dict[str, Any]:
 
 
 def save_config(config: dict[str, Any]) -> None:
-    """Save config to file. Silently skips on read-only filesystems (Vercel)."""
+    """Persist config: to file (local/Docker) and to the DB on cloud deployments.
+
+    On serverless (Vercel) the home filesystem is read-only, so the file write
+    is a no-op and the canonical store is the Postgres ``app_cache`` table. We
+    write the same keys ``load_config()`` reads back, so settings survive across
+    stateless invocations instead of reverting to defaults (#139, #145).
+    """
     try:
         CONFIG_DIR.mkdir(parents=True, exist_ok=True)
         CONFIG_FILE.write_text(json.dumps(config, indent=2))
     except OSError:
         logger.debug("Skipping config file write (read-only filesystem)")
+
+    # Cloud deployments: persist user-editable settings to the DB so callers
+    # that only call save_config() (e.g. Pull-from-Garmin) don't silently lose
+    # data on read-only filesystems. Symmetric with the keys load_config() reads.
+    from hevy2garmin.db import get_database_url
+
+    if not get_database_url():
+        return
+    try:
+        from hevy2garmin.db import get_db
+
+        _db = get_db()
+        if hasattr(_db, "set_app_config"):
+            for key in ("user_profile", "timing", "hr_fusion"):
+                value = config.get(key)
+                if isinstance(value, dict):
+                    _db.set_app_config(key, value)
+    except Exception:
+        logger.debug("Could not persist config to DB", exc_info=True)
 
 
 def get(key: str, default: Any = None) -> Any:

--- a/src/hevy2garmin/db_sqlite.py
+++ b/src/hevy2garmin/db_sqlite.py
@@ -29,7 +29,18 @@ class SQLiteDatabase(Database):
         self.db_path = Path(db_path)
 
     def _get_conn(self) -> sqlite3.Connection:
-        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            # Serverless (Vercel/Lambda) home is read-only — the cryptic
+            # FileNotFoundError/OSError here is what users saw as a blank
+            # dashboard / 500 on deploy (#145). Surface an actionable message.
+            raise RuntimeError(
+                "Cannot create a local SQLite database under ~/.hevy2garmin on "
+                "this read-only filesystem. Serverless deployments need Postgres: "
+                "add a Neon database (Vercel → Storage) so DATABASE_URL / "
+                "POSTGRES_URL is set, then redeploy."
+            ) from e
         conn = sqlite3.connect(str(self.db_path))
         conn.execute("""
             CREATE TABLE IF NOT EXISTS synced_workouts (

--- a/src/hevy2garmin/mapper.py
+++ b/src/hevy2garmin/mapper.py
@@ -666,7 +666,27 @@ def _ensure_custom_loaded() -> None:
 
 
 def save_custom_mapping(hevy_name: str, category: int, subcategory: int) -> None:
-    """Save a custom exercise mapping to disk."""
+    """Persist a custom exercise mapping.
+
+    On cloud deployments (DATABASE_URL set) writes to the DB — the home
+    filesystem is read-only on serverless, so the previous file-only write
+    raised a 500 and the mapping never persisted (#142, #145). Mirrors the
+    DB-first load path in ``_ensure_custom_loaded``. Falls back to the
+    filesystem for local/Docker installs.
+    """
+    # Cloud: persist to the DB
+    try:
+        from hevy2garmin.db import get_database_url, get_db
+        if get_database_url():
+            _db = get_db()
+            if hasattr(_db, "save_custom_mapping"):
+                _db.save_custom_mapping(hevy_name, category, subcategory)
+                _custom_mappings[hevy_name] = (category, subcategory)
+                return
+    except Exception:
+        pass
+
+    # Local/Docker: filesystem
     import json
     from pathlib import Path
     path = Path("~/.hevy2garmin/custom_mappings.json").expanduser()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from hevy2garmin.config import (
     DEFAULT_CONFIG,
@@ -12,6 +14,21 @@ from hevy2garmin.config import (
     load_config,
     save_config,
 )
+
+
+@pytest.fixture(autouse=True)
+def _local_mode(monkeypatch):
+    """File-based config tests run in local mode (no DB autodetect).
+
+    The Postgres CI job sets DATABASE_URL globally; without this, save_config
+    would write to the shared test DB and pollute later load_config() reads.
+    Cloud-specific tests opt back in by patching get_database_url/get_db.
+    """
+    for var in ("DATABASE_URL", "POSTGRES_URL", "STORAGE_URL", "NEON_DATABASE_URL"):
+        monkeypatch.delenv(var, raising=False)
+    import hevy2garmin.db as _db
+
+    _db.reset()
 
 
 class TestLoadConfig:
@@ -78,3 +95,48 @@ class TestIsConfigured:
 
         with patch("hevy2garmin.config.CONFIG_FILE", config_file):
             assert is_configured() is False
+
+
+class TestSaveConfigCloud:
+    """save_config must persist settings to the DB on cloud deployments (#139, #145).
+
+    The home filesystem is read-only on serverless, so a file-only write
+    silently lost profile/timing/hr_fusion changes (e.g. Pull-from-Garmin),
+    which then reverted to defaults on the next stateless invocation.
+    """
+
+    def test_persists_app_keys_to_db_on_cloud(self, tmp_path: Path) -> None:
+        fake_db = MagicMock()
+        cfg = {
+            "user_profile": {"weight_kg": 82.0, "birth_year": 1994, "sex": "male"},
+            "timing": {"working_set_seconds": 45},
+            "hr_fusion": {"enabled": True},
+        }
+        with patch("hevy2garmin.config.CONFIG_DIR", tmp_path), \
+             patch("hevy2garmin.config.CONFIG_FILE", tmp_path / "config.json"), \
+             patch("hevy2garmin.db.get_database_url", return_value="postgresql://x"), \
+             patch("hevy2garmin.db.get_db", return_value=fake_db):
+            save_config(cfg)
+
+        written = {c.args[0]: c.args[1] for c in fake_db.set_app_config.call_args_list}
+        assert set(written) == {"user_profile", "timing", "hr_fusion"}
+        assert written["user_profile"]["weight_kg"] == 82.0
+
+    def test_no_db_write_when_local(self, tmp_path: Path) -> None:
+        fake_db = MagicMock()
+        with patch("hevy2garmin.config.CONFIG_DIR", tmp_path), \
+             patch("hevy2garmin.config.CONFIG_FILE", tmp_path / "config.json"), \
+             patch("hevy2garmin.db.get_database_url", return_value=None), \
+             patch("hevy2garmin.db.get_db", return_value=fake_db):
+            save_config({"user_profile": {"weight_kg": 80.0}})
+        fake_db.set_app_config.assert_not_called()
+
+    def test_db_failure_does_not_raise(self, tmp_path: Path) -> None:
+        fake_db = MagicMock()
+        fake_db.set_app_config.side_effect = RuntimeError("db down")
+        with patch("hevy2garmin.config.CONFIG_DIR", tmp_path), \
+             patch("hevy2garmin.config.CONFIG_FILE", tmp_path / "config.json"), \
+             patch("hevy2garmin.db.get_database_url", return_value="postgresql://x"), \
+             patch("hevy2garmin.db.get_db", return_value=fake_db):
+            # Must not propagate — settings save should never 500 on a DB hiccup
+            save_config({"user_profile": {"weight_kg": 80.0}})

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -7,7 +7,23 @@ from pathlib import Path
 
 import pytest
 
+from unittest.mock import patch
+
 from hevy2garmin.db_sqlite import SQLiteDatabase
+
+
+class TestSQLiteReadOnlyFilesystem:
+    """SQLite must surface an actionable error on read-only/serverless FS (#145).
+
+    Previously the mkdir raised a cryptic FileNotFoundError/OSError that users
+    saw as a blank dashboard / 500 on Vercel deploy (u/mache_pachela).
+    """
+
+    def test_readonly_mkdir_raises_actionable_error(self, tmp_path: Path) -> None:
+        db = SQLiteDatabase(tmp_path / "nope" / "sync.db")
+        with patch.object(Path, "mkdir", side_effect=OSError("read-only file system")):
+            with pytest.raises(RuntimeError, match="read-only filesystem"):
+                db._get_conn()
 
 
 def _make_db(tmp_path):

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -91,3 +91,46 @@ class TestCustomMappings:
         m._custom_mappings.clear()
         # Should not crash when file doesn't exist
         _ensure_custom_loaded()
+
+
+class TestSaveCustomMappingCloud:
+    """save_custom_mapping must write to the DB on cloud (#142, #145).
+
+    The old file-only write 500'd on Vercel's read-only filesystem, so custom
+    mappings silently failed to persist (u/Zephyro7, u/fastcoconut).
+    """
+
+    def test_writes_to_db_on_cloud(self) -> None:
+        from unittest.mock import MagicMock
+        import hevy2garmin.mapper as m
+        m._custom_mappings.clear()
+        fake_db = MagicMock()
+        with patch("hevy2garmin.db.get_database_url", return_value="postgresql://x"), \
+             patch("hevy2garmin.db.get_db", return_value=fake_db):
+            save_custom_mapping("Agachamento Búlgaro", 28, 9)
+        fake_db.save_custom_mapping.assert_called_once_with("Agachamento Búlgaro", 28, 9)
+        assert m._custom_mappings["Agachamento Búlgaro"] == (28, 9)
+        m._custom_mappings.clear()
+
+    def test_does_not_touch_filesystem_on_cloud(self, tmp_path: Path) -> None:
+        from unittest.mock import MagicMock
+        import hevy2garmin.mapper as m
+        m._custom_mappings.clear()
+        target = tmp_path / "custom_mappings.json"
+        with patch("hevy2garmin.db.get_database_url", return_value="postgresql://x"), \
+             patch("hevy2garmin.db.get_db", return_value=MagicMock()), \
+             patch.object(Path, "expanduser", return_value=target):
+            save_custom_mapping("Foo (Bar)", 1, 2)
+        assert not target.exists()  # DB path used, no file written
+        m._custom_mappings.clear()
+
+    def test_falls_back_to_file_when_local(self, tmp_path: Path) -> None:
+        import hevy2garmin.mapper as m
+        m._custom_mappings.clear()
+        target = tmp_path / "custom_mappings.json"
+        with patch("hevy2garmin.db.get_database_url", return_value=None), \
+             patch.object(Path, "expanduser", return_value=target):
+            save_custom_mapping("Foo (Bar)", 12, 34)
+        assert json.loads(target.read_text())["Foo (Bar)"] == [12, 34]
+        assert m._custom_mappings["Foo (Bar)"] == (12, 34)
+        m._custom_mappings.clear()


### PR DESCRIPTION
## Summary

On Vercel the home filesystem is read-only (only `/tmp` is writable), but three write paths still targeted `~/.hevy2garmin`, breaking real users on the [r/Hevy thread](https://reddit.com/r/Hevy/comments/1sfu9id):

1. **`mapper.save_custom_mapping()`** always wrote the JSON file → **500 when saving a mapping** (u/fastcoconut #142, u/Zephyro7), so mappings silently never persisted. The load path already read from the DB — only the write was file-only.
2. **`config.save_config()`** only wrote the file, so profile/settings saved via **Pull-from-Garmin reverted to defaults** on the next stateless invocation (u/dleguisamo #139).
3. **`SQLiteDatabase` mkdir** crashed with a cryptic `FileNotFoundError` when no `DATABASE_URL` was set → blank dashboard / 500 on deploy (u/mache_pachela, u/Economy_Wasabi629).

## Changes

- `mapper.save_custom_mapping()` writes to the DB on cloud (mirrors the DB-first load path in `_ensure_custom_loaded`); filesystem only for local/Docker.
- `config.save_config()` persists `user_profile`/`timing`/`hr_fusion` to `app_cache` on cloud, symmetric with `load_config()`; file write stays for local. This covers every caller (including Pull-from-Garmin) at the source.
- `SQLiteDatabase._get_conn()` converts the mkdir `OSError` into an actionable "add Neon / set DATABASE_URL" `RuntimeError`.

## Test plan

- [x] New unit tests: mapping → DB on cloud + file fallback local; `save_config` → DB on cloud, no-op local, swallows DB failure; SQLite read-only mkdir → actionable error.
- [x] **E2E against real Postgres 17** (Docker): `Supino Reto (Barra)` mapping and a profile weight both persist and survive a simulated fresh invocation.
- [x] Full suite green in **SQLite mode (180 passed)** and **Postgres mode (187 passed)**.

Closes #145
Closes #142
