### PR TITLE
feat(merge): one activity for watch-recorded workouts (#159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **One activity for watch-recorded workouts** ([#159](https://github.com/drkostas/hevy2garmin/issues/159)). New setting "Workouts recorded on a watch" (Settings, Advanced). The default "Replace" uploads a single named activity with your heart rate and deletes the watch recording, so you get one activity with named exercises and no double-counted calories or activity totals. "Keep" leaves the watch activity untouched and lists the exercises in its description instead.
+
 ## [0.5.8] - 2026-06-26
 
 ### Fixed

--- a/src/hevy2garmin/config.py
+++ b/src/hevy2garmin/config.py
@@ -40,6 +40,13 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "enabled": True,
     },
     "merge_activity_types": ["strength_training"],
+    # What to do when a workout was recorded on a watch (Garmin will not show
+    # pushed exercise names on those). "replace": upload one named activity and
+    # delete the watch recording (default, single activity with named exercises).
+    # "describe": keep the watch activity untouched and just list the exercises in
+    # its description (preserves the watch HR + metrics, structured list stays
+    # generic). (#159)
+    "merge_watch_strategy": "replace",
 }
 
 

--- a/src/hevy2garmin/garmin.py
+++ b/src/hevy2garmin/garmin.py
@@ -195,6 +195,16 @@ def set_description(client: Garmin, activity_id: int, description: str) -> None:
     logger.info("  Description set (%d chars)", len(description))
 
 
+def delete_activity(client: Garmin, activity_id: int) -> None:
+    """Delete a Garmin activity.
+
+    Used to remove a watch-recorded activity after uploading a named
+    replacement, so the workout appears exactly once on Garmin (#159).
+    """
+    _limiter.call(client.delete_activity, activity_id)
+    logger.info("  Deleted activity %s", activity_id)
+
+
 def upload_image(client: Garmin, activity_id: int, image_bytes: bytes, filename: str = "image.png") -> None:
     """Upload an image to a Garmin activity."""
     files = {"file": (filename, io.BytesIO(image_bytes))}

--- a/src/hevy2garmin/merge.py
+++ b/src/hevy2garmin/merge.py
@@ -43,6 +43,9 @@ class MergeResult:
     # watch-recorded activity (#159). Tells the caller to upload a SEPARATE
     # named activity instead of deduping against the watch activity.
     force_fresh_upload: bool = False
+    # Watch activity id to delete AFTER a successful fresh upload, so the workout
+    # ends up as a single named activity ("replace" strategy, #159).
+    delete_after_upload: int | None = None
 
 
 def _names_applied(client, activity_id) -> bool:
