### PR TITLE
fix(sync): scan whole history so backfill reaches old workouts (#165)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **Backfill not reaching older workouts** ([#165](https://github.com/drkostas/hevy2garmin/issues/165)). The "Sync N Workouts" backfill searched only the first few pages of Hevy history, so when the recent workouts were already synced and the unsynced ones were older, it stopped before finding them and reported done. It now scans the whole history. Together with the earlier fetch-by-ID fix, both the bulk backfill and the per-workout Upload reach any workout regardless of age.
+
 ## [0.5.3] - 2026-06-24
 
 ### Fixed

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -1516,6 +1516,43 @@ async def api_sync_one(request: Request):
         _sync_executing.release()
 
 
+def _scan_for_unsynced(hevy, is_synced, total_count, failed_ids, on_page=None):
+    """Find the first unsynced Hevy workout, scanning the whole history.
+
+    When the recent workouts are already synced and the unsynced ones are older
+    (deep in the list), the search must page far enough back to reach them, so
+    the cap covers the whole history (#165). Breaks as soon as an unsynced
+    workout is found or the last Hevy page is reached. Returns
+    ``(unsynced_workout_or_None, unmapped_counts)``.
+    """
+    from hevy2garmin.mapper import lookup_exercise
+
+    unsynced = None
+    unmapped: dict[str, int] = {}
+    page = 1
+    max_pages = (total_count // 10) + 2
+    while page <= max_pages:
+        data = hevy.get_workouts(page=page, page_size=10)
+        workouts = data.get("workouts", [])
+        if not workouts:
+            break
+        if on_page is not None:
+            on_page(page, data)
+        for w in workouts:
+            if not unsynced and not is_synced(w["id"]) and w["id"] not in failed_ids:
+                unsynced = w
+            for ex in w.get("exercises", []):
+                name = ex.get("title") or ex.get("name", "")
+                if name and lookup_exercise(name)[0] == 65534:
+                    unmapped[name] = unmapped.get(name, 0) + 1
+        if unsynced:
+            break
+        if page >= data.get("page_count", page):
+            break
+        page += 1
+    return unsynced, unmapped
+
+
 async def _do_sync_one(request: Request):
     """Inner sync logic, called with _sync_executing lock held."""
     from fastapi.responses import JSONResponse
@@ -1541,34 +1578,15 @@ async def _do_sync_one(request: Request):
     synced_count = db.get_synced_count()
     remaining = max(0, total_count - synced_count)
 
-    unsynced = None
-    unmapped_found: dict[str, int] = {}
-    page = 1
-    max_pages = min(10, (remaining // 10) + 2)  # Don't search forever
-    while page <= max_pages:
-        data = hevy.get_workouts(page=page, page_size=10)
-        workouts = data.get("workouts", [])
-        if not workouts:
-            break
-        # Refresh the workouts-page cache while we already have the data
+    def _cache_page(pg, data):
         _db.set_app_config(
-            f"hevy_workouts_page_{page}",
-            {"workouts": workouts, "page_count": data.get("page_count", 1)},
+            f"hevy_workouts_page_{pg}",
+            {"workouts": data.get("workouts", []), "page_count": data.get("page_count", 1)},
         )
-        for w in workouts:
-            if not unsynced and not db.is_synced(w["id"]) and w["id"] not in _failed_ids:
-                unsynced = w
-            # Track unmapped exercises while we're iterating
-            from hevy2garmin.mapper import lookup_exercise
-            for ex in w.get("exercises", []):
-                name = ex.get("title") or ex.get("name", "")
-                if name and lookup_exercise(name)[0] == 65534:
-                    unmapped_found[name] = unmapped_found.get(name, 0) + 1
-        if unsynced:
-            break
-        if page >= data.get("page_count", page):
-            break
-        page += 1
+
+    unsynced, unmapped_found = _scan_for_unsynced(
+        hevy, db.is_synced, total_count, _failed_ids, on_page=_cache_page
+    )
     # Update unmapped cache in DB
     if unmapped_found:
         _db.set_app_config("unmapped_exercises", unmapped_found)

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -1,0 +1,56 @@
+"""The backfill scan must reach old unsynced workouts deep in the history (#165)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from hevy2garmin.server import _scan_for_unsynced
+
+
+def _fake_hevy(num_pages: int, page_size: int = 10):
+    """A Hevy client returning num_pages pages of page_size workouts (w0, w1, ...)."""
+    def get_workouts(page: int, page_size: int = 10):
+        start = (page - 1) * page_size
+        workouts = [{"id": f"w{start + i}", "exercises": []} for i in range(page_size)]
+        return {"workouts": workouts, "page_count": num_pages}
+
+    client = MagicMock()
+    client.get_workouts.side_effect = get_workouts
+    return client, num_pages * page_size
+
+
+def test_finds_unsynced_deep_in_history():
+    # 7 pages (70 workouts), only the one on page 6 is unsynced
+    client, total = _fake_hevy(7)
+    target = "w55"  # page 6
+    unsynced, _ = _scan_for_unsynced(client, lambda wid: wid != target, total, set())
+    assert unsynced is not None
+    assert unsynced["id"] == target
+
+
+def test_none_when_all_synced():
+    client, total = _fake_hevy(7)
+    unsynced, _ = _scan_for_unsynced(client, lambda wid: True, total, set())
+    assert unsynced is None
+
+
+def test_breaks_early_on_first_page():
+    client, total = _fake_hevy(7)
+    unsynced, _ = _scan_for_unsynced(client, lambda wid: wid != "w0", total, set())
+    assert unsynced["id"] == "w0"
+    assert client.get_workouts.call_count == 1  # did not page past the match
+
+
+def test_skips_failed_ids():
+    client, total = _fake_hevy(2)
+    # w5 is unsynced but quarantined; the next unsynced is w8
+    is_synced = lambda wid: wid not in ("w5", "w8")
+    unsynced, _ = _scan_for_unsynced(client, is_synced, total, {"w5"})
+    assert unsynced["id"] == "w8"
+
+
+def test_does_not_page_past_last_page():
+    client, total = _fake_hevy(3)
+    # nothing unsynced; should stop at page_count (3), not loop forever
+    _scan_for_unsynced(client, lambda wid: True, total, set())
+    assert client.get_workouts.call_count == 3


### PR DESCRIPTION
## Summary

Reopened by @KaiBoos: after updating, the bulk "Sync N Workouts" still does not sync the old workouts. Screenshots show 25 pending workouts on pages 6 to 7 of the list, and the backfill reporting done without touching them.

**Root cause:** `_do_sync_one` searched for the next unsynced workout with `max_pages = min(10, (remaining // 10) + 2)`. When the recent workouts are already synced and the unsynced ones are older, the search stopped before reaching them.

**Fix:** scan the whole history (`(total_count // 10) + 2` pages). The loop still breaks as soon as it finds an unsynced workout or reaches the last Hevy page, so it is not slower in the common case. Extracted the search into `_scan_for_unsynced` so it is unit-tested.

## Test plan
- [x] 5 new unit tests: reaches an unsynced workout on page 6, returns None when all synced, breaks early on a page-1 match, skips quarantined ids, stops at the last page.
- [x] Full suite: 225 passed, 7 skipped.

Note: KaiBoos's Vercel also shows the live deployment is a "Redeploy of" an older build sitting above the fresh commit, so part of what they saw (per-workout Upload still failing) is likely an old build still running. The footer version will confirm.

Closes #165