### PR TITLE
fix(merge): retry exerciseSets without names when Garmin rejects a subcategory

### DIFF
--- a/src/hevy2garmin/merge.py
+++ b/src/hevy2garmin/merge.py
@@ -148,6 +148,28 @@ def _exercise_to_string(cat_id: int, sub_id: int) -> str | None:
     return None
 
 
+def _strip_exercise_names(payload: dict) -> dict:
+    """Return a copy of an exerciseSets payload with every exercise *name*
+    removed but the category kept. Garmin always accepts a ``null`` name under a
+    valid parent category, so this is the safe fallback when it rejects a
+    specific ``(category, subcategory)`` pair."""
+    stripped = dict(payload)
+    stripped["exerciseSets"] = [
+        {**s, "exercises": [{**ex, "name": None} for ex in s.get("exercises", [])]}
+        for s in payload.get("exerciseSets", [])
+    ]
+    return stripped
+
+
+def _is_subcategory_rejection(exc: Exception) -> bool:
+    """True when a push failed because Garmin rejected an exercise
+    ``(category, subcategory)`` pair (HTTP 400 "Invalid Sub-Category"). The
+    exerciseSets PUT is atomic, so one such exercise 400s the whole payload,
+    and fit_tool considers these pairs valid so we can't filter them out first."""
+    msg = str(exc).lower()
+    return "sub-category" in msg or "subcategory" in msg or "invalid sub" in msg
+
+
 # ---------------------------------------------------------------------------
 # Payload builder
 # ---------------------------------------------------------------------------
