### PR TITLE
fix(sync): fetch workout by ID so older workouts sync (#165)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **"Workout not found" when syncing older workouts** ([#165](https://github.com/drkostas/hevy2garmin/issues/165)) — the per-workout Upload button and HR fetch now look up the exact workout by ID (`GET /v1/workouts/{id}`) instead of scanning only the first page of 10, so users with more than a page of history can sync any workout, not just recent ones.
+
 ## [0.5.1] - 2026-06-23
 
 ### Added

--- a/src/hevy2garmin/hevy.py
+++ b/src/hevy2garmin/hevy.py
@@ -78,6 +78,26 @@ class HevyClient:
         """Get a page of workouts."""
         return self._get("/workouts", {"page": page, "pageSize": page_size})
 
+    def get_workout(self, workout_id: str) -> dict | None:
+        """Fetch a single workout by ID via ``GET /v1/workouts/{id}``.
+
+        Works for ANY workout regardless of age — unlike scanning a page of
+        recent workouts, which misses older ones and made the dashboard
+        "Upload" button report "Workout not found" for users with more than a
+        page of history (#165). Returns the workout dict, or None if not found.
+        """
+        try:
+            data = self._get(f"/workouts/{workout_id}")
+        except Exception:
+            return None
+        if isinstance(data, dict):
+            if "id" in data:
+                return data
+            # Defensive: handle a wrapped {"workout": {...}} shape too.
+            if isinstance(data.get("workout"), dict):
+                return data["workout"]
+        return None
+
     def get_all_workouts(self, since_page: int = 1, page_size: int = 10) -> list[dict]:
         """Fetch all workouts (paginated). Returns list of workout dicts."""
         all_workouts: list[dict] = []

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -714,9 +714,8 @@ async def api_workout_hr(request: Request, hevy_id: str):
         from garmin_auth import RateLimiter
 
         hevy = HevyClient(api_key=config.get("hevy_api_key"))
-        data = hevy.get_workouts(page=1, page_size=10)
-        workouts = data.get("workouts", [])
-        workout = next((w for w in workouts if w["id"] == hevy_id), None)
+        # Fetch by ID so HR works for older workouts too, not just the first page (#165).
+        workout = hevy.get_workout(hevy_id)
         if not workout:
             return JSONResponse({"error": "Workout not found"}, status_code=404)
 
@@ -1139,8 +1138,9 @@ async def api_sync_single(request: Request, workout_id: str):
         force_upload = request.query_params.get("force") == "1"
 
         config = load_config()
-        data = HevyClient(api_key=config.get("hevy_api_key")).get_workouts(page=1, page_size=10)
-        workout = next((w for w in data.get("workouts", []) if w["id"] == workout_id), None)
+        # Fetch the exact workout by ID — scanning only the first page missed
+        # older workouts for users with more than a page of history (#165).
+        workout = HevyClient(api_key=config.get("hevy_api_key")).get_workout(workout_id)
         if not workout:
             return HTMLResponse('<td colspan="5">Workout not found</td>')
 

--- a/tests/test_hevy.py
+++ b/tests/test_hevy.py
@@ -39,6 +39,26 @@ class TestAPICalls:
             assert len(result["workouts"]) == 1
             mock_get.assert_called_once_with("/workouts", {"page": 1, "pageSize": 10})
 
+    def test_get_workout_by_id(self) -> None:
+        # Fetches the exact workout regardless of age (#165) — directly, not by
+        # scanning a page. The Hevy API returns the workout object at top level.
+        client = HevyClient(api_key="test")
+        wk = {"id": "old-123", "title": "Lower", "exercises": []}
+        with patch.object(client, "_get", return_value=wk) as mock_get:
+            result = client.get_workout("old-123")
+            assert result == wk
+            mock_get.assert_called_once_with("/workouts/old-123")
+
+    def test_get_workout_unwraps_workout_key(self) -> None:
+        client = HevyClient(api_key="test")
+        with patch.object(client, "_get", return_value={"workout": {"id": "x", "title": "P"}}):
+            assert client.get_workout("x") == {"id": "x", "title": "P"}
+
+    def test_get_workout_not_found_returns_none(self) -> None:
+        client = HevyClient(api_key="test")
+        with patch.object(client, "_get", side_effect=RuntimeError("404")):
+            assert client.get_workout("missing") is None
+
     def test_get_exercise_templates(self) -> None:
         client = HevyClient(api_key="test")
         mock_data = {"exercise_templates": [{"id": "e1"}], "page_count": 1}


### PR DESCRIPTION
## Summary

Reported by @KaiBoos: about half their workouts fail with **"Workout not found"** when clicking Upload, even though the workout exists.

**Root cause:** the per-workout Upload endpoint (`api_sync_single`) and the HR fetch resolved a workout by scanning only `get_workouts(page=1, page_size=10)` — the 10 most recent. Anything older than the first page → "Workout not found."

**Fix:** new `HevyClient.get_workout(id)` using `GET /v1/workouts/{id}`, used on both paths, so any workout syncs regardless of age.

## Test plan
- [x] Verified against the **live Hevy API**: fetches an older workout by ID; bogus ID → None gracefully.
- [x] 3 new unit tests (direct fetch, wrapped-shape, not-found).
- [x] Full suite: **215 passed, 7 skipped**.

Closes #165