### PR TITLE
feat(merge): add 'merge sets' watch strategy (#159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **"Merge sets" strategy for watch-recorded workouts** ([#159](https://github.com/drkostas/hevy2garmin/issues/159)). A third option for "Workouts recorded on a watch" (Settings, Advanced), requested by @bojanmk1: push the sets, reps, and weights into the watch activity and keep it, so you keep all the watch's native metrics (heart rate, training effect, body battery) and the structured set data in one activity. The exercise names still show as "Unknown" because Garmin does not apply pushed names to watch-recorded activities, but the set data is there. Default stays "replace" (named exercises, single activity).
+
 ## [0.5.9] - 2026-06-26
 
 ### Added

--- a/src/hevy2garmin/config.py
+++ b/src/hevy2garmin/config.py
@@ -41,11 +41,13 @@ DEFAULT_CONFIG: dict[str, Any] = {
     },
     "merge_activity_types": ["strength_training"],
     # What to do when a workout was recorded on a watch (Garmin will not show
-    # pushed exercise names on those). "replace": upload one named activity and
-    # delete the watch recording (default, single activity with named exercises).
-    # "describe": keep the watch activity untouched and just list the exercises in
-    # its description (preserves the watch HR + metrics, structured list stays
-    # generic). (#159)
+    # pushed exercise names on those). One activity in every case (#159):
+    #   "replace" (default): upload one named activity and delete the watch
+    #       recording. Named exercises, but loses watch-only metrics.
+    #   "merge": push the sets/reps/weights into the watch activity and keep it.
+    #       Keeps all watch metrics; exercise names show as "Unknown".
+    #   "describe": keep the watch activity, only list exercises in its
+    #       description (no structured sets).
     "merge_watch_strategy": "replace",
 }
 

