### PR TITLE
release: v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-06-23
+
 ### Added
 - **Merge into non-strength watch activities** ([#157](https://github.com/drkostas/hevy2garmin/pull/157)) — a `merge_activity_types` setting (default `["strength_training"]`) lets Enhance Watch Activities fuse Hevy workouts into other Garmin activity types you record on the watch (e.g. Indoor Climbing), instead of creating a duplicate. Configure extra types under Settings → Enhance Watch Activities → Advanced. Thanks @braianrabanal.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hevy2garmin"
-version = "0.5.0"
+version = "0.5.1"
 description = "Sync Hevy gym workouts to Garmin Connect — exercise mapping, FIT file generation, and automatic upload"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## v0.5.1

### Added
- Merge into non-strength watch activities (#157) — thanks @braianrabanal

### Changed
- Mobile-first Garmin login, no rate-limit fallback (#147, garmin-auth#29) — already deployed to the live worker; this ships the changelog + bumps the package

Bumps `pyproject.toml` 0.5.0 → 0.5.1 (triggers PyPI publish on merge). Full suite green (212 passed).