### PR TITLE
feat(hr): embed heart rate into the uploaded FIT (#158)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 - Version + changelog link in the dashboard footer ([#144](https://github.com/drkostas/hevy2garmin/issues/144)) — confirm which build you're running after an upgrade.
+- **Heart rate now embedded in the uploaded activity** ([#158](https://github.com/drkostas/hevy2garmin/issues/158)) — fetched HR is written into the FIT at real timestamps, so it appears on the Garmin Connect activity, not just the dashboard chart. New `hr.py` merges HR sources (in-workout/AirPods-preferred, Garmin watch fill); the merge is source-agnostic and ready for in-workout HR the moment Hevy exposes it via the API (it does not today). Gated by the existing HR-fusion toggle, cached, and best-effort (never breaks a sync).
 
 ### Fixed
 - **Serverless persistence** ([#145](https://github.com/drkostas/hevy2garmin/issues/145)) — custom exercise mappings and profile/settings now persist to Postgres on cloud deployments instead of the read-only `~/.hevy2garmin` filesystem. Fixes the 500 when saving a mapping on Vercel ([#142](https://github.com/drkostas/hevy2garmin/issues/142)), profile reverting to defaults / Pull-from-Garmin not sticking ([#139](https://github.com/drkostas/hevy2garmin/issues/139)), and the blank-dashboard crash on deploy without a database — now an actionable "set DATABASE_URL" error.

--- a/src/hevy2garmin/fit.py
+++ b/src/hevy2garmin/fit.py
@@ -141,10 +141,11 @@ def generate_fit(
     hevy_workout:
         Hevy workout dict with exercises and sets.
     hr_samples:
-        Heart-rate samples to embed. Can come from Garmin daily monitoring,
-        or be a synthetic list (e.g. [90]*30 for static fallback).
-        If None or empty, _DEFAULT_HR_BPM is used for calorie calculation
-        and no HR records are written.
+        Heart-rate samples to embed. Either a list of bpm ints (distributed
+        evenly across the workout) or timestamped ``{"time": secs_from_start,
+        "hr": bpm}`` dicts from Garmin daily monitoring (placed at their real
+        offsets). If None or empty, _DEFAULT_HR_BPM is used for calorie
+        calculation and no HR records are written.
     output_path:
         Path where the .fit file will be written.
 
@@ -153,8 +154,21 @@ def generate_fit(
     dict with keys: exercises, total_sets, hr_samples, calories, duration_s,
     avg_hr, output_path
     """
-    if hr_samples is None:
-        hr_samples = []
+    # Normalize HR input: callers pass either bpm ints or timestamped dicts.
+    # hr_bpm drives calories + lap/session avg; hr_timed (when present) places
+    # records at their real offsets instead of evenly distributing them.
+    hr_timed: list[tuple[float, int]] | None = None
+    if not hr_samples:
+        hr_bpm: list[int] = []
+    elif isinstance(hr_samples[0], dict):
+        hr_timed = [
+            (max(0.0, float(s.get("time", 0))), int(s["hr"]))
+            for s in hr_samples
+            if s.get("hr") is not None
+        ]
+        hr_bpm = [b for _, b in hr_timed]
+    else:
+        hr_bpm = [int(x) for x in hr_samples]
 
     p = _get_profile(profile)
 
@@ -173,7 +187,7 @@ def generate_fit(
 
     # -- Calculate calories from HR using Keytel formula --
     workout_year = start_dt.year
-    calories = _calc_calories(hr_samples, duration_s, workout_year, p)
+    calories = _calc_calories(hr_bpm, duration_s, workout_year, p)
 
     # -- Gather exercises and compute timing --
     exercises = hevy_workout.get("exercises", [])
@@ -272,14 +286,22 @@ def generate_fit(
     # Build a timeline of events sorted by timestamp
     timeline: list[tuple[int, str, object]] = []  # (ms, type, message)
 
-    # HR record messages distributed evenly across duration
-    if hr_samples:
-        if len(hr_samples) == 1:
+    # HR record messages. Timestamped samples go at their real offsets;
+    # plain bpm lists are distributed evenly across the duration.
+    if hr_timed:
+        for offset_s, hr_val in hr_timed:
+            t_ms = start_ms + round(offset_s * 1000)
+            rec = RecordMessage()
+            rec.timestamp = t_ms
+            rec.heart_rate = hr_val
+            timeline.append((t_ms, "record", rec))
+    elif hr_bpm:
+        if len(hr_bpm) == 1:
             hr_interval_ms = 0
         else:
-            hr_interval_ms = round(duration_s * 1000 / (len(hr_samples) - 1))
-        for i, hr_val in enumerate(hr_samples):
-            t_ms = start_ms + (i * hr_interval_ms if len(hr_samples) > 1 else 0)
+            hr_interval_ms = round(duration_s * 1000 / (len(hr_bpm) - 1))
+        for i, hr_val in enumerate(hr_bpm):
+            t_ms = start_ms + (i * hr_interval_ms if len(hr_bpm) > 1 else 0)
             rec = RecordMessage()
             rec.timestamp = t_ms
             rec.heart_rate = hr_val
@@ -371,9 +393,9 @@ def generate_fit(
     lap.message_index = 0
     lap.event = Event.LAP
     lap.event_type = EventType.STOP
-    if hr_samples:
-        lap.avg_heart_rate = round(sum(hr_samples) / len(hr_samples))
-        lap.max_heart_rate = max(hr_samples)
+    if hr_bpm:
+        lap.avg_heart_rate = round(sum(hr_bpm) / len(hr_bpm))
+        lap.max_heart_rate = max(hr_bpm)
     if total_distance_m > 0:
         lap.total_distance = total_distance_m
     lap.total_calories = calories
@@ -392,9 +414,9 @@ def generate_fit(
     session.num_laps = 1
     session.event = Event.LAP
     session.event_type = EventType.STOP
-    if hr_samples:
-        session.avg_heart_rate = round(sum(hr_samples) / len(hr_samples))
-        session.max_heart_rate = max(hr_samples)
+    if hr_bpm:
+        session.avg_heart_rate = round(sum(hr_bpm) / len(hr_bpm))
+        session.max_heart_rate = max(hr_bpm)
     if total_distance_m > 0:
         session.total_distance = total_distance_m
     session.total_calories = calories
@@ -414,11 +436,11 @@ def generate_fit(
     Path(output_path).parent.mkdir(parents=True, exist_ok=True)
     builder.build().to_file(output_path)
 
-    avg_hr = round(sum(hr_samples) / len(hr_samples)) if hr_samples else None
+    avg_hr = round(sum(hr_bpm) / len(hr_bpm)) if hr_bpm else None
     return {
         "exercises": num_exercises,
         "total_sets": total_sets,
-        "hr_samples": len(hr_samples),
+        "hr_samples": len(hr_bpm),
         "calories": calories,
         "avg_hr": avg_hr,
         "duration_s": duration_s,

--- a/src/hevy2garmin/hr.py
+++ b/src/hevy2garmin/hr.py
@@ -1,0 +1,141 @@
+"""Heart-rate sourcing + merging for FIT enrichment.
+
+hevy2garmin can enrich an uploaded workout with heart rate from more than one
+source, in priority order:
+
+1. **In-workout HR recorded by Hevy** (e.g. AirPods Pro 3 in-ear HR, which Hevy
+   captures via Apple HealthKit). This is the most consistent during a lift, but
+   only present when the user wore a recording device for that session — and
+   only when Hevy actually exposes it (see ``extract_hevy_hr``).
+2. **Garmin daily passive HR** (wrist monitoring, ~every couple of minutes).
+   Always available if the user wears the watch, but coarser.
+
+``merge_hr_sources`` combines them: the higher-priority source wins wherever it
+has a sample, and the lower-priority source fills the gaps. The result is a
+timestamped ``[{"time": secs_from_start, "hr": bpm}]`` series that
+``fit.generate_fit`` embeds at real offsets.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def extract_hevy_hr(workout: dict) -> list[dict]:
+    """Extract in-workout HR samples (e.g. AirPods) from a Hevy workout.
+
+    Returns ``[{"time": secs_from_start, "hr": bpm}]`` sorted by time, or ``[]``.
+
+    NOTE: the Hevy **public API** (`/v1/workouts/{id}`) does not currently expose
+    heart-rate data — sets carry only weight/reps/distance/duration/rpe. AirPods
+    HR that Hevy records via HealthKit stays on-device / in the app. So this
+    returns ``[]`` today; it's the seam where AirPods HR plugs in if/when Hevy
+    surfaces it in the API (or a future HealthKit path provides it). Kept as the
+    highest-priority source so no other code changes when that data appears.
+    """
+    samples: list[dict] = []
+    # Defensive: support a future Hevy field without breaking today.
+    raw = workout.get("heart_rate") or workout.get("heartRate") or workout.get("hr_samples")
+    if isinstance(raw, list):
+        for entry in raw:
+            if isinstance(entry, dict) and entry.get("hr") is not None and entry.get("time") is not None:
+                samples.append({"time": max(0.0, float(entry["time"])), "hr": int(entry["hr"])})
+            elif isinstance(entry, (list, tuple)) and len(entry) >= 2 and entry[1] is not None:
+                samples.append({"time": max(0.0, float(entry[0])), "hr": int(entry[1])})
+    samples.sort(key=lambda s: s["time"])
+    return samples
+
+
+def fetch_watch_hr(garmin_client, workout: dict, limiter=None) -> list[dict]:
+    """Fetch Garmin daily passive HR, sliced to the workout window.
+
+    Returns ``[{"time": secs_from_start, "hr": bpm}]`` sorted by time, or ``[]``
+    on any failure (HR enrichment is best-effort and must never break a sync).
+    """
+    from hevy2garmin.fit import _parse_timestamp
+
+    w_start = workout.get("start_time") or workout.get("startTime", "")
+    w_end = workout.get("end_time") or workout.get("endTime", "")
+    start_dt = _parse_timestamp(w_start)
+    end_dt = _parse_timestamp(w_end)
+    if not start_dt or not end_dt:
+        return []
+    start_ms = int(start_dt.timestamp() * 1000)
+    end_ms = int(end_dt.timestamp() * 1000)
+
+    try:
+        date_str = str(w_start)[:10]
+        call = (limiter.call if limiter is not None else (lambda f, *a: f(*a)))
+        daily_hr = call(garmin_client.get_heart_rates, date_str)
+    except Exception as e:  # pragma: no cover - network/auth failure path
+        logger.debug("watch HR fetch failed: %s", e)
+        return []
+
+    values = daily_hr.get("heartRateValues", []) if isinstance(daily_hr, dict) else []
+    samples: list[dict] = []
+    for entry in values or []:
+        if isinstance(entry, (list, tuple)) and len(entry) >= 2 and entry[1] is not None:
+            ts, bpm = entry[0], entry[1]
+            if start_ms - 60000 <= ts <= end_ms + 60000:  # ±1 min buffer
+                samples.append({"time": max(0.0, (ts - start_ms) / 1000), "hr": int(bpm)})
+    samples.sort(key=lambda s: s["time"])
+    return samples
+
+
+def merge_hr_sources(
+    primary: list[dict] | None,
+    secondary: list[dict] | None,
+    bucket_s: float = 10.0,
+) -> list[dict]:
+    """Merge two timestamped HR series, preferring ``primary`` per time bucket.
+
+    Time is bucketed into ``bucket_s``-second windows. For each window, if the
+    primary source has a sample it wins; otherwise the secondary fills in. This
+    yields a continuous series that uses the more consistent source (AirPods)
+    when present and the always-on source (watch) elsewhere.
+
+    Returns ``[{"time", "hr"}]`` sorted by time (empty if both inputs are empty).
+    """
+    primary = primary or []
+    secondary = secondary or []
+    if not primary:
+        return sorted(secondary, key=lambda s: s["time"])
+    if not secondary:
+        return sorted(primary, key=lambda s: s["time"])
+
+    chosen: dict[int, dict] = {}
+    # Secondary first, then overwrite with primary so primary wins ties.
+    for s in secondary:
+        chosen[int(s["time"] // bucket_s)] = s
+    for s in primary:
+        chosen[int(s["time"] // bucket_s)] = s
+    return [chosen[k] for k in sorted(chosen)]
+
+
+def build_workout_hr(garmin_client, workout: dict, limiter=None) -> list[dict]:
+    """Top-level helper: merged HR for a workout (AirPods-preferred, watch fill)."""
+    hevy_hr = extract_hevy_hr(workout)        # AirPods / in-workout (empty today)
+    watch_hr = fetch_watch_hr(garmin_client, workout, limiter)
+    return merge_hr_sources(hevy_hr, watch_hr)
+
+
+def hr_for_sync(db, garmin_client, workout: dict, config: dict, limiter=None) -> list[dict] | None:
+    """Merged HR samples for embedding in a sync's FIT — or None.
+
+    Honors the ``hr_fusion.enabled`` toggle, reuses the dashboard's cached HR
+    when present (avoids a duplicate Garmin call), and is fully best-effort:
+    any failure returns None so HR never breaks a sync.
+    """
+    if not garmin_client or not config.get("hr_fusion", {}).get("enabled", True):
+        return None
+    try:
+        wid = workout.get("id")
+        cached = db.get_cached_hr(wid) if wid else None
+        if isinstance(cached, dict) and cached.get("hr_samples"):
+            return merge_hr_sources(extract_hevy_hr(workout), cached["hr_samples"]) or None
+        return build_workout_hr(garmin_client, workout, limiter) or None
+    except Exception:
+        logger.debug("HR enrichment skipped for sync", exc_info=True)
+        return None

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -1139,9 +1139,11 @@ async def api_sync_single(request: Request, workout_id: str):
         if not force_upload and workout_start:
             existing_id = find_activity_by_start_time(garmin_client, workout_start)
 
+        from hevy2garmin.hr import hr_for_sync
+        hr_samples = hr_for_sync(db, garmin_client, workout, config)
         with tempfile.TemporaryDirectory() as tmp:
             fit_path = f"{tmp}/{workout_id}.fit"
-            result = generate_fit(workout, hr_samples=None, output_path=fit_path)
+            result = generate_fit(workout, hr_samples=hr_samples, output_path=fit_path)
             if existing_id:
                 aid = existing_id
                 logger.info("Activity already on Garmin (%s), skipping upload", aid)
@@ -1593,6 +1595,12 @@ async def _do_sync_one(request: Request):
                 remaining = hevy.get_workout_count() - db.get_synced_count()
                 return JSONResponse({"synced": 1, "title": unsynced["title"], "remaining": max(0, remaining), "done": remaining <= 0})
 
+        # HR enrichment for the uploaded FIT (#158): merged HR (AirPods-preferred,
+        # watch fill), best-effort. Computed after the merge early-return so the
+        # merge path doesn't pay for an HR fetch it won't upload.
+        from hevy2garmin.hr import hr_for_sync
+        hr_samples = hr_for_sync(db, garmin_client, unsynced, config)
+
         # Dedup: check if this workout already exists on Garmin before uploading.
         # Prevents duplicates when a prior sync uploaded successfully but crashed
         # before marking the workout as synced in the DB.
@@ -1606,7 +1614,7 @@ async def _do_sync_one(request: Request):
             # Still generate FIT to get calorie estimate
             with tempfile.TemporaryDirectory() as tmp:
                 fit_path = f"{tmp}/{unsynced['id']}.fit"
-                result = generate_fit(unsynced, hr_samples=None, output_path=fit_path)
+                result = generate_fit(unsynced, hr_samples=hr_samples, output_path=fit_path)
             rename_activity(garmin_client, aid, unsynced["title"])
             desc = generate_description(unsynced, calories=result.get("calories"), avg_hr=result.get("avg_hr"))
             set_description(garmin_client, aid, desc)
@@ -1614,7 +1622,7 @@ async def _do_sync_one(request: Request):
         else:
             with tempfile.TemporaryDirectory() as tmp:
                 fit_path = f"{tmp}/{unsynced['id']}.fit"
-                result = generate_fit(unsynced, hr_samples=None, output_path=fit_path)
+                result = generate_fit(unsynced, hr_samples=hr_samples, output_path=fit_path)
                 upload_result = upload_fit(garmin_client, fit_path, workout_start=workout_start)
                 aid = upload_result.get("activity_id")
                 if aid:

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -23,6 +23,12 @@ from hevy2garmin.hevy import HevyClient
 from hevy2garmin.mapper import lookup_exercise
 from hevy2garmin.merge import attempt_merge, reset_circuit_breaker, MergeResult
 
+try:  # rate-limit HR fetches like other Garmin data calls
+    from garmin_auth import RateLimiter
+    _hr_limiter = RateLimiter(delay=1.0)
+except Exception:  # pragma: no cover
+    _hr_limiter = None
+
 logger = logging.getLogger("hevy2garmin")
 
 
@@ -163,9 +169,16 @@ def sync(
                     stats["merge_fallback"] += 1
 
             # ── Standard upload path (FIT generation) ──
+            # Embed merged HR (AirPods-preferred, watch fill) so it reaches
+            # Garmin Connect, not just the dashboard (#158). Best-effort.
+            hr_samples = None
+            if not dry_run:
+                from hevy2garmin.hr import hr_for_sync
+                hr_samples = hr_for_sync(db, garmin_client, workout, cfg, _hr_limiter)
+
             with tempfile.TemporaryDirectory() as tmp:
                 fit_path = str(Path(tmp) / f"{wid}.fit")
-                result = generate_fit(workout, hr_samples=None, output_path=fit_path)
+                result = generate_fit(workout, hr_samples=hr_samples, output_path=fit_path)
                 logger.info(
                     "  FIT: %d exercises, %d sets, %d cal",
                     result["exercises"], result["total_sets"], result["calories"],

--- a/tests/test_hr.py
+++ b/tests/test_hr.py
@@ -1,0 +1,144 @@
+"""Tests for HR sourcing + merging and HR embedding in the FIT (#158)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from fit_tool.fit_file import FitFile
+from fit_tool.profile.messages.record_message import RecordMessage
+
+from hevy2garmin.hr import (
+    build_workout_hr,
+    extract_hevy_hr,
+    fetch_watch_hr,
+    merge_hr_sources,
+)
+from hevy2garmin.fit import generate_fit
+
+
+# --- merge_hr_sources -------------------------------------------------------
+
+class TestMergeHRSources:
+    def test_primary_wins_per_bucket(self):
+        primary = [{"time": 0, "hr": 150}, {"time": 10, "hr": 160}]   # AirPods
+        secondary = [{"time": 0, "hr": 90}, {"time": 10, "hr": 95}]   # watch
+        merged = merge_hr_sources(primary, secondary)
+        assert {s["hr"] for s in merged} == {150, 160}  # AirPods wins both buckets
+
+    def test_secondary_fills_gaps(self):
+        primary = [{"time": 0, "hr": 150}]                 # AirPods only at start
+        secondary = [{"time": 0, "hr": 90}, {"time": 60, "hr": 100}]  # watch covers later
+        merged = merge_hr_sources(primary, secondary)
+        hrs = [s["hr"] for s in merged]
+        assert 150 in hrs        # AirPods kept where present
+        assert 100 in hrs        # watch fills the gap at t=60
+
+    def test_empty_primary_returns_secondary(self):
+        secondary = [{"time": 5, "hr": 88}]
+        assert merge_hr_sources([], secondary) == secondary
+
+    def test_both_empty(self):
+        assert merge_hr_sources([], []) == []
+
+    def test_output_sorted_by_time(self):
+        merged = merge_hr_sources(
+            [{"time": 120, "hr": 150}],
+            [{"time": 0, "hr": 90}, {"time": 60, "hr": 95}],
+        )
+        times = [s["time"] for s in merged]
+        assert times == sorted(times)
+
+
+# --- extract_hevy_hr --------------------------------------------------------
+
+class TestExtractHevyHR:
+    def test_standard_hevy_workout_has_no_hr(self):
+        # The Hevy public API exposes no HR — sets carry only weight/reps/etc.
+        workout = {"exercises": [{"sets": [{"weight": 60, "reps": 10}]}]}
+        assert extract_hevy_hr(workout) == []
+
+    def test_parses_future_hr_field_dicts(self):
+        workout = {"heart_rate": [{"time": 5, "hr": 140}, {"time": 0, "hr": 130}]}
+        assert extract_hevy_hr(workout) == [{"time": 0, "hr": 130}, {"time": 5, "hr": 140}]
+
+    def test_parses_future_hr_field_pairs(self):
+        workout = {"hr_samples": [[0, 130], [10, 145]]}
+        assert extract_hevy_hr(workout) == [{"time": 0, "hr": 130}, {"time": 10, "hr": 145}]
+
+
+# --- fetch_watch_hr ---------------------------------------------------------
+
+class TestFetchWatchHR:
+    def _workout(self):
+        return {"start_time": "2026-03-15T18:00:00+00:00", "end_time": "2026-03-15T18:10:00+00:00"}
+
+    def test_slices_to_window(self):
+        w = self._workout()
+        import datetime as dt
+        start_ms = int(dt.datetime.fromisoformat(w["start_time"]).timestamp() * 1000)
+        client = MagicMock()
+        # one sample inside the window, one way outside
+        client.get_heart_rates.return_value = {
+            "heartRateValues": [
+                [start_ms + 60_000, 120],          # inside (t=60s)
+                [start_ms + 999_000_000, 200],     # far outside → dropped
+            ]
+        }
+        samples = fetch_watch_hr(client, w)
+        assert samples == [{"time": 60.0, "hr": 120}]
+
+    def test_failure_returns_empty(self):
+        client = MagicMock()
+        client.get_heart_rates.side_effect = RuntimeError("rate limited")
+        assert fetch_watch_hr(client, self._workout()) == []
+
+    def test_missing_timestamps_returns_empty(self):
+        client = MagicMock()
+        assert fetch_watch_hr(client, {"start_time": "", "end_time": ""}) == []
+
+
+# --- end-to-end: HR actually lands in the FIT -------------------------------
+
+def _hr_count_in_fit(path: str) -> int:
+    fit = FitFile.from_file(path)
+    n = 0
+    for record in fit.records:
+        msg = record.message
+        if isinstance(msg, RecordMessage) and getattr(msg, "heart_rate", None) is not None:
+            n += 1
+    return n
+
+
+class TestHREmbeddedInFit:
+    WORKOUT = {
+        "title": "Push",
+        "start_time": "2026-03-15T18:00:00+00:00",
+        "end_time": "2026-03-15T18:10:00+00:00",
+        "exercises": [
+            {"title": "Bench Press (Barbell)", "sets": [{"type": "normal", "weight_kg": 60, "reps": 10}]},
+        ],
+    }
+    PROFILE = {"weight_kg": 78.0, "birth_year": 1994, "vo2max": 50.0}
+
+    def test_timestamped_hr_written_to_fit(self, tmp_path: Path):
+        path = str(tmp_path / "w.fit")
+        hr = [{"time": 0, "hr": 110}, {"time": 120, "hr": 130}, {"time": 480, "hr": 150}]
+        result = generate_fit(self.WORKOUT, hr_samples=hr, output_path=path, profile=self.PROFILE)
+        assert result["hr_samples"] == 3
+        assert result["avg_hr"] == 130
+        assert _hr_count_in_fit(path) == 3  # HR records actually in the FIT
+
+    def test_plain_bpm_list_still_works(self, tmp_path: Path):
+        path = str(tmp_path / "w.fit")
+        result = generate_fit(self.WORKOUT, hr_samples=[100, 110, 120], output_path=path, profile=self.PROFILE)
+        assert result["hr_samples"] == 3
+        assert _hr_count_in_fit(path) == 3
+
+    def test_none_writes_no_hr(self, tmp_path: Path):
+        path = str(tmp_path / "w.fit")
+        result = generate_fit(self.WORKOUT, hr_samples=None, output_path=path, profile=self.PROFILE)
+        assert result["hr_samples"] == 0
+        assert _hr_count_in_fit(path) == 0


### PR DESCRIPTION
## Summary

Closes both halves of #158 (great diagnosis, @Bertram793):

- **Problem 1 (merged activities show "Unknown")** — already fixed on `main` by #155 (the `exerciseSets` payload now sends a valid FIT sub-category, validated against Garmin's real stored shape). Ships with this release.
- **Problem 2 (HR fetched but never reaches Garmin)** — fixed here. You were exactly right: every `generate_fit()` call passed `hr_samples=None`, so the fetched HR only fed the dashboard chart and the cache, never the uploaded FIT.

Also resolves the same HR complaint from u/RandomEJ and u/silas_christopher on the r/Hevy thread.

## Changes

- `generate_fit()` accepts **timestamped** `{"time", "hr"}` samples (placed at real offsets) in addition to plain bpm lists — backward compatible.
- New **`hr.py`**:
  - `fetch_watch_hr()` — Garmin daily passive HR, sliced to the workout window.
  - `merge_hr_sources()` — merges two timestamped series; the higher-priority source wins per time bucket, the other fills gaps.
  - `extract_hevy_hr()` — in-workout HR (e.g. AirPods Pro 3, which Hevy records via HealthKit). **The Hevy public API exposes no HR today** (verified: `/v1/workouts/{id}` sets carry only weight/reps/distance/duration/rpe), so this returns `[]` for now — it's the seam where AirPods HR plugs in the moment Hevy surfaces it, with no other code change.
  - `hr_for_sync()` — toggle-aware, reuses the dashboard's cached HR, fully best-effort.
- Wired into the sync cron path (`sync.py`) and the dashboard sync endpoints (`server.py`).

## Why source-agnostic merge

AirPods in-ear HR is more consistent than passive wrist HR during lifting, but users wear them only some sessions. The merge prefers AirPods where present and fills with watch HR elsewhere — so when Hevy exposes that data, coverage is automatically best-of-both. Until then, watch HR reaches Garmin (the actual bug fix).

## Test plan

- [x] New `test_hr.py` (14 tests): merge precedence + gap-fill, `extract_hevy_hr` (empty today + future-field parsing), `fetch_watch_hr` window slicing + failure-safety, and **FIT-parse proof that HR RecordMessages land in the file** at the right offsets.
- [x] Real Garmin `get_heart_rates` shape confirmed (read-only) — `[[ts_ms, bpm|null]]`, exactly what the slicer handles.
- [x] Full suite: **207 passed, 7 skipped**.

Closes #158