@@ -277,6 +280,17 @@ def build_exercise_sets_payload(
     return {"activityId": activity_id, "exerciseSets": exercise_sets}
 
 
+def _apply_name_and_description(client, activity_id, hevy_workout) -> None:
+    """Rename a Garmin activity to the Hevy title and set its exercise description."""
+    title = hevy_workout.get("title", "Workout")
+    rename_activity(client, activity_id, title)
+    desc = generate_description(hevy_workout)
+    note = "synced by hevy2garmin"
+    if not desc.rstrip().endswith(note):
+        desc = f"{desc}\n{note}"
+    set_description(client, activity_id, f"Exercises synced from Hevy by hevy2garmin\n\n{desc}")
+
+
 # ---------------------------------------------------------------------------
 # Orchestrator
 # ---------------------------------------------------------------------------
@@ -288,6 +302,7 @@ def attempt_merge(
     overlap_threshold: float = 0.70,
     max_drift_minutes: int = 20,
     activity_types: set[str] | None = None,
+    watch_strategy: str = "replace",
 ) -> MergeResult:
     """Try to merge Hevy exercise data into a matching Garmin activity.
 
@@ -321,14 +336,31 @@ def attempt_merge(
     # activity instead. HR fusion still pulls the watch heart rate into it.
     manufacturer = str(match.get("manufacturer") or "").upper()
     if manufacturer and manufacturer != "DEVELOPMENT":
+        if watch_strategy == "describe":
+            # Keep the single watch activity (its HR + device metrics) and just
+            # list the exercises in its description. No push (Garmin ignores it
+            # on watch activities anyway) and no upload, so it stays one activity.
+            logger.info(
+                "  Match %s recorded by %s; enriching its description (watch_strategy=describe)",
+                activity_id, manufacturer,
+            )
+            try:
+                _apply_name_and_description(client, activity_id, hevy_workout)
+            except Exception as e:
+                logger.warning("Rename/description failed for %s: %s", activity_id, e)
+            return MergeResult(merged=True, activity_id=activity_id)
+
+        # Default "replace": upload one named activity, then delete the watch
+        # recording, so the workout shows up exactly once with named exercises.
         logger.info(
-            "  Match %s was recorded by %s, not hevy2garmin — uploading a named activity instead of merging",
+            "  Match %s recorded by %s; uploading a named activity and removing the watch copy (watch_strategy=replace)",
             activity_id, manufacturer,
         )
         return MergeResult(
             merged=False,
             force_fresh_upload=True,
-            fallback_reason=f"activity recorded by {manufacturer}; Garmin will not show merged exercise names, uploading a named activity",
+            delete_after_upload=activity_id,
+            fallback_reason=f"activity recorded by {manufacturer}; replacing it with a named upload",
         )
 
     # Backup existing exercise sets
@@ -373,15 +405,9 @@ def attempt_merge(
 
     # Rename + set description
     try:
-        rename_activity(client, activity_id, title)
-        desc = generate_description(hevy_workout)
-        if not desc.endswith("— synced by hevy2garmin"):
-            desc += "\n— synced by hevy2garmin"
-        # Prepend merge note
-        desc = "⚡ Exercises synced from Hevy by hevy2garmin\n\n" + desc
-        set_description(client, activity_id, desc)
+        _apply_name_and_description(client, activity_id, hevy_workout)
     except Exception as e:
         logger.warning("Rename/description failed after merge for %s: %s", activity_id, e)
-        # Non-fatal — sets were already pushed
+        # Non-fatal, sets were already pushed
 
     return MergeResult(merged=True, activity_id=activity_id)

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -881,6 +881,7 @@ async def settings_save(
     merge_overlap_pct: int = Form(70),
     merge_max_drift_min: int = Form(20),
     merge_extra_types: str = Form(""),
+    merge_watch_strategy: str = Form("replace"),
 ):
     if is_demo_mode():
         return HTMLResponse('<div class="toast toast-error">Settings are read-only in demo mode</div>')
@@ -911,6 +912,7 @@ async def settings_save(
     config["merge_activity_types"] = ["strength_training"] + [
         t for t in dict.fromkeys(extra_types) if t != "strength_training"
     ]
+    config["merge_watch_strategy"] = merge_watch_strategy if merge_watch_strategy in ("replace", "describe") else "replace"
     save_config(config)
 
     # Persist settings to DB on cloud (filesystem is read-only on Vercel)
@@ -926,6 +928,7 @@ async def settings_save(
                 "merge_overlap_pct": config["merge_overlap_pct"],
                 "merge_max_drift_min": config["merge_max_drift_min"],
                 "merge_activity_types": config["merge_activity_types"],
+                "merge_watch_strategy": config["merge_watch_strategy"],
             })
         except Exception as e:
             logger.warning("Failed to persist settings to DB: %s", e)
@@ -1654,6 +1657,7 @@ async def _do_sync_one(request: Request):
         merge_mode = config.get("merge_mode", True)
         sync_method = "upload"
         merge_forced_fresh = False
+        merge_delete_id = None
 
         # Merge mode: try to enhance a watch-recorded activity with Hevy data
         if merge_mode:
@@ -1662,6 +1666,7 @@ async def _do_sync_one(request: Request):
                 overlap_threshold=config.get("merge_overlap_pct", 70) / 100.0,
                 max_drift_minutes=config.get("merge_max_drift_min", 20),
                 activity_types=set(config.get("merge_activity_types", ["strength_training"])),
+                watch_strategy=config.get("merge_watch_strategy", "replace"),
             )
             if merge_result.merged:
                 aid = merge_result.activity_id
@@ -1683,6 +1688,7 @@ async def _do_sync_one(request: Request):
                 remaining = hevy.get_workout_count() - db.get_synced_count()
                 return JSONResponse({"synced": 1, "title": unsynced["title"], "remaining": max(0, remaining), "done": remaining <= 0})
             merge_forced_fresh = merge_result.force_fresh_upload
+            merge_delete_id = merge_result.delete_after_upload
 
         # HR enrichment for the uploaded FIT (#158): merged HR (AirPods-preferred,
         # watch fill), best-effort. Computed after the merge early-return so the
@@ -1715,6 +1721,15 @@ async def _do_sync_one(request: Request):
                 result = generate_fit(unsynced, hr_samples=hr_samples, output_path=fit_path)
                 upload_result = upload_fit(garmin_client, fit_path, workout_start=workout_start)
                 aid = upload_result.get("activity_id")
+                if aid and merge_delete_id:
+                    # "replace" strategy (#159): named upload succeeded, delete the
+                    # watch recording so the workout is a single activity.
+                    try:
+                        from hevy2garmin.garmin import delete_activity
+                        delete_activity(garmin_client, merge_delete_id)
+                        logger.info("Removed watch copy %s (replaced by %s)", merge_delete_id, aid)
+                    except Exception as e:
+                        logger.warning("Could not delete watch activity %s: %s", merge_delete_id, e)
                 if aid:
                     rename_activity(garmin_client, aid, unsynced["title"])
                     desc = generate_description(unsynced, calories=result.get("calories"), avg_hr=result.get("avg_hr"))

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -12,6 +12,7 @@ from hevy2garmin import db
 from hevy2garmin.config import load_config
 from hevy2garmin.fit import generate_fit
 from hevy2garmin.garmin import (
+    delete_activity,
     find_activity_by_start_time,
     generate_description,
     get_client,
@@ -123,6 +124,7 @@ def sync(
     merge_overlap_pct = cfg.get("merge_overlap_pct", 70) / 100.0  # convert % to decimal
     merge_max_drift_min = cfg.get("merge_max_drift_min", 20)
     merge_activity_types = set(cfg.get("merge_activity_types", ["strength_training"]))
+    merge_watch_strategy = cfg.get("merge_watch_strategy", "replace")
     description_enabled = cfg.get("description_enabled", True)
     stats = {"synced": 0, "skipped": 0, "failed": 0, "total": len(workouts), "unmapped": [], "merged": 0, "merge_fallback": 0}
 
@@ -152,8 +154,9 @@ def sync(
         try:
             # ── Merge mode: try to enhance a watch-recorded activity ──
             merge_forced_fresh = False
+            merge_delete_id = None
             if merge_mode and garmin_client and not dry_run:
-                merge_result = attempt_merge(garmin_client, workout, db, overlap_threshold=merge_overlap_pct, max_drift_minutes=merge_max_drift_min, activity_types=merge_activity_types)
+                merge_result = attempt_merge(garmin_client, workout, db, overlap_threshold=merge_overlap_pct, max_drift_minutes=merge_max_drift_min, activity_types=merge_activity_types, watch_strategy=merge_watch_strategy)
                 if merge_result.merged:
                     db.mark_synced(
                         hevy_id=wid,
@@ -170,6 +173,7 @@ def sync(
                     logger.info("  Merge fallback: %s", merge_result.fallback_reason)
                     stats["merge_fallback"] += 1
                     merge_forced_fresh = merge_result.force_fresh_upload
+                    merge_delete_id = merge_result.delete_after_upload
 
             # ── Standard upload path (FIT generation) ──
             # Embed merged HR (AirPods-preferred, watch fill) so it reaches
@@ -204,6 +208,14 @@ def sync(
                 else:
                     upload_result = upload_fit(garmin_client, fit_path, workout_start=start_time)
                     activity_id = upload_result.get("activity_id")
+                    # "replace" strategy (#159): the named upload succeeded, so
+                    # delete the watch recording to keep a single activity.
+                    if activity_id and merge_delete_id:
+                        try:
+                            delete_activity(garmin_client, merge_delete_id)
+                            logger.info("  Removed watch copy %s (replaced by %s)", merge_delete_id, activity_id)
+                        except Exception as e:
+                            logger.warning("Could not delete watch activity %s: %s", merge_delete_id, e)
 
                 if activity_id:
                     rename_activity(garmin_client, activity_id, title)

--- a/src/hevy2garmin/templates/settings.html
+++ b/src/hevy2garmin/templates/settings.html
@@ -223,7 +223,19 @@
                         <label class="form-label" for="merge_extra_types">Additional Watch Activity Types</label>
                         <input class="form-input" type="text" id="merge_extra_types" name="merge_extra_types" value="{{ merge_extra_types }}" placeholder="bouldering, indoor_climbing">
                         <div class="form-hint">
-                            <strong>Strength Training</strong> is always enhanced. Add other Garmin activity types here (comma-separated, using Garmin's internal name) to also enhance them with the matching Hevy workout — e.g. <code>bouldering</code>, <code>indoor_climbing</code> for climbing sessions.
+                            <strong>Strength Training</strong> is always enhanced. Add other Garmin activity types here (comma-separated, using Garmin's internal name) to also enhance them with the matching Hevy workout, e.g. <code>bouldering</code>, <code>indoor_climbing</code> for climbing sessions.
+                        </div>
+                    </div>
+                </div>
+                <div class="form-grid">
+                    <div class="form-group">
+                        <label class="form-label" for="merge_watch_strategy">Workouts recorded on a watch</label>
+                        <select class="form-input" id="merge_watch_strategy" name="merge_watch_strategy">
+                            <option value="replace" {{ 'selected' if config.get('merge_watch_strategy', 'replace') == 'replace' }}>Replace with one named activity (recommended)</option>
+                            <option value="describe" {{ 'selected' if config.get('merge_watch_strategy', 'replace') == 'describe' }}>Keep the watch activity, list exercises in its description</option>
+                        </select>
+                        <div class="form-hint">
+                            Garmin does not show exercise names on a workout your watch recorded. <strong>Replace</strong> uploads one named activity (with your heart rate) and deletes the watch copy, so you get a single activity with named exercises and no double-counted calories. <strong>Keep</strong> leaves the watch activity untouched and only lists the exercises in its description.
                         </div>
                     </div>
                 </div>

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -416,19 +416,44 @@ class TestAttemptMerge:
 
 @patch("hevy2garmin.merge.find_matching_garmin_activity")
 @patch("hevy2garmin.merge.push_exercise_sets")
-def test_watch_recorded_match_skips_merge(mock_push, mock_find):
-    """A device-recorded match (manufacturer != DEVELOPMENT) is never merged;
-    it forces a fresh named upload, since Garmin ignores pushed names there (#159)."""
+def test_watch_replace_strategy_forces_upload_and_marks_for_delete(mock_push, mock_find):
+    """Default 'replace' strategy: a watch match forces a named upload and flags
+    the watch activity for deletion, so the workout ends up as one activity (#159)."""
     reset_circuit_breaker()
     act = _make_garmin_activity()
     act["manufacturer"] = "GARMIN"  # recorded on a watch
     mock_find.return_value = act
 
-    result = attempt_merge(MagicMock(), HEVY_WORKOUT, MagicMock())
+    result = attempt_merge(MagicMock(), HEVY_WORKOUT, MagicMock())  # default replace
 
     assert result.merged is False
     assert result.force_fresh_upload is True
+    assert result.delete_after_upload == 12345  # the watch activity id
     mock_push.assert_not_called()  # we never push to a watch activity
+
+
+@patch("hevy2garmin.merge.find_matching_garmin_activity")
+@patch("hevy2garmin.merge.push_exercise_sets")
+@patch("hevy2garmin.merge.rename_activity")
+@patch("hevy2garmin.merge.set_description")
+@patch("hevy2garmin.merge.generate_description")
+def test_watch_describe_strategy_enriches_in_place(mock_gen, mock_desc, mock_rename, mock_push, mock_find):
+    """'describe' strategy keeps the single watch activity, enriching its name and
+    description, with no push and no fresh upload."""
+    reset_circuit_breaker()
+    act = _make_garmin_activity()
+    act["manufacturer"] = "GARMIN"
+    mock_find.return_value = act
+    mock_gen.return_value = "Dumbbell Row: 3 sets"
+
+    result = attempt_merge(MagicMock(), HEVY_WORKOUT, MagicMock(), watch_strategy="describe")
+
+    assert result.merged is True
+    assert result.activity_id == 12345
+    assert result.force_fresh_upload is False
+    mock_push.assert_not_called()      # never pushes sets to a watch activity
+    mock_rename.assert_called_once()   # but does rename + describe it
+    mock_desc.assert_called_once()
 
 
 @patch("hevy2garmin.merge.time.sleep")


### PR DESCRIPTION
## Summary

Follow-up to the #159 fix. Because Garmin will not show pushed exercise names on a watch-recorded activity, the tool uploads a fresh named activity, which left two activities for one workout and double-counted calories and activity totals.

This adds a setting (Settings > Advanced, "Workouts recorded on a watch") so you always end up with one activity:
- **Replace (default):** upload one named activity (with the watch heart rate via fusion), then delete the watch recording. One activity, named exercises, no double count. The delete runs only after the upload succeeds.
- **Keep:** leave the watch activity untouched and just list the exercises in its description (preserves the watch HR and device metrics).

## Test plan
- [x] Tests for both strategies. Settings dropdown validated with Playwright. Full suite 239 passed.

Closes #159