### PR TITLE
fix(ui): auto-sync interval dropdown sends selected value (#177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **Auto-sync interval always reset to 2 hours** ([#177](https://github.com/drkostas/hevy2garmin/issues/177)). The interval dropdown read its value with `this.value` inside an htmx hx-vals expression, which did not resolve, so every change saved the default (120 min). It now reads the selected value explicitly, so your chosen interval sticks. Thanks @KaiBoos.
+
 ## [0.5.6] - 2026-06-25
 
 ### Added

--- a/src/hevy2garmin/templates/dashboard.html
+++ b/src/hevy2garmin/templates/dashboard.html
@@ -165,7 +165,7 @@
                 hx-post="/api/toggle-autosync"
                 hx-target="#autosync-status"
                 hx-swap="innerHTML"
-                hx-vals='js:{"enabled": document.getElementById("autosync-toggle").classList.contains("active"), "interval": this.value}'
+                hx-vals='js:{"enabled": document.getElementById("autosync-toggle").classList.contains("active"), "interval": document.getElementById("autosync-interval").value}'
                 hx-disabled-elt="this, #autosync-toggle"
                 hx-indicator="#autosync-spinner, #autosync-status"
                 hx-trigger="change"

--- a/tests/test_autosync_interval.py
+++ b/tests/test_autosync_interval.py
@@ -1,0 +1,19 @@
+"""The auto-sync interval dropdown must send the real selected value (#177)."""
+from __future__ import annotations
+from pathlib import Path
+
+DASH = Path(__file__).resolve().parent.parent / "src" / "hevy2garmin" / "templates" / "dashboard.html"
+
+
+def _interval_select_block() -> str:
+    html = DASH.read_text()
+    i = html.index('id="autosync-interval"')
+    return html[i:i + 600]
+
+
+def test_interval_dropdown_uses_explicit_value_not_this():
+    block = _interval_select_block()
+    # this.value did not resolve in htmx hx-vals, so the POST always sent the
+    # default (120). The dropdown must read the element value explicitly.
+    assert 'document.getElementById("autosync-interval").value' in block
+    assert '"interval": this.value' not in block


### PR DESCRIPTION
## Summary

Reported by @KaiBoos with a video (#177): the auto-sync interval can be changed in the dropdown but always reverts to 2 hours.

**Cause:** the dropdown computed its `hx-vals` interval with `this.value`, which does not resolve to the select's value in htmx's hx-vals context, so the POST sent no interval and the endpoint fell back to the default (120 min). The toggle button next to it already used the explicit `document.getElementById(...).value`.

**Fix:** the dropdown now reads its value the same explicit way.

## Test plan
- [x] Playwright against a live server: selecting 6 hours persists 360 (was 120 regardless), and the status text updates to match.
- [x] Regression test asserting the template no longer uses `this.value`.
- [x] Full suite: 236 passed, 7 skipped.

Closes #177