@@ -390,14 +412,33 @@ def attempt_merge(
     title = hevy_workout.get("title", "Workout")
     payload = build_exercise_sets_payload(hevy_workout, activity_id, act_start, act_duration)
 
-    # PUT exercise sets
+    # PUT exercise sets. The exerciseSets PUT is atomic: a single exercise whose
+    # (category, subcategory) pair Garmin rejects 400s the WHOLE payload and would
+    # drop every set (silas_christopher, r/Hevy). fit_tool treats these pairs as
+    # valid, so we can't screen them out up front. On that rejection, retry once
+    # with exercise names stripped (category kept, which Garmin always accepts) so
+    # the structured sets/reps/weights still land instead of losing the entire
+    # merge; the names then show as the generic category label.
     try:
         push_exercise_sets(client, activity_id, payload)
         _consecutive_failures = 0
     except Exception as e:
-        _consecutive_failures += 1
-        logger.error("PUT exerciseSets failed for activity %s: %s", activity_id, e)
-        return MergeResult(merged=False, fallback_reason=f"PUT failed: {e}")
+        if _is_subcategory_rejection(e):
+            logger.warning(
+                "  exerciseSets rejected a subcategory for activity %s (%s); "
+                "retrying without exercise names", activity_id, e,
+            )
+            try:
+                push_exercise_sets(client, activity_id, _strip_exercise_names(payload))
+                _consecutive_failures = 0
+            except Exception as e2:
+                _consecutive_failures += 1
+                logger.error("PUT exerciseSets failed for activity %s even without names: %s", activity_id, e2)
+                return MergeResult(merged=False, fallback_reason=f"PUT failed: {e2}")
+        else:
+            _consecutive_failures += 1
+            logger.error("PUT exerciseSets failed for activity %s: %s", activity_id, e)
+            return MergeResult(merged=False, fallback_reason=f"PUT failed: {e}")
 
     # hevy2garmin's own uploads (DEVELOPMENT) display the pushed names, so verify
     # there and fall back to a named upload if Garmin dropped them. For

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -13,6 +13,8 @@ from hevy2garmin.merge import (
     reset_circuit_breaker,
     _category_to_string,
     _exercise_to_string,
+    _strip_exercise_names,
+    _is_subcategory_rejection,
 )
 
 
@@ -501,6 +503,84 @@ def test_watch_merge_strategy_pushes_and_keeps(mock_gen, mock_desc, mock_rename,
     assert result.delete_after_upload is None
     mock_push.assert_called_once()     # pushed the sets into the watch activity
     mock_rename.assert_called_once()   # renamed + described it in place
+
+
+# ---------------------------------------------------------------------------
+# Resilience: one rejected subcategory must not drop the whole merge
+# ---------------------------------------------------------------------------
+
+def test_strip_exercise_names_nulls_names_keeps_category():
+    """_strip_exercise_names returns a copy with every name nulled, categories kept."""
+    payload = build_exercise_sets_payload(
+        HEVY_WORKOUT, activity_id=1,
+        activity_start_time="2026-03-15 18:00:00", activity_duration_s=45 * 60,
+    )
+    stripped = _strip_exercise_names(payload)
+    # the original still has real names (copy, not mutated)
+    assert any(ex["name"] for s in payload["exerciseSets"] for ex in s["exercises"])
+    for s in stripped["exerciseSets"]:
+        for ex in s["exercises"]:
+            assert ex["name"] is None
+            assert "category" in ex
+
+
+def test_is_subcategory_rejection_detects_garmin_400():
+    assert _is_subcategory_rejection(RuntimeError("API Error 400 - Invalid Sub-Category Passed in the request"))
+    assert _is_subcategory_rejection(Exception("invalid subcategory"))
+    assert not _is_subcategory_rejection(RuntimeError("connection reset"))
+    assert not _is_subcategory_rejection(RuntimeError("PUT failed"))
+
+
+@patch("hevy2garmin.merge.time.sleep")
+@patch("hevy2garmin.merge.find_matching_garmin_activity")
+@patch("hevy2garmin.merge.get_activity_exercise_sets")
+@patch("hevy2garmin.merge.push_exercise_sets")
+@patch("hevy2garmin.merge.rename_activity")
+@patch("hevy2garmin.merge.set_description")
+@patch("hevy2garmin.merge.generate_description")
+def test_subcategory_400_retries_without_names(mock_gen, mock_desc, mock_rename, mock_push, mock_get, mock_find, _sleep):
+    """A subcategory 400 on the atomic PUT retries once with names stripped so the
+    sets still land (merged=True), instead of dropping the entire merge."""
+    reset_circuit_breaker()
+    act = _make_garmin_activity()
+    act["manufacturer"] = "GARMIN"          # watch activity, merge strategy skips the name-verify
+    mock_find.return_value = act
+    mock_get.return_value = {"exerciseSets": []}
+    mock_gen.return_value = "Bench: 3 sets"
+    # first push rejected, the names-stripped retry succeeds
+    mock_push.side_effect = [
+        RuntimeError("API Error 400 - Invalid Sub-Category Passed in the request"),
+        None,
+    ]
+
+    result = attempt_merge(MagicMock(), HEVY_WORKOUT, MagicMock(), watch_strategy="merge")
+
+    assert result.merged is True
+    assert mock_push.call_count == 2
+    retry_payload = mock_push.call_args_list[1].args[2]
+    active = [s for s in retry_payload["exerciseSets"] if s["setType"] == "ACTIVE"]
+    assert active and all(ex["name"] is None for s in active for ex in s["exercises"])
+
+
+@patch("hevy2garmin.merge.time.sleep")
+@patch("hevy2garmin.merge.find_matching_garmin_activity")
+@patch("hevy2garmin.merge.get_activity_exercise_sets")
+@patch("hevy2garmin.merge.push_exercise_sets")
+def test_non_subcategory_error_is_not_retried(mock_push, mock_get, mock_find, _sleep):
+    """A non-subcategory push error (e.g. network) falls back immediately with no
+    stripped-names retry."""
+    reset_circuit_breaker()
+    act = _make_garmin_activity()
+    act["manufacturer"] = "GARMIN"
+    mock_find.return_value = act
+    mock_get.return_value = {"exerciseSets": []}
+    mock_push.side_effect = RuntimeError("connection reset by peer")
+
+    result = attempt_merge(MagicMock(), HEVY_WORKOUT, MagicMock(), watch_strategy="merge")
+
+    assert result.merged is False
+    assert "PUT failed" in result.fallback_reason
+    mock_push.assert_called_once()   # no retry
 
 
 class TestNamesApplied:


### PR DESCRIPTION
## What

On the merge path, a single exercise whose `(category, subcategory)` pair Garmin rejects made the atomic `exerciseSets` PUT fail with `400 - Invalid Sub-Category` and dropped **every** set on the activity. After three such workouts the circuit breaker disabled merge for the rest of the run, so the same kind of workout would sync cleanly or lose all its exercise data depending on whether it contained the offending exercise.

`fit_tool` accepts some pairs Garmin's live API rejects (SDK vs backend drift), so we cannot screen them out ahead of time.

## Change

On a subcategory rejection, retry the PUT once with exercise names stripped (category kept, which Garmin always accepts) so the structured sets/reps/weights still land. Names show as the generic category label instead of the whole merge being lost. Non-subcategory errors are unchanged (immediate fallback, still count toward the circuit breaker).

Two small helpers: `_strip_exercise_names` (null the names, keep categories) and `_is_subcategory_rejection` (detect the 400).

## Tests

Added to `tests/test_merge.py`:
- `test_subcategory_400_retries_without_names` (retry lands the sets, `merged=True`)
- `test_non_subcategory_error_is_not_retried` (network errors fall back immediately)
- `test_strip_exercise_names_nulls_names_keeps_category`
- `test_is_subcategory_rejection_detects_garmin_400`

Full suite: 250 passed, 7 skipped. No version bump (no release).

Closes #199
