### PR TITLE
fix(merge): detect watch-recorded activities by manufacturer (#159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **Exercises showing as "Unknown" on watch-recorded workouts** ([#159](https://github.com/drkostas/hevy2garmin/issues/159)). When a workout was recorded on a Garmin watch, merge mode pushed the exercise sets, but Garmin ignores pushed exercise identities on activities it recorded itself, so they showed "Unknown" with no reps. The tool now checks the matched activity's manufacturer and, for any activity it did not create (a watch, etc.), uploads a fresh named activity instead of merging. Heart-rate fusion still pulls the watch HR into it. Confirmed against the live Garmin API.
+
 ## [0.5.7] - 2026-06-26
 
 ### Fixed

--- a/src/hevy2garmin/merge.py
+++ b/src/hevy2garmin/merge.py
@@ -311,6 +311,26 @@ def attempt_merge(
     if not activity_id or not act_start or not act_duration:
         return MergeResult(merged=False, fallback_reason="Matched activity missing required fields")
 
+    # Garmin only displays pushed exercise identities on activities hevy2garmin
+    # created itself (FIT manufacturer "DEVELOPMENT"). On device-recorded
+    # activities (a watch, manufacturer "GARMIN", etc.) the exerciseSets PUT
+    # returns 204 but Garmin ignores it, so the activity shows "Unknown" with no
+    # reps (#159, confirmed against the live API). Reading the sets back cannot
+    # detect this, since the read reflects stored, not displayed, state. So for
+    # any match we did not create, skip the merge and upload a fresh named
+    # activity instead. HR fusion still pulls the watch heart rate into it.
+    manufacturer = str(match.get("manufacturer") or "").upper()
+    if manufacturer and manufacturer != "DEVELOPMENT":
+        logger.info(
+            "  Match %s was recorded by %s, not hevy2garmin — uploading a named activity instead of merging",
+            activity_id, manufacturer,
+        )
+        return MergeResult(
+            merged=False,
+            force_fresh_upload=True,
+            fallback_reason=f"activity recorded by {manufacturer}; Garmin will not show merged exercise names, uploading a named activity",
+        )
+
     # Backup existing exercise sets
     try:
         existing_sets = get_activity_exercise_sets(client, activity_id)

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -414,6 +414,43 @@ class TestAttemptMerge:
         assert "Circuit breaker" in result.fallback_reason
 
 
+@patch("hevy2garmin.merge.find_matching_garmin_activity")
+@patch("hevy2garmin.merge.push_exercise_sets")
+def test_watch_recorded_match_skips_merge(mock_push, mock_find):
+    """A device-recorded match (manufacturer != DEVELOPMENT) is never merged;
+    it forces a fresh named upload, since Garmin ignores pushed names there (#159)."""
+    reset_circuit_breaker()
+    act = _make_garmin_activity()
+    act["manufacturer"] = "GARMIN"  # recorded on a watch
+    mock_find.return_value = act
+
+    result = attempt_merge(MagicMock(), HEVY_WORKOUT, MagicMock())
+
+    assert result.merged is False
+    assert result.force_fresh_upload is True
+    mock_push.assert_not_called()  # we never push to a watch activity
+
+
+@patch("hevy2garmin.merge.time.sleep")
+@patch("hevy2garmin.merge.find_matching_garmin_activity")
+@patch("hevy2garmin.merge.get_activity_exercise_sets")
+@patch("hevy2garmin.merge.push_exercise_sets")
+@patch("hevy2garmin.merge.rename_activity")
+@patch("hevy2garmin.merge.set_description")
+def test_development_upload_still_merges(mock_desc, mock_rename, mock_push, mock_get, mock_find, _sleep):
+    """A hevy2garmin upload (manufacturer DEVELOPMENT) is still merged normally."""
+    reset_circuit_breaker()
+    act = _make_garmin_activity()
+    act["manufacturer"] = "DEVELOPMENT"
+    mock_find.return_value = act
+    mock_get.side_effect = [{"exerciseSets": []}, _APPLIED]
+
+    result = attempt_merge(MagicMock(), HEVY_WORKOUT, MagicMock())
+
+    assert result.merged is True
+    mock_push.assert_called_once()
+
+
 class TestNamesApplied:
     """Verify whether Garmin actually kept the exercise identities (#159)."""
 


### PR DESCRIPTION
## Root cause (traced in code, confirmed on the live API)

Merge mode pushes `exerciseSets` to the matched pre-existing Garmin activity. Garmin only **displays** pushed exercise identities on activities hevy2garmin created itself (FIT `manufacturer = DEVELOPMENT`). On a watch-recorded activity (`manufacturer = GARMIN`) the PUT returns 204 but Garmin ignores it, so the activity shows **"Unknown" with 0 reps**, which is exactly what @lozbrown and @ZHumphries see.

The v0.5.3 read-back verify could never catch this: the read-back reflects what Garmin **stored**, not what it **displays**, so it reported success and the fallback never fired.

I confirmed this on a real account via the garmin API:
- A hevy2garmin upload (`DEVELOPMENT`) has fully named exercise sets through the same API the merge uses.
- The activity summary dict already carries a top-level `manufacturer` field, so detecting the source needs no extra call.

## Fix

Before pushing, check `match["manufacturer"]`. If it is not `DEVELOPMENT` (a watch or any other source we did not create), skip the merge and return `force_fresh_upload`, so the caller uploads a fresh, named activity. HR fusion still pulls the watch heart rate into the new activity. The read-back verify stays as a backstop for matches with no manufacturer.

Tradeoff (unavoidable given the Garmin limitation): a watch-recorder ends up with two activities, the watch one with HR and the named upload with the exercises.

## Test plan
- [x] New tests: a `GARMIN` match skips the push and forces a named upload; a `DEVELOPMENT` match still merges.
- [x] Full suite: 238 passed, 7 skipped.

Closes #159