--- a/src/hevy2garmin/merge.py
+++ b/src/hevy2garmin/merge.py
@@ -335,23 +335,24 @@ def attempt_merge(
     # any match we did not create, skip the merge and upload a fresh named
     # activity instead. HR fusion still pulls the watch heart rate into it.
     manufacturer = str(match.get("manufacturer") or "").upper()
-    if manufacturer and manufacturer != "DEVELOPMENT":
-        if watch_strategy == "describe":
-            # Keep the single watch activity (its HR + device metrics) and just
-            # list the exercises in its description. No push (Garmin ignores it
-            # on watch activities anyway) and no upload, so it stays one activity.
-            logger.info(
-                "  Match %s recorded by %s; enriching its description (watch_strategy=describe)",
-                activity_id, manufacturer,
-            )
-            try:
-                _apply_name_and_description(client, activity_id, hevy_workout)
-            except Exception as e:
-                logger.warning("Rename/description failed for %s: %s", activity_id, e)
-            return MergeResult(merged=True, activity_id=activity_id)
+    is_watch = bool(manufacturer) and manufacturer != "DEVELOPMENT"
+    if is_watch and watch_strategy == "describe":
+        # Keep the single watch activity (its HR + device metrics) and just list
+        # the exercises in its description. No push (Garmin ignores names on watch
+        # activities) and no upload, so it stays one activity.
+        logger.info(
+            "  Match %s recorded by %s; enriching its description (watch_strategy=describe)",
+            activity_id, manufacturer,
+        )
+        try:
+            _apply_name_and_description(client, activity_id, hevy_workout)
+        except Exception as e:
+            logger.warning("Rename/description failed for %s: %s", activity_id, e)
+        return MergeResult(merged=True, activity_id=activity_id)
 
-        # Default "replace": upload one named activity, then delete the watch
-        # recording, so the workout shows up exactly once with named exercises.
+    if is_watch and watch_strategy == "replace":
+        # Upload one named activity, then delete the watch recording, so the
+        # workout shows up exactly once with named exercises.
         logger.info(
             "  Match %s recorded by %s; uploading a named activity and removing the watch copy (watch_strategy=replace)",
             activity_id, manufacturer,
@@ -361,6 +362,17 @@ def attempt_merge(
             force_fresh_upload=True,
             delete_after_upload=activity_id,
             fallback_reason=f"activity recorded by {manufacturer}; replacing it with a named upload",
+        )
+
+    if is_watch:
+        # watch_strategy == "merge": push the sets/reps/weights into the single
+        # watch activity, keeping all its native metrics (HR, training effect,
+        # body battery). Garmin will not display the exercise NAMES on a
+        # device-recorded activity, so they show as "Unknown", but the structured
+        # sets/reps/weights land in the activity. One activity, no upload/delete.
+        logger.info(
+            "  Match %s recorded by %s; merging sets in place, names may show as Unknown (watch_strategy=merge)",
+            activity_id, manufacturer,
         )
 
     # Backup existing exercise sets
@@ -387,13 +399,13 @@ def attempt_merge(
         logger.error("PUT exerciseSets failed for activity %s: %s", activity_id, e)
         return MergeResult(merged=False, fallback_reason=f"PUT failed: {e}")
 
-    # The push returns 204 even when Garmin drops the exercise names on a
-    # watch-recorded activity (#159). Verify the names actually applied; if not,
-    # restore the activity and tell the caller to upload a separate named
-    # activity instead (the only way those users get real exercise names).
-    if not _names_applied(client, activity_id):
+    # hevy2garmin's own uploads (DEVELOPMENT) display the pushed names, so verify
+    # there and fall back to a named upload if Garmin dropped them. For
+    # watch_strategy="merge" we intentionally keep the watch activity even though
+    # Garmin will not show the names, so skip the verify and keep the sets.
+    if not (is_watch and watch_strategy == "merge") and not _names_applied(client, activity_id):
         logger.info(
-            "  Exercise names not applied on watch activity %s — restoring and uploading a named activity",
+            "  Exercise names not applied on activity %s, restoring and uploading a named activity",
             activity_id,
         )
         _restore_sets(client, activity_id, database)

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -912,7 +912,7 @@ async def settings_save(
     config["merge_activity_types"] = ["strength_training"] + [
         t for t in dict.fromkeys(extra_types) if t != "strength_training"
     ]
-    config["merge_watch_strategy"] = merge_watch_strategy if merge_watch_strategy in ("replace", "describe") else "replace"
+    config["merge_watch_strategy"] = merge_watch_strategy if merge_watch_strategy in ("replace", "merge", "describe") else "replace"
     save_config(config)
 
     # Persist settings to DB on cloud (filesystem is read-only on Vercel)

--- a/src/hevy2garmin/templates/settings.html
+++ b/src/hevy2garmin/templates/settings.html
@@ -231,11 +231,12 @@
                     <div class="form-group">
                         <label class="form-label" for="merge_watch_strategy">Workouts recorded on a watch</label>
                         <select class="form-input" id="merge_watch_strategy" name="merge_watch_strategy">
-                            <option value="replace" {{ 'selected' if config.get('merge_watch_strategy', 'replace') == 'replace' }}>Replace with one named activity (recommended)</option>
+                            <option value="replace" {{ 'selected' if config.get('merge_watch_strategy', 'replace') == 'replace' }}>Replace with one named activity (named exercises)</option>
+                            <option value="merge" {{ 'selected' if config.get('merge_watch_strategy', 'replace') == 'merge' }}>Merge sets into the watch activity (keeps watch metrics)</option>
                             <option value="describe" {{ 'selected' if config.get('merge_watch_strategy', 'replace') == 'describe' }}>Keep the watch activity, list exercises in its description</option>
                         </select>
                         <div class="form-hint">
-                            Garmin does not show exercise names on a workout your watch recorded. <strong>Replace</strong> uploads one named activity (with your heart rate) and deletes the watch copy, so you get a single activity with named exercises and no double-counted calories. <strong>Keep</strong> leaves the watch activity untouched and only lists the exercises in its description.
+                            Garmin does not show exercise names on a workout your watch recorded, so you always end up with one activity but with a tradeoff. <strong>Replace</strong> uploads one named activity (with your heart rate) and deletes the watch copy, so exercises are named, but you lose watch-only metrics like training effect. <strong>Merge sets</strong> pushes the sets, reps, and weights into the watch activity and keeps it, so you keep all watch metrics and structured set data, but the exercise names show as "Unknown". <strong>Keep + describe</strong> leaves the watch activity untouched and only lists the exercises in its description, with no structured sets.
                         </div>
                     </div>
                 </div>

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -476,6 +476,33 @@ def test_development_upload_still_merges(mock_desc, mock_rename, mock_push, mock
     mock_push.assert_called_once()
 
 
+@patch("hevy2garmin.merge.time.sleep")
+@patch("hevy2garmin.merge.find_matching_garmin_activity")
+@patch("hevy2garmin.merge.get_activity_exercise_sets")
+@patch("hevy2garmin.merge.push_exercise_sets")
+@patch("hevy2garmin.merge.rename_activity")
+@patch("hevy2garmin.merge.set_description")
+@patch("hevy2garmin.merge.generate_description")
+def test_watch_merge_strategy_pushes_and_keeps(mock_gen, mock_desc, mock_rename, mock_push, mock_get, mock_find, _sleep):
+    """'merge' strategy pushes sets into the watch activity and keeps it as one
+    activity (merged=True), without verifying names or forcing a fresh upload (#159)."""
+    reset_circuit_breaker()
+    act = _make_garmin_activity()
+    act["manufacturer"] = "GARMIN"
+    mock_find.return_value = act
+    mock_get.return_value = {"exerciseSets": []}  # only the backup read; verify is skipped
+    mock_gen.return_value = "Dumbbell Row: 3 sets"
+
+    result = attempt_merge(MagicMock(), HEVY_WORKOUT, MagicMock(), watch_strategy="merge")
+
+    assert result.merged is True
+    assert result.activity_id == 12345
+    assert result.force_fresh_upload is False
+    assert result.delete_after_upload is None
+    mock_push.assert_called_once()     # pushed the sets into the watch activity
+    mock_rename.assert_called_once()   # renamed + described it in place
+
+
 class TestNamesApplied:
     """Verify whether Garmin actually kept the exercise identities (#159)."""
 


### PR DESCRIPTION
## Summary

Requested by @bojanmk1 on #159: a third option for "Workouts recorded on a watch" that keeps the single watch activity and pushes the sets, reps, and weights into it, preserving all the watch's native metrics (heart rate, training effect, body battery) plus the structured set data. The exercise names still show as "Unknown" because Garmin does not apply pushed names to device-recorded activities, but the set data is in the activity.

`merge_watch_strategy` now has three values:
- **replace** (default): upload one named activity, delete the watch copy. Named exercises, loses watch-only metrics.
- **merge** (new): push sets into the watch activity, keep it. All watch metrics + structured sets, names show as Unknown.
- **describe**: keep the watch activity, only list exercises in the description.

For the merge strategy the names-applied verify is skipped, so it keeps the activity instead of falling back to a named upload.

## Test plan
- [x] Test: merge strategy pushes sets, keeps the activity (merged=True), no force_fresh, no delete.
- [x] Settings dropdown (3 options + hint) validated with Playwright.
- [x] Full suite: 240 passed.

Closes #159