### PR TITLE
feat(merge): enhance non-strength watch activities (#157, @braianrabanal)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **Merge into non-strength watch activities** ([#157](https://github.com/drkostas/hevy2garmin/pull/157)) — a `merge_activity_types` setting (default `["strength_training"]`) lets Enhance Watch Activities fuse Hevy workouts into other Garmin activity types you record on the watch (e.g. Indoor Climbing), instead of creating a duplicate. Configure extra types under Settings → Enhance Watch Activities → Advanced. Thanks @braianrabanal.
+
 ## [0.5.0] - 2026-06-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -370,6 +370,22 @@ If you start a **Strength Training** activity on your Garmin watch when you hit 
 
 If no matching watch activity is found, hevy2garmin falls back to the default flow automatically. Matching requires 70% temporal overlap with a Strength Training activity within 20 minutes of the Hevy workout start time.
 
+### Non-strength watch activities (climbing, etc.)
+
+By default, only watch activities recorded as **Strength Training** are eligible for enhancement. If you record something else on your watch at the same time as your Hevy workout — e.g. a **Climbing** session — it's matched as **Strength Training only**, so it won't be merged and a separate activity is created instead.
+
+To also enhance e.g. climbing sessions, add the Garmin activity type(s) under **Settings → Enhance Watch Activities → Advanced → Additional Watch Activity Types**, using Garmin's internal type names (comma-separated), for example:
+
+```
+bouldering, indoor_climbing
+```
+
+or set `merge_activity_types` directly in `config.json`:
+
+```json
+"merge_activity_types": ["strength_training", "bouldering", "indoor_climbing"]
+```
+
 ## How It Works
 
 1. Pulls workouts from the Hevy API

--- a/src/hevy2garmin/config.py
+++ b/src/hevy2garmin/config.py
@@ -39,6 +39,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "hr_fusion": {
         "enabled": True,
     },
+    "merge_activity_types": ["strength_training"],
 }
 
 

--- a/src/hevy2garmin/garmin.py
+++ b/src/hevy2garmin/garmin.py
@@ -212,15 +212,21 @@ def find_matching_garmin_activity(
     hevy_workout: dict,
     overlap_threshold: float = 0.70,
     max_drift_minutes: int = 20,
+    activity_types: set[str] | None = None,
 ) -> dict | None:
-    """Find a user-recorded Garmin Strength Training activity matching a Hevy workout.
+    """Find a user-recorded Garmin activity matching a Hevy workout.
 
     Searches for activities that overlap the Hevy workout's time window,
     then scores by temporal overlap and start-time proximity.
 
     Returns the best-matching activity dict, or None if nothing qualifies.
-    Only matches completed activities of type 'strength_training'.
+    Only matches completed activities whose ``activityType.typeKey`` is in
+    ``activity_types`` (default: ``{"strength_training"}``). Pass additional
+    types (e.g. ``"bouldering"``, ``"indoor_climbing"``) to also enhance
+    non-strength watch activities with Hevy exercise data.
     """
+    if activity_types is None:
+        activity_types = {"strength_training"}
     from datetime import datetime, timedelta, timezone
 
     start_raw = hevy_workout.get("start_time") or hevy_workout.get("startTime", "")
@@ -251,9 +257,9 @@ def find_matching_garmin_activity(
     best: dict | None = None
 
     for act in (activities or []):
-        # Hard filter: strength_training only
+        # Hard filter: only configured activity types are eligible for merge
         act_type = act.get("activityType", {}).get("typeKey", "")
-        if act_type != "strength_training":
+        if act_type not in activity_types:
             continue
 
         # Must be a completed activity (has duration)

--- a/src/hevy2garmin/merge.py
+++ b/src/hevy2garmin/merge.py
@@ -240,7 +240,14 @@ def build_exercise_sets_payload(
 # Orchestrator
 # ---------------------------------------------------------------------------
 
-def attempt_merge(client, hevy_workout: dict, database, overlap_threshold: float = 0.70, max_drift_minutes: int = 20) -> MergeResult:
+def attempt_merge(
+    client,
+    hevy_workout: dict,
+    database,
+    overlap_threshold: float = 0.70,
+    max_drift_minutes: int = 20,
+    activity_types: set[str] | None = None,
+) -> MergeResult:
     """Try to merge Hevy exercise data into a matching Garmin activity.
 
     Returns MergeResult with merged=True if successful, or merged=False
