### PR TITLE
fix(sync): sanitize quoted internalId from Garmin upload (#153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - **Serverless persistence** ([#145](https://github.com/drkostas/hevy2garmin/issues/145)) — custom exercise mappings and profile/settings now persist to Postgres on cloud deployments instead of the read-only `~/.hevy2garmin` filesystem. Fixes the 500 when saving a mapping on Vercel ([#142](https://github.com/drkostas/hevy2garmin/issues/142)), profile reverting to defaults / Pull-from-Garmin not sticking ([#139](https://github.com/drkostas/hevy2garmin/issues/139)), and the blank-dashboard crash on deploy without a database — now an actionable "set DATABASE_URL" error.
+- **Activity lookup by date range** ([#140](https://github.com/drkostas/hevy2garmin/issues/140)) — `find_activity_by_start_time` now searches a ±1 day window instead of only the 10 most recent activities, so older uploads are found regardless of account volume. Thanks @zv33 ([#141](https://github.com/drkostas/hevy2garmin/pull/141)).
+- **Quoted activity ID breaks rename** ([#153](https://github.com/drkostas/hevy2garmin/issues/153)) — Garmin sometimes returns `internalId` as a quoted string (`"'123'"`); it's now sanitized to a clean int before storage, so rename no longer 404s. Diagnosed by @frankzotynia10 ([#143](https://github.com/drkostas/hevy2garmin/pull/143)).
 
 ## [0.4.0]
 

--- a/src/hevy2garmin/garmin.py
+++ b/src/hevy2garmin/garmin.py
@@ -44,6 +44,28 @@ def get_client(
     return auth.login()
 
 
+def _sanitize_activity_id(raw: object) -> int | None:
+    """Normalize an activity ID returned by the Garmin upload API.
+
+    Garmin occasionally returns ``internalId`` as a string wrapped in quote
+    characters (e.g. ``"'23126363872'"``). Stored verbatim, the literal quotes
+    make every later Garmin API call 404, so rename silently fails and the
+    activity stays named "Strength Training" (#153). Strip surrounding quotes
+    and coerce to int; return None if it cannot be parsed.
+
+    Diagnosed by @frankzotynia10 (#143).
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, int):
+        return raw
+    cleaned = str(raw).strip().strip("'\"").strip()
+    try:
+        return int(cleaned)
+    except (ValueError, TypeError):
+        return None
+
+
 def upload_fit(client: Garmin, fit_path: str | Path, workout_start: str | None = None) -> dict:
     """Upload a FIT file to Garmin Connect.
 
@@ -82,7 +104,9 @@ def upload_fit(client: Garmin, fit_path: str | Path, workout_start: str | None =
         upload_id = detail.get("uploadId")
         successes = detail.get("successes", [])
         if successes and isinstance(successes, list):
-            activity_id = successes[0].get("internalId")
+            # internalId may come back as a quoted string ("'123'") — sanitize
+            # so the stored ID is a clean int, otherwise rename 404s (#153).
+            activity_id = _sanitize_activity_id(successes[0].get("internalId"))
         failures = detail.get("failures", [])
         if failures:
             logger.warning("  Upload failures: %s", failures)

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -6,7 +6,36 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from hevy2garmin.garmin import find_activity_by_start_time, generate_description
+from hevy2garmin.garmin import (
+    _sanitize_activity_id,
+    find_activity_by_start_time,
+    generate_description,
+)
+
+
+class TestSanitizeActivityId:
+    """Garmin sometimes returns internalId as a quoted string → must coerce to int (#153)."""
+
+    def test_quoted_string(self) -> None:
+        assert _sanitize_activity_id("'23126363872'") == 23126363872
+
+    def test_double_quoted_string(self) -> None:
+        assert _sanitize_activity_id('"23126363872"') == 23126363872
+
+    def test_plain_int(self) -> None:
+        assert _sanitize_activity_id(23126363872) == 23126363872
+
+    def test_plain_numeric_string(self) -> None:
+        assert _sanitize_activity_id("23126363872") == 23126363872
+
+    def test_none(self) -> None:
+        assert _sanitize_activity_id(None) is None
+
+    def test_garbage_returns_none(self) -> None:
+        assert _sanitize_activity_id("not-an-id") is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert _sanitize_activity_id("") is None
 
 
 class TestFindActivityByStartTime:


### PR DESCRIPTION
## Summary

Garmin's upload endpoint occasionally returns `internalId` as a **quoted string** (e.g. `"'23126363872'"`). Stored verbatim in the sync DB, the literal quotes make every later Garmin API call 404 — so activity **rename silently fails** and the activity stays named "Strength Training" instead of the Hevy workout name.

Adds `_sanitize_activity_id()` which strips surrounding quote chars and coerces to `int` before the value from `successes[0]["internalId"]` is used or stored.

## Credit

Diagnosed and originally fixed by **@frankzotynia10** in #143 (Bug 1). That PR also bundles unrelated changes (it removes the repo's CI/publish workflows and rewrites merge mode), so this lands just the sanitizer upstream. Thanks @frankzotynia10! 🙏

## Test plan

- [x] 7 new unit tests for `_sanitize_activity_id` (quoted, double-quoted, plain int, numeric string, None, garbage, empty)
- [x] Full suite green (187 passed, 7 skipped)

Closes #153
