### PR TITLE
fix(mappings): drop mapped exercises from the unmapped list (#172)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **Mapped exercises stayed in the "Unknown" list** ([#172](https://github.com/drkostas/hevy2garmin/issues/172)). After mapping an exercise on the Mappings page, it kept showing as unmapped until the next sync or a restart, even after a reload. The unmapped list now filters out exercises that already have a mapping, and a saved mapping is dropped from the cached list right away. Thanks @KaiBoos.
+
 ## [0.5.4] - 2026-06-25
 
 ### Fixed

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -90,13 +90,25 @@ def _acquire_sync_lock() -> bool:
 
 
 def _get_unmapped_exercises() -> list[tuple[str, int]]:
-    """Get unmapped exercises. Uses DB cache (updated during sync)."""
+    """Get unmapped exercises. Uses DB cache (updated during sync).
+
+    Exercises that now have a mapping are filtered out, so a freshly mapped one
+    leaves the list immediately instead of lingering until the next sync (#172).
+    """
+    from hevy2garmin.mapper import lookup_exercise
+
+    def _still_unmapped(items):
+        return sorted(
+            ((name, count) for name, count in items if lookup_exercise(name)[0] == 65534),
+            key=lambda x: -x[1],
+        )
+
     # Try DB cache first (instant)
     try:
         _db = db.get_db()
         cached = _db.get_app_config("unmapped_exercises")
         if cached and isinstance(cached, dict):
-            return sorted(cached.items(), key=lambda x: -x[1])
+            return _still_unmapped(cached.items())
     except Exception:
         pass
 
@@ -952,6 +964,18 @@ async def api_save_mapping(request: Request):
 
     global _unmapped_cache
     _unmapped_cache = None
+
+    # Drop the just-mapped exercise from the cached unmapped list (DB + memory).
+    # The cache is only rebuilt during a sync, so without this the exercise kept
+    # showing as "Unknown" on the Mappings page even after a reload (#172).
+    try:
+        _db2 = db.get_db()
+        cached = _db2.get_app_config("unmapped_exercises")
+        if isinstance(cached, dict) and hevy_name in cached:
+            del cached[hevy_name]
+            _db2.set_app_config("unmapped_exercises", cached)
+    except Exception as e:
+        logger.debug("Could not update unmapped cache after mapping: %s", e)
 
     cat_label = _get_cat_names().get(category, f"Category {category}")
     return HTMLResponse(f'<div class="toast toast-success">Mapped "{hevy_name}" → {cat_label} ({category}:{subcategory}). <a href="/mappings">Reload</a></div>')

--- a/tests/test_mappings_refresh.py
+++ b/tests/test_mappings_refresh.py
@@ -1,0 +1,30 @@
+"""Mapped exercises must leave the unmapped list immediately (#172)."""
+from __future__ import annotations
+from unittest.mock import MagicMock, patch
+from hevy2garmin.server import _get_unmapped_exercises
+
+
+def test_filters_out_now_mapped_exercises():
+    fake_db = MagicMock()
+    fake_db.get_app_config.return_value = {
+        "Totally Invented Movement 9000": 3,  # genuinely unmapped
+        "Bench Press (Barbell)": 2,           # has a built-in mapping
+    }
+    with patch("hevy2garmin.server.db.get_db", return_value=fake_db):
+        result = _get_unmapped_exercises()
+    names = [n for n, _ in result]
+    assert "Totally Invented Movement 9000" in names
+    assert "Bench Press (Barbell)" not in names
+
+
+def test_custom_mapped_exercise_is_filtered():
+    import hevy2garmin.mapper as m
+    m._custom_mappings["Seitheben (Kurzhantel)"] = (14, 11)  # just mapped
+    try:
+        fake_db = MagicMock()
+        fake_db.get_app_config.return_value = {"Seitheben (Kurzhantel)": 1}
+        with patch("hevy2garmin.server.db.get_db", return_value=fake_db):
+            result = _get_unmapped_exercises()
+        assert all(n != "Seitheben (Kurzhantel)" for n, _ in result)
+    finally:
+        m._custom_mappings.pop("Seitheben (Kurzhantel)", None)


### PR DESCRIPTION
## Summary

Reported by @KaiBoos with a video (#172). After mapping an exercise on the Mappings page, the success toast shows but the exercise stays in the "Unknown" list, and stays there even after a reload, until the next sync or a restart.

**Cause:** the unmapped list comes from a DB cache (`unmapped_exercises`, rebuilt during sync). Saving a mapping did not touch that cache, so the exercise lingered.

**Fix:**
- `api_save_mapping` removes the exercise from the cached `unmapped_exercises` immediately, so the next page load is correct regardless of serverless in-memory state.
- `_get_unmapped_exercises` also filters out anything that now resolves to a real category.

## Test plan
- [x] New tests: a built-in-mapped and a custom-mapped exercise are both filtered out of the unmapped list.
- [x] Full suite: 227 passed, 7 skipped.

Closes #172