@@ -252,7 +259,7 @@ def attempt_merge(client, hevy_workout: dict, database, overlap_threshold: float
         return MergeResult(merged=False, fallback_reason="Circuit breaker: too many PUT failures")
 
     # Find matching activity
-    match = find_matching_garmin_activity(client, hevy_workout, overlap_threshold=overlap_threshold, max_drift_minutes=max_drift_minutes)
+    match = find_matching_garmin_activity(client, hevy_workout, overlap_threshold=overlap_threshold, max_drift_minutes=max_drift_minutes, activity_types=activity_types)
     if not match:
         return MergeResult(merged=False, fallback_reason="No matching Garmin activity found")
 

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -852,7 +852,10 @@ async def settings_page(request: Request):
             unmapped[name] = count
     except Exception:
         pass
-    return _render("settings.html", config=config, unmapped=sorted(unmapped.items(), key=lambda x: -x[1]))
+    merge_extra_types = ", ".join(
+        t for t in config.get("merge_activity_types", ["strength_training"]) if t != "strength_training"
+    )
+    return _render("settings.html", config=config, unmapped=sorted(unmapped.items(), key=lambda x: -x[1]), merge_extra_types=merge_extra_types)
 
 
 @app.post("/settings")
@@ -866,6 +869,7 @@ async def settings_save(
     description_enabled: str = Form("off"),
     merge_overlap_pct: int = Form(70),
     merge_max_drift_min: int = Form(20),
+    merge_extra_types: str = Form(""),
 ):
     if is_demo_mode():
         return HTMLResponse('<div class="toast toast-error">Settings are read-only in demo mode</div>')
@@ -888,6 +892,14 @@ async def settings_save(
     config["description_enabled"] = description_enabled == "on"
     config["merge_overlap_pct"] = max(50, min(95, merge_overlap_pct))
     config["merge_max_drift_min"] = max(5, min(60, merge_max_drift_min))
+    extra_types = [
+        t.strip().lower().replace(" ", "_")
+        for t in merge_extra_types.split(",")
+        if t.strip()
+    ]
+    config["merge_activity_types"] = ["strength_training"] + [
+        t for t in dict.fromkeys(extra_types) if t != "strength_training"
+    ]
     save_config(config)
 
     # Persist settings to DB on cloud (filesystem is read-only on Vercel)
@@ -902,6 +914,7 @@ async def settings_save(
                 "description_enabled": config["description_enabled"],
                 "merge_overlap_pct": config["merge_overlap_pct"],
                 "merge_max_drift_min": config["merge_max_drift_min"],
+                "merge_activity_types": config["merge_activity_types"],
             })
         except Exception as e:
             logger.warning("Failed to persist settings to DB: %s", e)
@@ -1574,7 +1587,12 @@ async def _do_sync_one(request: Request):
 
         # Merge mode: try to enhance a watch-recorded activity with Hevy data
         if merge_mode:
-            merge_result = attempt_merge(garmin_client, unsynced, db.get_db())
+            merge_result = attempt_merge(
+                garmin_client, unsynced, db.get_db(),
+                overlap_threshold=config.get("merge_overlap_pct", 70) / 100.0,
+                max_drift_minutes=config.get("merge_max_drift_min", 20),
+                activity_types=set(config.get("merge_activity_types", ["strength_training"])),
+            )
             if merge_result.merged:
                 aid = merge_result.activity_id
                 result = {"calories": 0, "avg_hr": None}

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -122,6 +122,7 @@ def sync(
     merge_mode = cfg.get("merge_mode", True)
     merge_overlap_pct = cfg.get("merge_overlap_pct", 70) / 100.0  # convert % to decimal
     merge_max_drift_min = cfg.get("merge_max_drift_min", 20)
+    merge_activity_types = set(cfg.get("merge_activity_types", ["strength_training"]))
     description_enabled = cfg.get("description_enabled", True)
     stats = {"synced": 0, "skipped": 0, "failed": 0, "total": len(workouts), "unmapped": [], "merged": 0, "merge_fallback": 0}
 
@@ -151,7 +152,7 @@ def sync(
         try:
             # ── Merge mode: try to enhance a watch-recorded activity ──
             if merge_mode and garmin_client and not dry_run:
-                merge_result = attempt_merge(garmin_client, workout, db, overlap_threshold=merge_overlap_pct, max_drift_minutes=merge_max_drift_min)
+                merge_result = attempt_merge(garmin_client, workout, db, overlap_threshold=merge_overlap_pct, max_drift_minutes=merge_max_drift_min, activity_types=merge_activity_types)
                 if merge_result.merged:
                     db.mark_synced(
                         hevy_id=wid,

--- a/src/hevy2garmin/templates/settings.html
+++ b/src/hevy2garmin/templates/settings.html
@@ -218,6 +218,15 @@
                         <div class="form-hint">Max difference between Hevy and Garmin start times (default 20 min)</div>
                     </div>
                 </div>
+                <div class="form-grid">
+                    <div class="form-group">
+                        <label class="form-label" for="merge_extra_types">Additional Watch Activity Types</label>
+                        <input class="form-input" type="text" id="merge_extra_types" name="merge_extra_types" value="{{ merge_extra_types }}" placeholder="bouldering, indoor_climbing">
+                        <div class="form-hint">
+                            <strong>Strength Training</strong> is always enhanced. Add other Garmin activity types here (comma-separated, using Garmin's internal name) to also enhance them with the matching Hevy workout — e.g. <code>bouldering</code>, <code>indoor_climbing</code> for climbing sessions.
+                        </div>
+                    </div>
+                </div>
 
                 <hr style="border: none; border-top: 1px solid var(--border); margin: 20px 0;">
 

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -101,6 +101,31 @@ class TestFindMatchingActivity:
         match = find_matching_garmin_activity(client, HEVY_WORKOUT)
         assert match is None
 
+    def test_non_strength_type_rejected_by_default(self):
+        """Climbing activity with perfect overlap → no match unless opted in."""
+        from hevy2garmin.garmin import find_matching_garmin_activity
+
+        client = MagicMock()
+        client.get_activities_by_date.return_value = [
+            _make_garmin_activity(type_key="bouldering"),
+        ]
+        match = find_matching_garmin_activity(client, HEVY_WORKOUT)
+        assert match is None
+
+    def test_non_strength_type_matches_when_configured(self):
+        """Climbing activity matches when its type is added to activity_types."""
+        from hevy2garmin.garmin import find_matching_garmin_activity
+
+        client = MagicMock()
+        client.get_activities_by_date.return_value = [
+            _make_garmin_activity(type_key="bouldering"),
+        ]
+        match = find_matching_garmin_activity(
+            client, HEVY_WORKOUT, activity_types={"strength_training", "bouldering"},
+        )
+        assert match is not None
+        assert match["activityId"] == 12345
+
     def test_incomplete_activity_rejected(self):
         """Activity still in progress (end time in future) → no match."""
         from datetime import datetime, timezone

--- a/tests/test_merge_mode_persist.py
+++ b/tests/test_merge_mode_persist.py
@@ -40,6 +40,23 @@ class TestMergeModeFilePersistence:
             config = load_config()
             assert config.get("merge_mode", True) is True
 
+    def test_merge_activity_types_defaults_to_strength_training(self, tmp_path: Path) -> None:
+        """Without any saved config, merge_activity_types defaults to ['strength_training']."""
+        with patch("hevy2garmin.config.CONFIG_FILE", tmp_path / "missing.json"):
+            config = load_config()
+            assert config["merge_activity_types"] == ["strength_training"]
+
+    def test_merge_activity_types_persists(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "config.json"
+        with patch("hevy2garmin.config.CONFIG_DIR", tmp_path), \
+             patch("hevy2garmin.config.CONFIG_FILE", config_file):
+            config = load_config()
+            config["merge_activity_types"] = ["strength_training", "bouldering", "indoor_climbing"]
+            save_config(config)
+
+            reloaded = load_config()
+            assert reloaded["merge_activity_types"] == ["strength_training", "bouldering", "indoor_climbing"]
+
 
 class TestMergeModeDbPersistence:
     """Verify merge_mode is loaded from DB merge_settings (cloud deployments)."""
@@ -136,3 +153,14 @@ class TestMergeModeDbPersistence:
             assert config["description_enabled"] is False
             assert config["merge_overlap_pct"] == 85
             assert config["merge_max_drift_min"] == 30
+
+    def test_merge_activity_types_loaded_from_db(self, tmp_path: Path) -> None:
+        fake_db = self._make_db_loader([
+            {"key": "merge_settings", "value": {"merge_mode": True, "description_enabled": True,
+                                                  "merge_overlap_pct": 70, "merge_max_drift_min": 20,
+                                                  "merge_activity_types": ["strength_training", "bouldering"]}},
+        ])
+
+        with self._patch_db(tmp_path, fake_db):
+            config = load_config()
+            assert config["merge_activity_types"] == ["strength_training", "bouldering"]


### PR DESCRIPTION
Lands the feature from #157 by @braianrabanal — **merge mode can now fuse non-strength watch activities** (e.g. Indoor Climbing recorded on the watch + logged in Hevy) instead of creating a duplicate.

Adds a `merge_activity_types` setting (default `["strength_training"]`, fully backward-compatible). Extra Garmin activity types can be added under **Settings → Enhance Watch Activities → Advanced**, and `find_matching_garmin_activity` / `attempt_merge` honor it.

This is @braianrabanal's commit cherry-picked onto current `main` (authorship preserved), with their accidental personal `.github/workflows/sync.yml` left out — it shouldn't ship upstream. Supersedes #157.

## Test plan
- [x] Cherry-picked cleanly onto main (post-v0.5.0), no conflicts with the recent merge/HR/sanitize changes.
- [x] Full suite green: **212 passed, 7 skipped**.

Closes #157
