### PR TITLE
feat(ui): Reload Data button to refetch Hevy workouts (#174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **"Reload Data" button on the Workouts page** ([#174](https://github.com/drkostas/hevy2garmin/issues/174)). The page serves cached workout data, so editing a workout in Hevy was not reflected until the next sync. The button refetches your latest workouts from Hevy on demand. Thanks @KaiBoos.
+
 ## [0.5.5] - 2026-06-25
 
 ### Fixed

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -981,6 +981,33 @@ async def api_save_mapping(request: Request):
     return HTMLResponse(f'<div class="toast toast-success">Mapped "{hevy_name}" → {cat_label} ({category}:{subcategory}). <a href="/mappings">Reload</a></div>')
 
 
+@app.post("/api/reload-data", response_class=HTMLResponse)
+async def api_reload_data(request: Request):
+    """Clear the cached Hevy workout data so the dashboard refetches from Hevy.
+
+    The workouts page serves cached pages (populated during sync), so editing a
+    workout in Hevy was not reflected until the next sync. This button drops the
+    cached pages and reloads with fresh data (#174).
+    """
+    if is_demo_mode():
+        return HTMLResponse('<div class="toast toast-error">Read-only in demo mode</div>')
+    config = load_config()
+    try:
+        from hevy2garmin.hevy import HevyClient
+        _db = db.get_db()
+        total = HevyClient(api_key=config.get("hevy_api_key")).get_workout_count()
+        _db.set_app_config("hevy_total", {"count": total})
+        for pg in range(1, (total // 10) + 2):
+            _db.set_app_config(f"hevy_workouts_page_{pg}", {})
+        global _unmapped_cache
+        _unmapped_cache = None
+        # HX-Refresh tells htmx to reload the page, which refetches fresh data.
+        return HTMLResponse("", headers={"HX-Refresh": "true"})
+    except Exception as e:
+        logger.warning("Reload data failed: %s", e)
+        return HTMLResponse(f'<div class="toast toast-error">Reload failed: {str(e)[:120]}</div>')
+
+
 @app.post("/api/mapping/delete", response_class=HTMLResponse)
 async def api_delete_mapping(request: Request):
     """Delete a custom exercise mapping."""

--- a/src/hevy2garmin/templates/workouts.html
+++ b/src/hevy2garmin/templates/workouts.html
@@ -83,6 +83,17 @@
     <div>
         <h1>Your Hevy Workouts</h1>
         <p>Recent workouts from Hevy with sync status and exercise details</p>
+        <button class="btn btn-secondary btn-sm"
+                hx-post="/api/reload-data"
+                hx-target="#reload-toast"
+                hx-swap="innerHTML"
+                hx-indicator="this"
+                style="margin-top: 8px;"
+                title="Refetch your latest workouts from Hevy. Use this after you edit a workout in Hevy.">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M23 4v6h-6M1 20v-6h6"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>
+            Reload Data
+        </button>
+        <div id="reload-toast"></div>
     </div>
     {% if page_count > 1 %}
     <div style="display: flex; align-items: center; gap: 8px;">

--- a/tests/test_reload.py
+++ b/tests/test_reload.py
@@ -1,0 +1,41 @@
+"""Reload Data button clears the cached Hevy workout pages (#174)."""
+from __future__ import annotations
+import os
+from unittest.mock import MagicMock, patch
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("HEVY2GARMIN_SECRET", None)
+        os.environ.pop("DEMO_MODE", None)
+        import hevy2garmin.server as srv
+        srv._is_configured_cache = True  # skip the setup-redirect gate
+        yield TestClient(srv.app)
+
+
+def test_reload_clears_page_caches_and_refreshes(client):
+    fake_db = MagicMock()
+    mock_hevy = MagicMock()
+    mock_hevy.get_workout_count.return_value = 25
+    with patch("hevy2garmin.server.is_configured", return_value=True), \
+         patch("hevy2garmin.server.is_demo_mode", return_value=False), \
+         patch("hevy2garmin.hevy.HevyClient", return_value=mock_hevy), \
+         patch("hevy2garmin.server.db.get_db", return_value=fake_db):
+        resp = client.post("/api/reload-data")
+    assert resp.headers.get("HX-Refresh") == "true"
+    cleared = [c.args for c in fake_db.set_app_config.call_args_list
+               if c.args[0].startswith("hevy_workouts_page_")]
+    # 25 workouts -> pages 1..3 cleared, all set to {}
+    assert len(cleared) >= 3
+    assert all(val == {} for _, val in cleared)
+
+
+def test_reload_blocked_in_demo(client):
+    with patch("hevy2garmin.server.is_configured", return_value=True), \
+         patch("hevy2garmin.server.is_demo_mode", return_value=True):
+        resp = client.post("/api/reload-data")
+    assert "demo" in resp.text.lower()
+    assert resp.headers.get("HX-Refresh") is None


### PR DESCRIPTION
## Summary

Requested by @KaiBoos (#174): when you edit a workout in Hevy before uploading, the dashboard serves stale cached data. This adds a **Reload Data** button on the Workouts page that drops the cached pages and reloads with fresh data from Hevy.

## Test plan
- [x] Unit tests: clears `hevy_workouts_page_*` caches and returns HX-Refresh; blocked in demo mode.
- [x] Button rendering verified with Playwright on the live workouts page.
- [x] Full suite: 229 passed, 7 skipped.

Closes #174