### PR TITLE
release: v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-23
+
 ### Added
 - Version + changelog link in the dashboard footer ([#144](https://github.com/drkostas/hevy2garmin/issues/144)) — confirm which build you're running after an upgrade.
 - **Heart rate now embedded in the uploaded activity** ([#158](https://github.com/drkostas/hevy2garmin/issues/158)) — fetched HR is written into the FIT at real timestamps, so it appears on the Garmin Connect activity, not just the dashboard chart. New `hr.py` merges HR sources (in-workout/AirPods-preferred, Garmin watch fill); the merge is source-agnostic and ready for in-workout HR the moment Hevy exposes it via the API (it does not today). Gated by the existing HR-fusion toggle, cached, and best-effort (never breaks a sync).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hevy2garmin"
-version = "0.4.0"
+version = "0.5.0"
 description = "Sync Hevy gym workouts to Garmin Connect — exercise mapping, FIT file generation, and automatic upload"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## v0.5.0

Ships all fixes accumulated since 0.4.0 to PyPI + users' forks.

### Added
- HR embedded in the uploaded Garmin activity (#158)
- Version + changelog link in dashboard footer (#144)
- README FAQ (#149)

### Fixed
- Serverless persistence: mappings + profile to Postgres (#145, #142, #139)
- 'Unknown' exercise names in merge mode (#138)
- Activity lookup by date range (#140 — thanks @zv33)
- Quoted internalId breaks rename (#153 — diagnosed by @frankzotynia10)
- Redundant setup login tripped rate limits + clearer message (#148)

Bumps `pyproject.toml` 0.4.0 → 0.5.0 (triggers the PyPI publish workflow on merge) and moves the CHANGELOG `[Unreleased]` section to `[0.5.0]`. Full suite green (207 passed).