### PR TITLE
feat(ui): Unsync All button to re-import the whole history (#174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- **"Unsync All" button** ([#174](https://github.com/drkostas/hevy2garmin/issues/174)). On the Workouts page, next to Reload Data. Clears the sync status of every workout so the next sync re-imports them all, which is handy after a mapping fix instead of unsyncing one at a time. It does not delete anything from Garmin, and workouts still on Garmin are skipped as duplicates on re-sync. Thanks @KaiBoos.
+
 ### Fixed
 - **Footer showed the wrong version (e.g. 0.4.0) after a Vercel fork + sync** ([#189](https://github.com/drkostas/hevy2garmin/issues/189)). The version came from the installed package metadata, which the Vercel build can cache stale, so the footer showed an old number even though the code was current. It now reads the version from pyproject.toml in the deployed source, so the footer always matches the running code. Thanks @KaiBoos.
 

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -1267,6 +1267,9 @@ async def api_unsync_all(request: Request):
     """Remove ALL sync records. Does not delete from Garmin."""
     from fastapi.responses import JSONResponse
 
+    if is_demo_mode():
+        return JSONResponse({"ok": False, "error": "Read-only in demo mode"}, status_code=403)
+
     form = await request.form()
     confirm = form.get("confirm", "")
     if confirm != "RESET":

--- a/src/hevy2garmin/templates/workouts.html
+++ b/src/hevy2garmin/templates/workouts.html
@@ -93,6 +93,13 @@
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M23 4v6h-6M1 20v-6h6"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>
             Reload Data
         </button>
+        <button class="btn btn-secondary btn-sm"
+                onclick="unsyncAll(this)"
+                style="margin-top: 8px; margin-left: 8px;"
+                title="Clear the sync status of every workout so the next sync re-imports them all. Useful after a mapping fix. Does not delete anything from Garmin.">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M3 6h18M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
+            Unsync All
+        </button>
         <div id="reload-toast"></div>
     </div>
     {% if page_count > 1 %}
@@ -522,6 +529,30 @@ async function unsyncWorkout(hevyId, btn) {
         alert('Network error: ' + e.message);
         btn.disabled = false;
         btn.textContent = 'Unsync';
+    }
+}
+
+async function unsyncAll(btn) {
+    if (!confirm('Clear the sync status of ALL workouts?\n\nThe next sync will re-import every workout. This does not delete anything from Garmin. If a workout is still on Garmin it is skipped as a duplicate, so delete it from Garmin first if you want a fresh upload (for example after a mapping fix).')) return;
+    const original = btn.textContent.trim();
+    btn.disabled = true;
+    btn.textContent = 'Working…';
+    try {
+        const form = new FormData();
+        form.append('confirm', 'RESET');
+        const resp = await fetch('/api/unsync-all', { method: 'POST', body: form });
+        const data = await resp.json();
+        if (data.ok) {
+            window.location.reload();
+        } else {
+            alert('Failed: ' + (data.error || 'Unknown error'));
+            btn.disabled = false;
+            btn.textContent = original;
+        }
+    } catch (e) {
+        alert('Network error: ' + e.message);
+        btn.disabled = false;
+        btn.textContent = original;
     }
 }
 </script>

--- a/tests/test_unsync_all.py
+++ b/tests/test_unsync_all.py
@@ -1,0 +1,43 @@
+"""Bulk Unsync All endpoint: confirm-gated, demo-blocked, clears records (#174)."""
+from __future__ import annotations
+import os
+from unittest.mock import MagicMock, patch
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("HEVY2GARMIN_SECRET", None)
+        os.environ.pop("DEMO_MODE", None)
+        import hevy2garmin.server as srv
+        srv._is_configured_cache = True
+        yield TestClient(srv.app)
+
+
+def test_requires_confirm(client):
+    with patch("hevy2garmin.server.is_configured", return_value=True), \
+         patch("hevy2garmin.server.is_demo_mode", return_value=False):
+        resp = client.post("/api/unsync-all")  # no confirm
+    assert resp.status_code == 400
+    assert resp.json()["ok"] is False
+
+
+def test_clears_all_records(client):
+    fake_db = MagicMock()
+    with patch("hevy2garmin.server.is_configured", return_value=True), \
+         patch("hevy2garmin.server.is_demo_mode", return_value=False), \
+         patch("hevy2garmin.server.db.unsync_all", return_value=65) as mock_unsync, \
+         patch("hevy2garmin.server.db.get_db", return_value=fake_db):
+        resp = client.post("/api/unsync-all", data={"confirm": "RESET"})
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True, "count": 65}
+    mock_unsync.assert_called_once()
+
+
+def test_blocked_in_demo(client):
+    with patch("hevy2garmin.server.is_configured", return_value=True), \
+         patch("hevy2garmin.server.is_demo_mode", return_value=True):
+        resp = client.post("/api/unsync-all", data={"confirm": "RESET"})
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary

@KaiBoos (and @lozbrown) wanted to re-import their whole Hevy history after the workout-id and mapping fixes, but the only way was unsyncing one workout at a time (65+ clicks). The `/api/unsync-all` endpoint already existed, it just had no button.

Adds an **Unsync All** button on the Workouts page next to Reload Data, with a confirmation that explains it clears all local sync records (nothing on Garmin), so the next sync re-imports everything. Workouts still on Garmin are skipped as duplicates on re-sync, so the typical flow after a mapping fix is: delete the bad ones from Garmin, Unsync All, then Sync.

Also added a demo-mode guard to the endpoint.

## Test plan
- [x] Tests: confirm-gated (400 without confirm=RESET), demo-blocked (403), clears records (calls unsync_all, returns count).
- [x] Button rendering validated with Playwright.
- [x] Full suite: 244 passed.

Closes #174