### PR TITLE
fix(deploy): friendly 'add a database' page instead of a 500 + clearer Vercel docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,17 +83,17 @@ This token lets hevy2garmin set up automatic syncing on your behalf. Open [this 
 
 1. Go to [vercel.com/new](https://vercel.com/new) and sign in with GitHub
 2. Find **hevy2garmin** in your repo list and click **Import**
-3. If you see an **Integrations** section, click **Add** next to **Neon** (this is the free database that stores your sync history). If you don't see it, no problem -- after deploy, go to your project's **Storage** tab and add **Neon Postgres** from there.
-4. **Environment Variables** -- fill in these 4 values:
+3. **Add a database (required).** If you see an **Integrations** or **Storage** section during import, add **Neon Postgres** (it's free). This is where your sync history lives. If you don't see it during import, that's fine: deploy first, then open your project's **Storage** tab, add **Neon Postgres**, and redeploy. A serverless host has a read-only filesystem, so with no database the app can't save anything and shows an "internal server error".
+4. **Environment Variables.** Vercel does not pre-fill these. The form shows an empty field with a placeholder like `EXAMPLE_NAME`. Add each of the four below as its own variable: type the name in **Key**, the value in **Value**, then click **Add More** for the next one.
 
-| Field | What to paste |
+| Key | What to paste |
 |-------|--------------|
 | `HEVY_API_KEY` | The API key from step 1 |
 | `GARMIN_EMAIL` | Your Garmin Connect email |
 | `GARMIN_PASSWORD` | Your Garmin Connect password |
 | `GITHUB_PAT` | The token from step 3 |
 
-5. Click **Deploy** and wait about a minute for it to build.
+5. Click **Deploy** and wait about a minute for it to build. If the deployed page shows an "internal server error", it almost always means the database step was skipped: add **Neon Postgres** from the **Storage** tab, then redeploy.
 
 **Step 6: Connect Garmin**
 

--- a/src/hevy2garmin/db_interface.py
+++ b/src/hevy2garmin/db_interface.py
@@ -5,6 +5,15 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 
 
+class NoWritableDatabaseError(RuntimeError):
+    """No Postgres URL is set and the local SQLite fallback cannot be written.
+
+    Happens on serverless deploys (Vercel/Lambda) where the home filesystem is
+    read-only and no database has been attached. Handlers catch this to show an
+    actionable "add a database" message instead of a raw 500 (#145, #142).
+    """
+
+
 class Database(ABC):
     """Abstract base class for workout sync storage."""
 

--- a/src/hevy2garmin/db_sqlite.py
+++ b/src/hevy2garmin/db_sqlite.py
@@ -7,7 +7,7 @@ import sqlite3
 from datetime import datetime
 from pathlib import Path
 
-from hevy2garmin.db_interface import Database
+from hevy2garmin.db_interface import Database, NoWritableDatabaseError
 
 
 def _ts_newer(new_ts: str, old_ts: str) -> bool:
@@ -35,7 +35,7 @@ class SQLiteDatabase(Database):
             # Serverless (Vercel/Lambda) home is read-only — the cryptic
             # FileNotFoundError/OSError here is what users saw as a blank
             # dashboard / 500 on deploy (#145). Surface an actionable message.
-            raise RuntimeError(
+            raise NoWritableDatabaseError(
                 "Cannot create a local SQLite database under ~/.hevy2garmin on "
                 "this read-only filesystem. Serverless deployments need Postgres: "
                 "add a Neon database (Vercel → Storage) so DATABASE_URL / "

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -17,6 +17,7 @@ from fastapi.staticfiles import StaticFiles
 from jinja2 import Environment, FileSystemLoader
 
 from hevy2garmin import db, __version__
+from hevy2garmin.db_interface import NoWritableDatabaseError
 from hevy2garmin.auth import auth_enabled, verify_session, sign_session, check_password, SESSION_COOKIE
 from hevy2garmin.config import is_configured, load_config, save_config
 from hevy2garmin.demo import is_demo_mode
@@ -55,6 +56,37 @@ def _render(template_name: str, **ctx) -> HTMLResponse:
 
 app = FastAPI(title="hevy2garmin", docs_url=None, redoc_url=None)
 app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
+
+
+_NO_DB_PAGE = """<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>hevy2garmin — database needed</title>
+<style>
+ body{margin:0;background:#0f1115;color:#e6e6e6;font:16px/1.6 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;display:flex;min-height:100vh;align-items:center;justify-content:center}
+ .card{max-width:560px;margin:24px;padding:32px;background:#171a21;border:1px solid #262b36;border-radius:14px}
+ h1{margin:0 0 4px;font-size:20px}
+ p{color:#aab2c0}
+ ol{padding-left:20px} li{margin:8px 0}
+ code{background:#0f1115;border:1px solid #262b36;border-radius:6px;padding:1px 6px;font-size:14px}
+ a{color:#7aa2ff}
+</style></head><body><div class="card">
+ <h1>Almost there — hevy2garmin needs a database</h1>
+ <p>This deployment has no database attached yet. Serverless hosts have a read-only
+ filesystem, so the app can't fall back to a local file and needs Postgres.</p>
+ <ol>
+  <li>Open your project on <a href="https://vercel.com/dashboard" target="_blank" rel="noopener">Vercel</a>.</li>
+  <li>Go to the <b>Storage</b> tab and add a <b>Neon Postgres</b> database (it's free). This sets <code>POSTGRES_URL</code> automatically.</li>
+  <li>Go to <b>Deployments</b>, open the latest one, and click <b>Redeploy</b>.</li>
+ </ol>
+ <p>Once the database is connected and it redeploys, this page becomes your dashboard.</p>
+</div></body></html>"""
+
+
+@app.exception_handler(NoWritableDatabaseError)
+async def _no_database_handler(request: Request, exc: NoWritableDatabaseError) -> HTMLResponse:
+    """Render an actionable 'add a database' page instead of a raw 500 (#145, #142)."""
+    logger.warning("No writable database on %s: %s", request.url.path, exc)
+    return HTMLResponse(_NO_DB_PAGE, status_code=503)
 
 
 # ── Auto-sync state ─────────────────────────────────────────────────────────

--- a/tests/test_no_database.py
+++ b/tests/test_no_database.py
@@ -1,0 +1,67 @@
+"""A serverless deploy with no database attached must show a friendly, actionable
+page instead of a raw 500 (#145, #142).
+
+The dashboard's first DB call (get_synced_count) hits the SQLite fallback, whose
+_get_conn() can't create ~/.hevy2garmin on a read-only filesystem. That now
+raises NoWritableDatabaseError, and the app renders a "add a Neon database" page.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hevy2garmin.db_interface import NoWritableDatabaseError
+
+
+@pytest.fixture
+def client():
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("HEVY2GARMIN_SECRET", None)
+        os.environ.pop("DEMO_MODE", None)
+        for v in ("POSTGRES_URL", "DATABASE_URL", "STORAGE_URL", "NEON_DATABASE_URL"):
+            os.environ.pop(v, None)
+        os.environ["HEVY_API_KEY"] = "k"  # configured, so no /setup redirect
+        import hevy2garmin.server as srv
+        srv._is_configured_cache = None
+        from hevy2garmin import db
+        db.reset()
+        yield TestClient(srv.app, follow_redirects=False)
+        db.reset()
+
+
+def test_no_database_shows_friendly_page(client):
+    """No Postgres + unwritable SQLite -> 503 friendly page reaching through the
+    HTTP middleware, not an unhandled 500."""
+    from hevy2garmin.db_sqlite import SQLiteDatabase
+
+    def _boom(self):
+        raise NoWritableDatabaseError("read-only fs")
+
+    with patch.object(SQLiteDatabase, "_get_conn", _boom):
+        resp = client.get("/")
+
+    assert resp.status_code == 503
+    body = resp.text.lower()
+    assert "database" in body
+    assert "neon" in body
+    assert "redeploy" in body
+
+
+def test_sqlite_maps_readonly_fs_to_no_writable_error(tmp_path):
+    """SQLiteDatabase._get_conn turns a read-only-FS OSError into the typed
+    NoWritableDatabaseError the handler keys on."""
+    from hevy2garmin.db_sqlite import SQLiteDatabase
+
+    dbf = SQLiteDatabase(db_path=tmp_path / "sub" / "sync.db")
+
+    def _raise(*a, **k):
+        raise OSError(30, "Read-only file system")
+
+    with patch.object(Path, "mkdir", _raise):
+        with pytest.raises(NoWritableDatabaseError):
+            dbf._get_conn()


### PR DESCRIPTION
## What

Two recurring Vercel-deploy pain points, both hit again this week (r/Hevy "internal server error on visit", plus a self-host report).

1. **Friendly page instead of a 500.** With no Postgres attached, the app falls back to SQLite under `~/.hevy2garmin`, which can't be written on Vercel's read-only filesystem. It now raises a typed `NoWritableDatabaseError` and renders a self-contained 503 page telling the user to add Neon Postgres (Storage tab) and redeploy, instead of a raw "internal server error". Recurrence of #145 / #142.
2. **Clearer deploy docs.** README: the database step is now required (not "add it later if you see it"), env vars are explained as manual Key/Value entry (the `EXAMPLE_NAME` placeholder confused people), and a one-line "internal server error -> add Neon + redeploy" note.

## Tests

- New `tests/test_no_database.py`: asserts the 503 friendly page renders through the HTTP middleware (not a 500), and that the SQLite path maps a read-only-FS `OSError` to `NoWritableDatabaseError`.
- Full suite: 246 passed, 7 skipped.

Closes #195
Closes #196
Closes #197
