### PR TITLE
fix(version): footer shows the real version after Vercel sync (#189)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- **Footer showed the wrong version (e.g. 0.4.0) after a Vercel fork + sync** ([#189](https://github.com/drkostas/hevy2garmin/issues/189)). The version came from the installed package metadata, which the Vercel build can cache stale, so the footer showed an old number even though the code was current. It now reads the version from pyproject.toml in the deployed source, so the footer always matches the running code. Thanks @KaiBoos.
+
 ## [0.5.10] - 2026-06-26
 
 ### Added

--- a/src/hevy2garmin/__init__.py
+++ b/src/hevy2garmin/__init__.py
@@ -1,8 +1,32 @@
 """Sync Hevy gym workouts to Garmin Connect."""
 
-from importlib.metadata import version, PackageNotFoundError
+import re
+from pathlib import Path
 
-try:
-    __version__ = version("hevy2garmin")
-except PackageNotFoundError:
-    __version__ = "0.0.0-dev"
+
+def _detect_version() -> str:
+    """Resolve the running version.
+
+    Read pyproject.toml from the source tree first. On source deploys (Vercel
+    fork + sync) the build can cache the installed package metadata, so
+    importlib.metadata returns a stale version (e.g. 0.4.0) even though the code
+    is current, which made the footer show the wrong version (#189). pyproject
+    always matches the deployed code. Fall back to the installed metadata for
+    pip installs, where pyproject is not next to the package.
+    """
+    pyproject = Path(__file__).resolve().parent.parent.parent / "pyproject.toml"
+    try:
+        if pyproject.exists():
+            match = re.search(r'^version\s*=\s*"([^"]+)"', pyproject.read_text(), re.M)
+            if match:
+                return match.group(1)
+    except Exception:
+        pass
+    try:
+        from importlib.metadata import version
+        return version("hevy2garmin")
+    except Exception:
+        return "0.0.0-dev"
+
+
+__version__ = _detect_version()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,12 @@
+"""The reported version must match the source, not stale installed metadata (#189)."""
+from __future__ import annotations
+import re
+from pathlib import Path
+import hevy2garmin
+
+
+def test_version_matches_pyproject():
+    pyproject = Path(hevy2garmin.__file__).resolve().parent.parent.parent / "pyproject.toml"
+    expected = re.search(r'^version\s*=\s*"([^"]+)"', pyproject.read_text(), re.M).group(1)
+    assert hevy2garmin.__version__ == expected
+    assert hevy2garmin.__version__ != "0.0.0-dev"


### PR DESCRIPTION
## Summary

@KaiBoos reported the footer dropping back to v0.4.0 after a fork + sync on Vercel, even with the fork at v0.5.10.

**Cause:** `__version__` came from `importlib.metadata`, which reads the installed package metadata. The Vercel build caches that, so the version string went stale while the actual code was current. KaiBoos's own comment on #173 (the v0.5.6 mapping fix working for them) proves the code was current and only the footer was wrong.

**Fix:** read the version from `pyproject.toml` in the deployed source tree first (always matches the running code on source deploys), fall back to installed metadata for pip installs.

## Test plan
- [x] Test asserts `__version__` equals the pyproject version and is not the dev sentinel.
- [x] Verified locally: now reports 0.5.10 instead of the stale 0.4.0.

Closes #189