### PR TITLE
fix(auth): mobile-first Garmin login, no rate-limit fallback (#147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 - **Merge into non-strength watch activities** ([#157](https://github.com/drkostas/hevy2garmin/pull/157)) — a `merge_activity_types` setting (default `["strength_training"]`) lets Enhance Watch Activities fuse Hevy workouts into other Garmin activity types you record on the watch (e.g. Indoor Climbing), instead of creating a duplicate. Configure extra types under Settings → Enhance Watch Activities → Advanced. Thanks @braianrabanal.
 
-## [0.5.0] - 2026-06-23
+### Changed
+- **Garmin login is now mobile-first** ([#147](https://github.com/drkostas/hevy2garmin/issues/147), [garmin-auth#29](https://github.com/drkostas/garmin-auth/issues/29)) — the login worker tries Garmin's mobile/app endpoint first (the one built for native 2FA, so MFA accounts no longer take a portal→427→fallback detour) and **no longer retries the other endpoint on a rate limit**. Garmin's login limit is per-account across both endpoints, so the old fallback was deepening the throttle that wouldn't clear. Verified end-to-end on a real 2FA account (login → email MFA → tokens).
 
 ### Added
 - Version + changelog link in the dashboard footer ([#144](https://github.com/drkostas/hevy2garmin/issues/144)) — confirm which build you're running after an upgrade.

--- a/worker-di/index.js
+++ b/worker-di/index.js
@@ -156,19 +156,25 @@ async function handleLogin(request, env) {
     return json({ status: "error", message: "email and password required" }, 400);
   }
 
-  // Try portal (browser-flavoured) first — it's the faster, lower-friction
-  // endpoint. Fall back to mobile when:
-  //   - portal returns Garmin error 427 (MFA-enabled accounts, which
-  //     Garmin forces through the mobile app flow for programmatic auth),
-  //   - portal returns rate_limited (the two endpoints are on different
-  //     rate-limit buckets and mobile may still be open),
-  //   - portal produces any generic error (last-chance retry).
-  const portalResult = await tryLoginFlavour(env, email, password, "portal");
-  if (portalResult.fallback) {
-    const mobileResult = await tryLoginFlavour(env, email, password, "mobile");
-    return mobileResult.response;
-  }
-  return portalResult.response;
+  // Mobile-first: the mobile/app login endpoint is the one Garmin designed for
+  // native MFA, so it's the least likely to reject programmatic logins with a
+  // 427. Fall back to the portal endpoint ONLY on a 427 (MFA-routing). We do
+  // NOT fall back on a 429: Garmin's login rate limit is per-account (it spans
+  // both endpoints), so retrying the other flavour just burns its bucket too
+  // and deepens the throttle that won't clear (#147). On 429 we surface
+  // rate_limited immediately.
+  const first = await tryLoginFlavour(env, email, password, "mobile");
+  if (!first.fallback) return first.response;
+
+  const second = await tryLoginFlavour(env, email, password, "portal");
+  if (!second.fallback) return second.response;
+
+  // 427 on both endpoints → Garmin is steering us to the manual flow.
+  return json({
+    status: "needs_captcha",
+    message:
+      "Garmin returned error 427 on both login flows. Use the manual sign-in fallback.",
+  });
 }
 
 /** Attempt a single login flavour (portal or mobile) and return either a
@@ -261,10 +267,9 @@ async function tryLoginFlavour(env, email, password, flavour) {
 
   // Step 3: parse and branch.
   if (loginResp.status === 429) {
-    // For portal, signal fallback — mobile endpoint uses a different rate
-    // limit bucket and may still be open. For mobile (the last flavour we
-    // try), surface the rate limit to the caller.
-    if (flavour === "portal") return { fallback: true };
+    // Never fall back to the other flavour on a rate limit — Garmin's login
+    // limit is per-account across both endpoints, so retrying just deepens it
+    // (#147). Surface it so the caller can tell the user to wait it out.
     return { response: json({ status: "rate_limited" }) };
   }
   let loginData;
@@ -286,25 +291,13 @@ async function tryLoginFlavour(env, email, password, flavour) {
   // Handle Garmin's custom error envelope.
   const garminErrCode = loginData?.error?.["status-code"];
   if (garminErrCode === "429") {
-    // Same fallback logic as HTTP-level 429.
-    if (flavour === "portal") return { fallback: true };
+    // Per-account rate limit — never retry the other flavour (#147).
     return { response: json({ status: "rate_limited" }) };
   }
   if (garminErrCode === "427") {
-    // Portal endpoint blocks MFA-enabled accounts with 427. Mobile endpoint
-    // should accept them, so signal caller to retry with the other flavour.
-    if (flavour === "portal") {
-      return { fallback: true };
-    }
-    // If we got 427 on the mobile endpoint too, Garmin really is blocking
-    // us. Fall through to the copy-paste UI.
-    return {
-      response: json({
-        status: "needs_captcha",
-        message:
-          "Garmin returned error 427 on both portal and mobile login flows. Use the manual sign-in fallback.",
-      }),
-    };
+    // 427 routes MFA-enabled accounts to a different flow. Signal the caller to
+    // try the other flavour; the caller surfaces needs_captcha if both 427.
+    return { fallback: true };
   }
   if (garminErrCode) {
     return {


### PR DESCRIPTION
## Summary

Reworks the Garmin login worker (`worker-di/index.js`) to fix the persistent rate-limit (#147) and improve native 2FA (garmin-auth#29).

**Before:** tried the **portal** endpoint first, falling back to mobile on `427` **OR `429` OR any error**. Two problems:
- Garmin's login rate limit is **per-account and spans both endpoints** ([python-garminconnect#344](https://github.com/cyberjunky/python-garminconnect/issues/344)), so falling back on a `429` just burned the other bucket too and **deepened the throttle** that wouldn't clear (#147, reported by u/Joucifer, u/wwhetst, u/virgcm).
- The portal endpoint returns `427` for 2FA accounts, forcing **every** MFA login through a portal→427→mobile detour.

**After:**
- **Mobile-first** — try the mobile/app endpoint first (the one Garmin built for native 2FA, so it returns `MFA_REQUIRED` directly instead of `427`).
- Fall back to portal **only on `427`**; `427` on both → manual sign-in fallback.
- **Never retry on `429`** — surface `rate_limited` immediately so the user knows to wait it out instead of deepening the per-account throttle.

## Verification

Tested **end-to-end via `wrangler dev` against a real 2FA-enabled Garmin account**:
1. `POST /login` → `status: needs_mfa`, `mfa_method: email` — went **straight to the mobile endpoint, no 427**.
2. `POST /login-mfa` with the emailed code → `status: success` with DI tokens (`di_client_id: GARMIN_CONNECT_MOBILE_ANDROID_DI_2025Q2`, confirming the mobile flavour carried through the ticket exchange).

> Note: this updates the worker **code**. The live shared worker (`hevy2garmin-exchange-di.gkos.workers.dev`) updates only on a manual `wrangler deploy` — merging this PR does not redeploy it.

Closes #147
