### PR TITLE
fix(merge): verify names stuck, fall back to named upload (#159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **Exercises showing as "Choose an Exercise" on watch-recorded activities** ([#159](https://github.com/drkostas/hevy2garmin/issues/159)). When you record a strength workout on your Garmin watch and the tool merges Hevy data into it, Garmin accepts the sets but ignores the exercise names, so every set stays "Choose an Exercise". The tool now verifies after the merge whether the names actually stuck. When Garmin drops them, it restores the watch activity and uploads a separate, properly named activity instead, so the exercises are named. Confirmed live against a real Garmin account.
+
 ## [0.5.2] - 2026-06-24
 
 ### Fixed

--- a/src/hevy2garmin/merge.py
+++ b/src/hevy2garmin/merge.py
@@ -12,6 +12,7 @@ Public API:
 from __future__ import annotations
 
 import logging
+import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
@@ -38,6 +39,46 @@ class MergeResult:
     merged: bool
     activity_id: int | None = None
     fallback_reason: str | None = None
+    # Set when the merge pushed sets but Garmin dropped the exercise names on a
+    # watch-recorded activity (#159). Tells the caller to upload a SEPARATE
+    # named activity instead of deduping against the watch activity.
+    force_fresh_upload: bool = False
+
+
+def _names_applied(client, activity_id) -> bool:
+    """Check whether Garmin actually kept the exercise identities after a PUT.
+
+    Watch-recorded strength activities accept the sets (HTTP 204) but silently
+    drop the exercise category/name, leaving every set as "Choose an Exercise"
+    (#159, confirmed live). Returns True if at least one active set came back
+    with a real category, False if the names were dropped. Returns True on any
+    read error so an unverifiable merge is not needlessly discarded.
+    """
+    time.sleep(4)  # let Garmin process the PUT before reading back
+    try:
+        after = get_activity_exercise_sets(client, activity_id)
+    except Exception:
+        return True
+    cats = [
+        e.get("category")
+        for s in (after.get("exerciseSets") or [])
+        if s.get("setType") == "ACTIVE"
+        for e in (s.get("exercises") or [])
+    ]
+    if not cats:
+        return False
+    return any(c and c != "UNKNOWN" for c in cats)
+
+
+def _restore_sets(client, activity_id, database) -> None:
+    """Restore an activity's pre-merge exercise sets from the backup."""
+    try:
+        backup = database.get_app_config(f"merge_backup_{activity_id}")
+        original = (backup or {}).get("original_sets")
+        if original and original.get("exerciseSets") is not None:
+            push_exercise_sets(client, activity_id, original)
+    except Exception as e:
+        logger.warning("Could not restore sets for %s: %s", activity_id, e)
 
 
 def reset_circuit_breaker() -> None:
@@ -293,6 +334,22 @@ def attempt_merge(
         _consecutive_failures += 1
         logger.error("PUT exerciseSets failed for activity %s: %s", activity_id, e)
         return MergeResult(merged=False, fallback_reason=f"PUT failed: {e}")
+
+    # The push returns 204 even when Garmin drops the exercise names on a
+    # watch-recorded activity (#159). Verify the names actually applied; if not,
+    # restore the activity and tell the caller to upload a separate named
+    # activity instead (the only way those users get real exercise names).
+    if not _names_applied(client, activity_id):
+        logger.info(
+            "  Exercise names not applied on watch activity %s — restoring and uploading a named activity",
+            activity_id,
+        )
+        _restore_sets(client, activity_id, database)
+        return MergeResult(
+            merged=False,
+            force_fresh_upload=True,
+            fallback_reason="Garmin dropped exercise names on the watch-recorded activity",
+        )
 
     # Rename + set description
     try:

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -1584,6 +1584,7 @@ async def _do_sync_one(request: Request):
         workout_start = unsynced.get("start_time")
         merge_mode = config.get("merge_mode", True)
         sync_method = "upload"
+        merge_forced_fresh = False
 
         # Merge mode: try to enhance a watch-recorded activity with Hevy data
         if merge_mode:
@@ -1612,6 +1613,7 @@ async def _do_sync_one(request: Request):
                 )
                 remaining = hevy.get_workout_count() - db.get_synced_count()
                 return JSONResponse({"synced": 1, "title": unsynced["title"], "remaining": max(0, remaining), "done": remaining <= 0})
+            merge_forced_fresh = merge_result.force_fresh_upload
 
         # HR enrichment for the uploaded FIT (#158): merged HR (AirPods-preferred,
         # watch fill), best-effort. Computed after the merge early-return so the
@@ -1621,9 +1623,10 @@ async def _do_sync_one(request: Request):
 
         # Dedup: check if this workout already exists on Garmin before uploading.
         # Prevents duplicates when a prior sync uploaded successfully but crashed
-        # before marking the workout as synced in the DB.
+        # before marking the workout as synced in the DB. Skip it when the merge
+        # asked for a fresh named upload (#159), else it finds the watch activity.
         existing_id = None
-        if workout_start:
+        if workout_start and not merge_forced_fresh:
             existing_id = find_activity_by_start_time(garmin_client, workout_start)
 
         if existing_id:

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -151,6 +151,7 @@ def sync(
 
         try:
             # ── Merge mode: try to enhance a watch-recorded activity ──
+            merge_forced_fresh = False
             if merge_mode and garmin_client and not dry_run:
                 merge_result = attempt_merge(garmin_client, workout, db, overlap_threshold=merge_overlap_pct, max_drift_minutes=merge_max_drift_min, activity_types=merge_activity_types)
                 if merge_result.merged:
@@ -168,6 +169,7 @@ def sync(
                 else:
                     logger.info("  Merge fallback: %s", merge_result.fallback_reason)
                     stats["merge_fallback"] += 1
+                    merge_forced_fresh = merge_result.force_fresh_upload
 
             # ── Standard upload path (FIT generation) ──
             # Embed merged HR (AirPods-preferred, watch fill) so it reaches
@@ -190,8 +192,12 @@ def sync(
                     stats["synced"] += 1
                     continue
 
-                # Dedup: check if activity already exists on Garmin
-                existing_id = find_activity_by_start_time(garmin_client, start_time) if start_time else None
+                # Dedup: check if activity already exists on Garmin. Skip the
+                # check when the merge wants a fresh upload (#159) — otherwise it
+                # would find the watch activity and refuse to upload the named one.
+                existing_id = None
+                if start_time and not merge_forced_fresh:
+                    existing_id = find_activity_by_start_time(garmin_client, start_time)
                 if existing_id:
                     logger.info("  Activity already on Garmin (%s), skipping upload", existing_id)
                     activity_id = existing_id

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -328,28 +328,61 @@ class TestCategoryConversion:
 # Integration: attempt_merge
 # ---------------------------------------------------------------------------
 
+_APPLIED = {"exerciseSets": [
+    {"setType": "ACTIVE", "exercises": [{"category": "BENCH_PRESS", "name": "BARBELL_BENCH_PRESS"}]}
+]}
+_DROPPED = {"exerciseSets": [
+    {"setType": "ACTIVE", "exercises": [{"category": None, "name": None}]}
+]}
+
+
 class TestAttemptMerge:
 
     def setup_method(self):
         reset_circuit_breaker()
 
+    @patch("hevy2garmin.merge.time.sleep")  # don't wait for the verify read-back
     @patch("hevy2garmin.merge.find_matching_garmin_activity")
     @patch("hevy2garmin.merge.get_activity_exercise_sets")
     @patch("hevy2garmin.merge.push_exercise_sets")
     @patch("hevy2garmin.merge.rename_activity")
     @patch("hevy2garmin.merge.set_description")
-    def test_merge_path_taken(self, mock_desc, mock_rename, mock_push, mock_get_sets, mock_find):
-        """When a match is found, PUT is called and result is merged=True."""
+    def test_merge_path_taken(self, mock_desc, mock_rename, mock_push, mock_get_sets, mock_find, _sleep):
+        """When a match is found, PUT is called and (if names stick) merged=True."""
         mock_find.return_value = _make_garmin_activity()
-        mock_get_sets.return_value = {"exerciseSets": []}
+        # first read = backup, second read = verify (names applied)
+        mock_get_sets.side_effect = [{"exerciseSets": []}, _APPLIED]
         mock_db = MagicMock()
 
         result = attempt_merge(MagicMock(), HEVY_WORKOUT, mock_db)
 
         assert result.merged is True
+        assert result.force_fresh_upload is False
         assert result.activity_id == 12345
         mock_push.assert_called_once()
         mock_rename.assert_called_once()
+
+    @patch("hevy2garmin.merge.time.sleep")
+    @patch("hevy2garmin.merge.find_matching_garmin_activity")
+    @patch("hevy2garmin.merge.get_activity_exercise_sets")
+    @patch("hevy2garmin.merge.push_exercise_sets")
+    @patch("hevy2garmin.merge.rename_activity")
+    def test_names_dropped_forces_fresh_upload(self, mock_rename, mock_push, mock_get_sets, mock_find, _sleep):
+        """Watch activity drops the names -> merged=False, force_fresh_upload=True (#159)."""
+        mock_find.return_value = _make_garmin_activity()
+        # backup read, then verify read shows the names were dropped
+        mock_get_sets.side_effect = [{"exerciseSets": []}, _DROPPED]
+        mock_db = MagicMock()
+        mock_db.get_app_config.return_value = {"original_sets": {"exerciseSets": []}}
+
+        result = attempt_merge(MagicMock(), HEVY_WORKOUT, mock_db)
+
+        assert result.merged is False
+        assert result.force_fresh_upload is True
+        # PUT happened twice: the merge push + the restore
+        assert mock_push.call_count == 2
+        # we did NOT rename the watch activity since we abandoned the merge
+        mock_rename.assert_not_called()
 
     @patch("hevy2garmin.merge.find_matching_garmin_activity")
     def test_no_match_fallback(self, mock_find):
@@ -379,6 +412,38 @@ class TestAttemptMerge:
         result = attempt_merge(MagicMock(), HEVY_WORKOUT, mock_db)
         assert result.merged is False
         assert "Circuit breaker" in result.fallback_reason
+
+
+class TestNamesApplied:
+    """Verify whether Garmin actually kept the exercise identities (#159)."""
+
+    @patch("hevy2garmin.merge.time.sleep")
+    @patch("hevy2garmin.merge.get_activity_exercise_sets")
+    def test_names_present(self, mock_get, _sleep):
+        from hevy2garmin.merge import _names_applied
+        mock_get.return_value = _APPLIED
+        assert _names_applied(MagicMock(), 1) is True
+
+    @patch("hevy2garmin.merge.time.sleep")
+    @patch("hevy2garmin.merge.get_activity_exercise_sets")
+    def test_names_dropped(self, mock_get, _sleep):
+        from hevy2garmin.merge import _names_applied
+        mock_get.return_value = _DROPPED
+        assert _names_applied(MagicMock(), 1) is False
+
+    @patch("hevy2garmin.merge.time.sleep")
+    @patch("hevy2garmin.merge.get_activity_exercise_sets")
+    def test_no_exercises_at_all(self, mock_get, _sleep):
+        from hevy2garmin.merge import _names_applied
+        mock_get.return_value = {"exerciseSets": []}
+        assert _names_applied(MagicMock(), 1) is False
+
+    @patch("hevy2garmin.merge.time.sleep")
+    @patch("hevy2garmin.merge.get_activity_exercise_sets")
+    def test_read_error_assumes_applied(self, mock_get, _sleep):
+        from hevy2garmin.merge import _names_applied
+        mock_get.side_effect = RuntimeError("boom")
+        assert _names_applied(MagicMock(), 1) is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #159 (ZHumphries) and the same symptom in silas_christopher's reports: when you record a strength workout on your Garmin watch and the tool merges Hevy data into it, every exercise shows as **"Choose an Exercise"**.

## Root cause (confirmed live, not inferred)

I ran three experiments against a real Garmin account (all cleaned up afterward):
1. Create-new FIT upload, exercises named correctly.
2. PUT a different exercise onto an uploaded activity, it changed.
3. PUT into a blank strength activity, it added named exercises.

So the `exerciseSets` PUT works. But ZHumphries' Docker log shows `Pushed 25 exercise sets to activity 23267281336` (the push returned 204) and the names still do not show. He records on a Fenix 6 and syncs after. Conclusion: **Garmin accepts the sets on a watch-recorded activity but silently ignores the exercise identity.** The push only names exercises on activities the tool uploads itself.

## Fix (option B from the issue discussion)

After the merge push, read the sets back and check whether the names actually applied. When Garmin dropped them:
- restore the watch activity from the pre-merge backup, and
- return `force_fresh_upload`, which tells the caller to upload a separate, properly named activity instead of deduping against the watch activity (the dedup would otherwise find it by start time and skip the upload).

Self-correcting: it keeps the single-activity merge whenever Garmin honors the names, and only falls back to a named upload when it does not. The tradeoff, accepted in the issue, is that the named activity is separate from the watch activity, so the watch HR stays on the watch one.

## Test plan
- [x] New unit tests: `_names_applied` (present, dropped, empty, read-error), and `attempt_merge` returning `force_fresh_upload=True` with a restore when names drop, `merged=True` when they stick.
- [x] Dedup-skip wired into both sync paths (`sync.py` and the dashboard `_do_sync_one`).
- [x] Full suite: 220 passed, 7 skipped.

Note: the watch-activity drop itself cannot be unit-tested (no watch in CI), but the building blocks are all verified live, and ZHumphries' log confirms the production symptom.

Closes #159
