### PR TITLE
fix: valid exercise categories + accurate Garmin rate-limit message

### DIFF
--- a/src/hevy2garmin/mapper.py
+++ b/src/hevy2garmin/mapper.py
@@ -104,9 +104,9 @@ HEVY_TO_GARMIN: dict[str, tuple[int, int]] = {
     #  BACK – Rows (category 23)
     # ======================================================================= #
     "Bent Over Row (Band)":                     (23, 0),   # row / barbell_straight_leg_deadlift_to_row (closest band row)
-    "Bent Over Row (Barbell)":                  (23, 46),  # row / bent_over_barbell_row
+    "Bent Over Row (Barbell)":                  (23, 65535),  # ROW / generic (no exact barbell bent-over sub in fit_tool)
     "Bent Over Row (Dumbbell)":                 (23, 2),   # row / dumbbell_row
-    "Chest Supported Incline Row (Dumbbell)":   (23, 40),  # row / chest_supported_dumbbell_row
+    "Chest Supported Incline Row (Dumbbell)":   (23, 2),  # ROW / dumbbell_row
     "Dumbbell Row":                             (23, 2),   # row / dumbbell_row
     "Face Pull":                                (23, 5),   # row / face_pull
     "Gorilla Row (Kettlebell)":                 (23, 9),   # row / kettlebell_row (closest)
@@ -117,7 +117,7 @@ HEVY_TO_GARMIN: dict[str, tuple[int, int]] = {
     "Landmine Row":                             (23, 13),  # row / one_arm_bent_over_row (closest)
     "Low Row (Suspension)":                     (23, 26),  # row / suspended_inverted_row
     "Meadows Rows (Barbell)":                   (23, 13),  # row / one_arm_bent_over_row
-    "Pendlay Row (Barbell)":                    (23, 46),  # row / bent_over_barbell_row (Pendlay variant)
+    "Pendlay Row (Barbell)":                    (23, 65535),  # ROW / generic (no exact sub in fit_tool)
     "Renegade Row (Dumbbell)":                  (23, 15),  # row / renegade_row
     "Seated Cable Row - Bar Grip":              (23, 18),  # row / seated_cable_row
     "Seated Cable Row - Bar Wide Grip":         (23, 33),  # row / wide_grip_seated_cable_row
@@ -342,8 +342,8 @@ HEVY_TO_GARMIN: dict[str, tuple[int, int]] = {
     # ======================================================================= #
     "Dumbbell Step Up":                         (28, 32),  # squat / dumbbell_step_up
     "Step Up":                                  (28, 66),  # squat / step_up
-    "Stair Machine (Floors)":                   (47, 0),   # stair_stepper / stair_stepper
-    "Stair Machine (Steps)":                    (47, 0),   # stair_stepper / stair_stepper
+    "Stair Machine (Floors)":                   (2, 65535),   # CARDIO / generic (fit_tool lacks stair_stepper)
+    "Stair Machine (Steps)":                    (2, 65535),   # CARDIO / generic (fit_tool lacks stair_stepper)
 
     # ======================================================================= #
     #  LEGS – Lunges (category 17)
@@ -590,26 +590,26 @@ HEVY_TO_GARMIN: dict[str, tuple[int, int]] = {
     #  CARDIO / MACHINES — uses newer FIT SDK categories (33+) where available
     # ======================================================================= #
     "Aerobics":                                 (2, 0),    # cardio / generic
-    "Air Bike":                                 (41, 0),   # indoor_bike / air_bike
-    "Battle Ropes":                             (38, 0),   # battle_rope / alternating_waves
-    "Boxing":                                   (2, 42),   # cardio / punch
+    "Air Bike":                                 (2, 65535),   # CARDIO / generic
+    "Battle Ropes":                             (2, 65535),   # CARDIO / generic
+    "Boxing":                                   (2, 65535),   # CARDIO / generic
     "Climbing":                                 (2, 0),    # cardio / generic
-    "Cycling":                                  (33, 0),   # bike / bike
-    "Elliptical Trainer":                       (39, 0),   # elliptical / elliptical
+    "Cycling":                                  (2, 65535),   # CARDIO / generic
+    "Elliptical Trainer":                       (2, 65535),   # CARDIO / generic
     "HIIT":                                     (2, 0),    # cardio / generic
     "Hiking":                                   (32, 1),   # run / walk (hiking = walking)
     "Jump Rope":                                (2, 6),    # cardio / jump_rope
     "Jumping Jack":                             (2, 12),   # cardio / jumping_jacks
     "Pilates":                                  (2, 0),    # cardio / generic
-    "Rowing Machine":                           (42, 0),   # indoor_row / rowing_machine
+    "Rowing Machine":                           (2, 65535),   # CARDIO / generic
     "Skating":                                  (2, 0),    # cardio / generic
     "Skiing":                                   (2, 0),    # cardio / generic
     "Snowboarding":                             (2, 0),    # cardio / generic
-    "Spinning":                                 (41, 3),   # indoor_bike / stationary_bike
+    "Spinning":                                 (2, 65535),   # CARDIO / generic
     "Stretching":                               (31, 0),   # warm_up / generic (stretching)
     "Swimming":                                 (2, 0),    # cardio / generic
-    "Treadmill":                                (52, 1),   # run_indoor / treadmill
-    "Yoga":                                     (36, 0),   # pose / generic (yoga)
+    "Treadmill":                                (2, 65535),   # CARDIO / generic
+    "Yoga":                                     (29, 65535),   # TOTAL_BODY / generic (not a Garmin strength exercise)
     "High Knees":                               (2, 0),    # cardio / generic
     "Sprints":                                  (32, 3),   # run / sprint
     "Cable Pull Through":                       (10, 11),  # hip_raise / hip_raise (cable pull-through = hip hinge)

--- a/src/hevy2garmin/templates/setup.html
+++ b/src/hevy2garmin/templates/setup.html
@@ -233,7 +233,7 @@ async function handleGarminLoginResponse(data) {
     }
 
     if (data.status === 'rate_limited') {
-        result.innerHTML = '<span style="color: var(--red);">&#10007; Garmin rate-limited this account. Wait a few minutes and try again.</span>';
+        result.innerHTML = '<span style="color: var(--red);">&#10007; Garmin rate-limited this account on their side (separate from your password, your Garmin app still works). It clears on its own, usually within a few hours. Repeated retries just reset the timer, so leave it a while and try once more.</span>';
         return;
     }
 

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -134,3 +134,36 @@ class TestSaveCustomMappingCloud:
         assert json.loads(target.read_text())["Foo (Bar)"] == [12, 34]
         assert m._custom_mappings["Foo (Bar)"] == (12, 34)
         m._custom_mappings.clear()
+
+
+class TestValidCategories:
+    """Bug B: some mappings used FIT categories (33-52) the installed fit_tool
+    doesn't implement, so they silently fell back to TOTAL_BODY instead of their
+    real category."""
+
+    def test_every_mapped_category_is_valid(self) -> None:
+        """Every built-in mapping must use a real FIT ExerciseCategory (0-32) or
+        the UNKNOWN sentinel — an out-of-range category resolves to 'UNKNOWN' and
+        would silently become TOTAL_BODY."""
+        from hevy2garmin.merge import _category_to_string
+        bad = {
+            name: (c, s)
+            for name, (c, s) in HEVY_TO_GARMIN.items()
+            if c != _UNKNOWN_CATEGORY and _category_to_string(c) == "UNKNOWN"
+        }
+        assert not bad, f"mappings with invalid (out-of-range) categories: {bad}"
+
+    def test_cardio_machines_map_to_cardio(self) -> None:
+        """Cardio machines resolve to the CARDIO category, not the TOTAL_BODY
+        fallback they hit before."""
+        from hevy2garmin.merge import _category_to_string
+        for name in ("Cycling", "Treadmill", "Elliptical Trainer", "Rowing Machine"):
+            cat, sub, _ = lookup_exercise(name)
+            assert _category_to_string(cat) == "CARDIO", name
+
+    def test_dumbbell_row_resolves_to_real_subcategory(self) -> None:
+        """Chest Supported Incline Row (Dumbbell) now resolves to a real Row
+        subcategory name instead of a broken out-of-range sub."""
+        from hevy2garmin.merge import _exercise_to_string
+        cat, sub, _ = lookup_exercise("Chest Supported Incline Row (Dumbbell)")
+        assert _exercise_to_string(cat, sub) == "DUMBBELL_ROW"


### PR DESCRIPTION
Two small fixes surfaced while triaging r/Hevy reports.

## 1. Exercise mappings using categories fit_tool can't stringify (Closes #201)

Cycling, Treadmill, Elliptical, Rowing Machine, Air Bike, Battle Ropes, Stair Machine, Spinning and Yoga were mapped to FIT exercise categories 33–52. The installed `fit_tool` (and `_CATEGORY_NAMES`) only implement 0–32, so they resolved to `UNKNOWN` and silently fell back to the generic `TOTAL_BODY` parent instead of their real category. A few Row entries also used out-of-range subcategory ids that never resolved.

Remapped to valid categories that Garmin's strength API accepts:
- cardio machines / battle ropes / boxing → `CARDIO` (generic name)
- yoga → `TOTAL_BODY` (generic; not a strength exercise)
- barbell bent-over / Pendlay rows → `ROW` (generic; no exact fit_tool sub)
- chest-supported incline dumbbell row → `DUMBBELL_ROW` (now shows the specific name)

Added `TestValidCategories` asserting **every** built-in mapping uses a real FIT category (0–32) or the UNKNOWN sentinel, so an out-of-range category can't slip back in.

## 2. Accurate Garmin rate-limit message (Closes #202)

On cloud/browser login (`templates/setup.html`), a Garmin 429 showed "Garmin rate-limited this account. Wait a few minutes and try again." The real wait is hours, and retrying resets the timer (#147), so the wording pushed users toward exactly the behavior that makes it worse. Three r/Hevy users hit this. Reworded to match the already-accurate `server.py` message (their side, separate from password, clears in a few hours, don't keep retrying).

## Tests

Full suite: **253 passed, 7 skipped** (3 new mapping tests). No version bump.
