### PR TITLE
feat: merge reliability — grace period + HR reliability + duplicate detection (self-hosted)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,13 @@ You're on the dashboard. Click **Sync All Workouts** to backfill your history. T
 
 To keep future workouts syncing automatically, toggle **Auto-sync** on the dashboard. This creates a background job that syncs new workouts every 2 hours.
 
+> **Sync timing:** hevy2garmin waits `sync.grace_period_minutes` (default 120)
+> after a workout ends before syncing it automatically, so your Garmin watch
+> activity can land first and it merges into one activity instead of creating a
+> duplicate. On Vercel the default cron runs once a day; if your plan allows,
+> lower the cron interval (e.g. every few hours) so recently-finished workouts
+> sync the same day. Manual "Sync now" always ignores the grace period.
+
 **That's it.** Check [Garmin Connect](https://connect.garmin.com/modern/activities) to see your workouts with proper exercise names, sets, reps, and weights.
 
 ### Web Dashboard (local install)

--- a/src/hevy2garmin/config.py
+++ b/src/hevy2garmin/config.py
@@ -25,6 +25,11 @@ DEFAULT_CONFIG: dict[str, Any] = {
     "sync": {
         "default_limit": 10,
         "skip_existing": True,
+        # Wait this many minutes after a workout ends before syncing it, so the
+        # Garmin watch activity has time to appear and we can merge instead of
+        # uploading a duplicate. 0 = sync immediately (old behavior). Applies to
+        # automatic runs only; manual "sync now" bypasses it.
+        "grace_period_minutes": 120,
     },
     "auto_sync": {
         "enabled": False,

--- a/src/hevy2garmin/reconcile.py
+++ b/src/hevy2garmin/reconcile.py
@@ -1,0 +1,65 @@
+"""Detect (log-only) duplicate Garmin activities left by past sync races.
+
+When hevy2garmin syncs a workout before its Garmin watch activity has landed, it
+uploads a fresh activity; the watch copy appears later and the user has two
+activities for one workout. This module finds those pairs and logs them. It does
+NOT delete anything — deletion is a separate, opt-in feature.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+
+from hevy2garmin.fit import _parse_timestamp
+
+logger = logging.getLogger("hevy2garmin")
+
+
+def detect_duplicates(client, workouts: list[dict], limiter=None) -> list[dict]:
+    """Return a list of duplicate descriptors, one per workout window that holds
+    both a tool-created (manufacturer DEVELOPMENT) and a watch (other
+    manufacturer) activity. Best-effort: never raises."""
+    dups: list[dict] = []
+    for workout in workouts:
+        try:
+            start = _parse_timestamp(workout.get("start_time") or workout.get("startTime", ""))
+            end = _parse_timestamp(workout.get("end_time") or workout.get("endTime", ""))
+            if start is None or end is None:
+                continue
+            # Normalize to naive UTC for comparison so Garmin's naive GMT strings
+            # (no offset) and workout's aware UTC strings can be compared safely.
+            start_naive = start.replace(tzinfo=None)
+            end_naive = end.replace(tzinfo=None)
+            date_str = str(workout.get("start_time") or "")[:10]
+            call = (limiter.call if limiter is not None else (lambda f, *a: f(*a)))
+            acts = call(client.get_activities_by_date, date_str, date_str)
+            tool_id = watch_id = None
+            for act in acts or []:
+                a_start = _parse_timestamp(act.get("startTimeGMT") or act.get("startTimeLocal", ""))
+                a_dur = act.get("duration", 0) or 0
+                if a_start is None or a_dur <= 0:
+                    continue
+                # Normalize activity timestamps to naive UTC as well.
+                a_start_naive = a_start.replace(tzinfo=None)
+                a_end_naive = a_start_naive + timedelta(seconds=a_dur)
+                if a_start_naive > end_naive or a_end_naive < start_naive:
+                    continue
+                manufacturer = str(act.get("manufacturer") or "").upper()
+                if manufacturer == "DEVELOPMENT":
+                    tool_id = act.get("activityId")
+                elif manufacturer:
+                    watch_id = act.get("activityId")
+            if tool_id is not None and watch_id is not None:
+                dup = {"workout_id": workout.get("id"),
+                       "workout_title": workout.get("title"),
+                       "tool_activity_id": tool_id,
+                       "watch_activity_id": watch_id}
+                logger.warning(
+                    "  ⚠ Duplicate for workout %s: tool activity %s + watch activity %s",
+                    dup["workout_id"], tool_id, watch_id,
+                )
+                dups.append(dup)
+        except Exception:
+            logger.debug("duplicate detection skipped for a workout", exc_info=True)
+            continue
+    return dups

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -1318,6 +1318,22 @@ async def api_unsync_all(request: Request):
     return JSONResponse({"ok": True, "count": count})
 
 
+@app.post("/api/scan-duplicates", response_class=HTMLResponse)
+async def api_scan_duplicates(request: Request):
+    """On-demand: scan recent workouts for duplicate tool+watch activity pairs
+    and show the count. Log-only, no deletion."""
+    from hevy2garmin.reconcile import detect_duplicates
+    from hevy2garmin.sync import fetch_workouts, _hr_limiter
+    from hevy2garmin.hevy import HevyClient
+    from hevy2garmin.garmin import get_client
+    cfg = load_config()
+    hevy = HevyClient(api_key=cfg.get("hevy_api_key"))
+    garmin_client = get_client(cfg.get("garmin_email"))
+    workouts = fetch_workouts(hevy, limit=50)
+    dups = detect_duplicates(garmin_client, workouts, _hr_limiter)
+    return HTMLResponse(f"<div>Found {len(dups)} possible duplicate(s). See server logs for details.</div>")
+
+
 @app.post("/api/toggle-autosync", response_class=HTMLResponse)
 async def api_toggle_autosync(request: Request):
     if is_demo_mode():

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -1326,11 +1326,15 @@ async def api_scan_duplicates(request: Request):
     from hevy2garmin.sync import fetch_workouts, _hr_limiter
     from hevy2garmin.hevy import HevyClient
     from hevy2garmin.garmin import get_client
-    cfg = load_config()
-    hevy = HevyClient(api_key=cfg.get("hevy_api_key"))
-    garmin_client = get_client(cfg.get("garmin_email"))
-    workouts = fetch_workouts(hevy, limit=50)
-    dups = detect_duplicates(garmin_client, workouts, _hr_limiter)
+    try:
+        cfg = load_config()
+        hevy = HevyClient(api_key=cfg.get("hevy_api_key"))
+        garmin_client = get_client(cfg.get("garmin_email"))
+        workouts = fetch_workouts(hevy, limit=50)
+        dups = detect_duplicates(garmin_client, workouts, _hr_limiter)
+    except Exception as e:
+        logger.warning("Duplicate scan failed: %s", e)
+        return HTMLResponse(f'<div class="toast toast-error">Scan failed: {e}</div>')
     return HTMLResponse(f"<div>Found {len(dups)} possible duplicate(s). See server logs for details.</div>")
 
 

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -189,7 +189,7 @@ def _run_autosync() -> None:
     logger.info("Auto-sync: running scheduled sync")
     hevy_auth_failed = False
     try:
-        result = sync(limit=10, dry_run=False)
+        result = sync(limit=10, dry_run=False, respect_grace=True)
     except Exception as e:
         from hevy2garmin.hevy import HevyAuthError
         if isinstance(e, HevyAuthError):
@@ -1202,7 +1202,7 @@ async def api_sync(request: Request):
         return HTMLResponse('<div class="toast toast-error">Another sync is already running. Please wait.</div>')
 
     try:
-        result = sync(**sync_kwargs)
+        result = sync(**sync_kwargs, respect_grace=False)
     except Exception as e:
         result = {"synced": 0, "skipped": 0, "failed": 1, "unmapped": [], "error": str(e)}
     finally:

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -8,9 +8,11 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
+from datetime import datetime, timezone
+
 from hevy2garmin import db
 from hevy2garmin.config import load_config
-from hevy2garmin.fit import generate_fit
+from hevy2garmin.fit import generate_fit, _parse_timestamp
 from hevy2garmin.garmin import (
     delete_activity,
     find_activity_by_start_time,
@@ -82,6 +84,7 @@ def sync(
     since: str | None = None,
     fetch_all: bool = False,
     dry_run: bool = False,
+    respect_grace: bool = True,
     **overrides: Any,
 ) -> dict:
     """Sync Hevy workouts to Garmin Connect.
@@ -103,6 +106,7 @@ def sync(
     garmin_password = overrides.get("garmin_password") or cfg.get("garmin_password", "")
     garmin_token_dir = cfg.get("garmin_token_dir", "~/.garminconnect")
     skip_existing = cfg.get("sync", {}).get("skip_existing", True)
+    grace_minutes = cfg.get("sync", {}).get("grace_period_minutes", 120)
 
     if not limit and not fetch_all and not since:
         limit = cfg.get("sync", {}).get("default_limit", 10)
@@ -126,7 +130,7 @@ def sync(
     merge_activity_types = set(cfg.get("merge_activity_types", ["strength_training"]))
     merge_watch_strategy = cfg.get("merge_watch_strategy", "replace")
     description_enabled = cfg.get("description_enabled", True)
-    stats = {"synced": 0, "skipped": 0, "failed": 0, "total": len(workouts), "unmapped": [], "merged": 0, "merge_fallback": 0}
+    stats = {"synced": 0, "skipped": 0, "failed": 0, "total": len(workouts), "unmapped": [], "merged": 0, "merge_fallback": 0, "deferred": 0}
 
     if merge_mode:
         reset_circuit_breaker()
@@ -141,6 +145,19 @@ def sync(
             logger.debug("Skipping %s (%s) — already synced", wid, title)
             stats["skipped"] += 1
             continue
+
+        # Grace period: on automatic runs, wait until the workout has had time
+        # for its Garmin watch activity to land, so we merge instead of
+        # uploading a duplicate. Manual syncs pass respect_grace=False.
+        if respect_grace and grace_minutes > 0:
+            end_raw = workout.get("end_time") or workout.get("endTime", "")
+            end_dt = _parse_timestamp(end_raw)
+            if end_dt is not None and end_dt.tzinfo is not None:
+                age_min = (datetime.now(timezone.utc) - end_dt).total_seconds() / 60.0
+                if age_min < grace_minutes:
+                    logger.info("  Deferring %s — ended %.0f min ago (< %d min grace); waiting for watch data", wid, age_min, grace_minutes)
+                    stats["deferred"] += 1
+                    continue
 
         logger.info("Syncing: %s (%s)", title, wid)
 

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -130,7 +130,7 @@ def sync(
     merge_activity_types = set(cfg.get("merge_activity_types", ["strength_training"]))
     merge_watch_strategy = cfg.get("merge_watch_strategy", "replace")
     description_enabled = cfg.get("description_enabled", True)
-    stats = {"synced": 0, "skipped": 0, "failed": 0, "total": len(workouts), "unmapped": [], "merged": 0, "merge_fallback": 0, "deferred": 0, "no_hr": 0}
+    stats = {"synced": 0, "skipped": 0, "failed": 0, "total": len(workouts), "unmapped": [], "merged": 0, "merge_fallback": 0, "deferred": 0, "no_hr": 0, "duplicates": 0}
 
     if merge_mode:
         reset_circuit_breaker()
@@ -274,6 +274,17 @@ def sync(
     if stats["unmapped"]:
         logger.warning("\nUnmapped exercises: %s", ", ".join(stats["unmapped"]))
         logger.warning("Add custom mappings: hevy2garmin map \"Exercise Name\" --category N --subcategory N")
+
+    # Log-only duplicate scan (best-effort; never breaks a sync).
+    if not dry_run and garmin_client:
+        try:
+            from hevy2garmin.reconcile import detect_duplicates
+            dups = detect_duplicates(garmin_client, workouts, _hr_limiter)
+            stats["duplicates"] = len(dups)
+            if dups:
+                logger.warning("Found %d possible duplicate activity pair(s) from past races", len(dups))
+        except Exception:
+            logger.debug("duplicate scan skipped", exc_info=True)
 
     # Record to sync log (shows up in dashboard)
     trigger = "cli"

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -222,6 +222,7 @@ def sync(
                 # check when the merge wants a fresh upload (#159) — otherwise it
                 # would find the watch activity and refuse to upload the named one.
                 existing_id = None
+                uploaded = False
                 if start_time and not merge_forced_fresh:
                     existing_id = find_activity_by_start_time(garmin_client, start_time)
                 if existing_id:
@@ -230,6 +231,7 @@ def sync(
                 else:
                     upload_result = upload_fit(garmin_client, fit_path, workout_start=start_time)
                     activity_id = upload_result.get("activity_id")
+                    uploaded = bool(activity_id)
                     # "replace" strategy (#159): the named upload succeeded, so
                     # delete the watch recording to keep a single activity.
                     if activity_id and merge_delete_id:
@@ -259,7 +261,7 @@ def sync(
                     hevy_updated_at=workout.get("updated_at"),
                     sync_method=sync_method,
                 )
-                if hr_fusion_on and not hr_samples:
+                if hr_fusion_on and uploaded and not hr_samples:
                     logger.warning("  ⚠ No heart-rate data available for %s — activity uploaded without HR", wid)
                     stats["no_hr"] += 1
                 stats["synced"] += 1

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -130,7 +130,7 @@ def sync(
     merge_activity_types = set(cfg.get("merge_activity_types", ["strength_training"]))
     merge_watch_strategy = cfg.get("merge_watch_strategy", "replace")
     description_enabled = cfg.get("description_enabled", True)
-    stats = {"synced": 0, "skipped": 0, "failed": 0, "total": len(workouts), "unmapped": [], "merged": 0, "merge_fallback": 0, "deferred": 0}
+    stats = {"synced": 0, "skipped": 0, "failed": 0, "total": len(workouts), "unmapped": [], "merged": 0, "merge_fallback": 0, "deferred": 0, "no_hr": 0}
 
     if merge_mode:
         reset_circuit_breaker()
@@ -196,9 +196,14 @@ def sync(
             # Embed merged HR (AirPods-preferred, watch fill) so it reaches
             # Garmin Connect, not just the dashboard (#158). Best-effort.
             hr_samples = None
-            if not dry_run:
+            hr_fusion_on = cfg.get("hr_fusion", {}).get("enabled", True)
+            if not dry_run and hr_fusion_on:
                 from hevy2garmin.hr import hr_for_sync
                 hr_samples = hr_for_sync(db, garmin_client, workout, cfg, _hr_limiter)
+                if not hr_samples:
+                    # One retry — the watch's daily HR for this window may not
+                    # have settled on the first try.
+                    hr_samples = hr_for_sync(db, garmin_client, workout, cfg, _hr_limiter)
 
             with tempfile.TemporaryDirectory() as tmp:
                 fit_path = str(Path(tmp) / f"{wid}.fit")
@@ -254,6 +259,9 @@ def sync(
                     hevy_updated_at=workout.get("updated_at"),
                     sync_method=sync_method,
                 )
+                if hr_fusion_on and not hr_samples:
+                    logger.warning("  ⚠ No heart-rate data available for %s — activity uploaded without HR", wid)
+                    stats["no_hr"] += 1
                 stats["synced"] += 1
                 logger.info("  ✓ Synced → Garmin activity %s", activity_id)
 

--- a/src/hevy2garmin/templates/partials/sync_result.html
+++ b/src/hevy2garmin/templates/partials/sync_result.html
@@ -13,6 +13,9 @@
     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" style="vertical-align: middle; margin-right: 6px;"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg>
     {{ result.synced }} synced, {{ result.failed }} failed
     {% if result.unmapped %} &middot; {{ result.unmapped|length }} unmapped{% endif %}
+    {% if result.get('deferred') %} &middot; {{ result.deferred }} deferred{% endif %}
+    {% if result.get('no_hr') %} &middot; {{ result.no_hr }} without HR{% endif %}
+    {% if result.get('duplicates') %} &middot; {{ result.duplicates }} possible duplicate(s){% endif %}
 </div>
 {% else %}
 <div class="toast toast-success">
@@ -20,5 +23,8 @@
     {{ result.synced }} synced
     {% if result.skipped %}, {{ result.skipped }} skipped{% endif %}
     {% if result.unmapped %} &middot; {{ result.unmapped|length }} unmapped{% endif %}
+    {% if result.get('deferred') %} &middot; {{ result.deferred }} deferred{% endif %}
+    {% if result.get('no_hr') %} &middot; {{ result.no_hr }} without HR{% endif %}
+    {% if result.get('duplicates') %} &middot; {{ result.duplicates }} possible duplicate(s){% endif %}
 </div>
 {% endif %}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -140,3 +140,8 @@ class TestSaveConfigCloud:
              patch("hevy2garmin.db.get_db", return_value=fake_db):
             # Must not propagate — settings save should never 500 on a DB hiccup
             save_config({"user_profile": {"weight_kg": 80.0}})
+
+
+def test_default_has_grace_period() -> None:
+    """DEFAULT_CONFIG must include sync.grace_period_minutes."""
+    assert DEFAULT_CONFIG["sync"]["grace_period_minutes"] == 120

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+from unittest.mock import MagicMock
+
+
+def _act(aid, manufacturer, start="2026-03-15 18:02:00", dur=2580, type_key="strength_training"):
+    return {"activityId": aid, "manufacturer": manufacturer,
+            "startTimeGMT": start, "startTimeLocal": start,
+            "duration": dur, "activityType": {"typeKey": type_key}}
+
+
+WORKOUT = {"id": "w1", "title": "Push",
+           "start_time": "2026-03-15T18:00:00+00:00",
+           "end_time": "2026-03-15T18:45:00+00:00"}
+
+
+def test_detects_tool_plus_watch_pair():
+    from hevy2garmin.reconcile import detect_duplicates
+    client = MagicMock()
+    client.get_activities_by_date.return_value = [
+        _act(1, "DEVELOPMENT"), _act(2, "GARMIN"),
+    ]
+    dups = detect_duplicates(client, [WORKOUT])
+    assert len(dups) == 1
+    d = dups[0]
+    assert d["workout_id"] == "w1"
+    assert {d["tool_activity_id"], d["watch_activity_id"]} == {1, 2}
+
+
+def test_single_activity_is_not_a_duplicate():
+    from hevy2garmin.reconcile import detect_duplicates
+    client = MagicMock()
+    client.get_activities_by_date.return_value = [_act(1, "DEVELOPMENT")]
+    assert detect_duplicates(client, [WORKOUT]) == []
+
+
+def test_never_raises_on_garmin_error():
+    from hevy2garmin.reconcile import detect_duplicates
+    client = MagicMock()
+    client.get_activities_by_date.side_effect = RuntimeError("boom")
+    assert detect_duplicates(client, [WORKOUT]) == []

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -2,12 +2,91 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from hevy2garmin.sync import fetch_workouts, sync
+
+
+def _iso(dt):
+    return dt.isoformat()
+
+
+@patch("hevy2garmin.sync.db")
+@patch("hevy2garmin.sync.get_client")
+@patch("hevy2garmin.sync.HevyClient")
+@patch("hevy2garmin.sync.attempt_merge")
+def test_grace_defers_too_new_workout(mock_merge, mock_hevy_cls, mock_gclient, mock_db):
+    now = datetime.now(timezone.utc)
+    fresh = {
+        "id": "w1", "title": "Push",
+        "start_time": _iso(now - timedelta(minutes=30)),
+        "end_time": _iso(now - timedelta(minutes=10)),
+        "updated_at": _iso(now), "exercises": [],
+    }
+    h = MagicMock()
+    h.get_workout_count.return_value = 1
+    h.get_workouts.return_value = {"workouts": [fresh], "page_count": 1}
+    mock_hevy_cls.return_value = h
+    mock_gclient.return_value = MagicMock()
+    mock_db.is_synced.return_value = False
+    from hevy2garmin.sync import sync
+    stats = sync(config={"hevy_api_key": "t", "merge_mode": True,
+                         "sync": {"grace_period_minutes": 120}}, limit=1)
+    assert stats["deferred"] == 1
+    assert stats["synced"] == 0
+    mock_merge.assert_not_called()
+    mock_db.mark_synced.assert_not_called()
+
+
+@patch("hevy2garmin.sync.db")
+@patch("hevy2garmin.sync.get_client")
+@patch("hevy2garmin.sync.HevyClient")
+@patch("hevy2garmin.sync.attempt_merge")
+def test_grace_processes_old_enough_workout(mock_merge, mock_hevy_cls, mock_gclient, mock_db):
+    from hevy2garmin.merge import MergeResult
+    now = datetime.now(timezone.utc)
+    old = {"id": "w1", "title": "Push",
+           "start_time": _iso(now - timedelta(hours=5)),
+           "end_time": _iso(now - timedelta(hours=4)),
+           "updated_at": _iso(now), "exercises": []}
+    h = MagicMock(); h.get_workout_count.return_value = 1
+    h.get_workouts.return_value = {"workouts": [old], "page_count": 1}
+    mock_hevy_cls.return_value = h; mock_gclient.return_value = MagicMock()
+    mock_db.is_synced.return_value = False
+    mock_merge.return_value = MergeResult(merged=True, activity_id=99)
+    from hevy2garmin.sync import sync
+    stats = sync(config={"hevy_api_key": "t", "merge_mode": True,
+                         "sync": {"grace_period_minutes": 120}}, limit=1)
+    assert stats["deferred"] == 0
+    assert stats["synced"] == 1
+
+
+@patch("hevy2garmin.sync.db")
+@patch("hevy2garmin.sync.get_client")
+@patch("hevy2garmin.sync.HevyClient")
+@patch("hevy2garmin.sync.attempt_merge")
+def test_manual_run_bypasses_grace(mock_merge, mock_hevy_cls, mock_gclient, mock_db):
+    from hevy2garmin.merge import MergeResult
+    now = datetime.now(timezone.utc)
+    fresh = {"id": "w1", "title": "Push",
+             "start_time": _iso(now - timedelta(minutes=20)),
+             "end_time": _iso(now - timedelta(minutes=5)),
+             "updated_at": _iso(now), "exercises": []}
+    h = MagicMock(); h.get_workout_count.return_value = 1
+    h.get_workouts.return_value = {"workouts": [fresh], "page_count": 1}
+    mock_hevy_cls.return_value = h; mock_gclient.return_value = MagicMock()
+    mock_db.is_synced.return_value = False
+    mock_merge.return_value = MergeResult(merged=True, activity_id=99)
+    from hevy2garmin.sync import sync
+    stats = sync(config={"hevy_api_key": "t", "merge_mode": True,
+                         "sync": {"grace_period_minutes": 120}},
+                 limit=1, respect_grace=False)
+    assert stats["deferred"] == 0
+    assert stats["synced"] == 1
 
 
 class TestFetchWorkouts:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -307,3 +307,28 @@ def test_no_hr_not_counted_on_dedup_path(mock_hr, *rest):
     mock_upload.assert_not_called()   # dedup: nothing uploaded
     assert stats["no_hr"] == 0        # so no_hr must not fire
     assert stats["synced"] == 1
+
+
+@patch("hevy2garmin.sync.db")
+@patch("hevy2garmin.sync.get_client")
+@patch("hevy2garmin.sync.HevyClient")
+@patch("hevy2garmin.sync.attempt_merge")
+@patch("hevy2garmin.reconcile.detect_duplicates")
+def test_sync_runs_duplicate_scan(mock_detect, mock_merge, mock_hevy_cls, mock_gclient, mock_db):
+    from hevy2garmin.merge import MergeResult
+    now = datetime.now(timezone.utc)
+    w = {"id": "w1", "title": "Push",
+         "start_time": (now - timedelta(hours=4)).isoformat(),
+         "end_time": (now - timedelta(hours=3)).isoformat(),
+         "updated_at": now.isoformat(), "exercises": []}
+    h = MagicMock(); h.get_workout_count.return_value = 1
+    h.get_workouts.return_value = {"workouts": [w], "page_count": 1}
+    mock_hevy_cls.return_value = h; mock_gclient.return_value = MagicMock()
+    mock_db.is_synced.return_value = False
+    mock_merge.return_value = MergeResult(merged=True, activity_id=99)
+    mock_detect.return_value = [{"workout_id": "w1", "tool_activity_id": 1, "watch_activity_id": 2}]
+    from hevy2garmin.sync import sync
+    stats = sync(config={"hevy_api_key": "t", "merge_mode": True,
+                         "sync": {"grace_period_minutes": 120}}, limit=1)
+    assert stats["duplicates"] == 1
+    mock_detect.assert_called_once()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -270,3 +270,40 @@ def test_hr_fusion_disabled_no_retry_no_count(mock_hr, *rest):
                          "hr_fusion": {"enabled": False}}, limit=1)
     assert mock_hr.call_count == 0
     assert stats["no_hr"] == 0
+
+
+@patch("hevy2garmin.sync.db")
+@patch("hevy2garmin.sync.get_client")
+@patch("hevy2garmin.sync.HevyClient")
+@patch("hevy2garmin.sync.attempt_merge")
+@patch("hevy2garmin.sync.generate_fit", return_value={"exercises": 1, "total_sets": 1, "calories": 100, "avg_hr": None})
+@patch("hevy2garmin.sync.upload_fit")
+@patch("hevy2garmin.sync.find_activity_by_start_time", return_value=555)
+@patch("hevy2garmin.sync.rename_activity")
+@patch("hevy2garmin.sync.set_description")
+@patch("hevy2garmin.sync.generate_description", return_value="d")
+@patch("hevy2garmin.hr.hr_for_sync")
+def test_no_hr_not_counted_on_dedup_path(mock_hr, *rest):
+    """When the activity already exists on Garmin (dedup, no upload), no_hr must
+    NOT fire — nothing was uploaded, and the existing activity may have its own HR."""
+    from hevy2garmin.merge import MergeResult
+    (mock_desc, mock_setdesc, mock_rename, mock_find, mock_upload,
+     mock_fit, mock_merge, mock_hevy_cls, mock_gclient, mock_db) = rest
+    mock_hr.return_value = None
+    now = datetime.now(timezone.utc)
+    w = {"id": "w1", "title": "Push",
+         "start_time": (now - timedelta(hours=4)).isoformat(),
+         "end_time": (now - timedelta(hours=3)).isoformat(),
+         "updated_at": now.isoformat(), "exercises": [{"title": "Bench Press (Barbell)", "sets": [{"type": "normal", "weight_kg": 60, "reps": 8}]}]}
+    h = MagicMock(); h.get_workout_count.return_value = 1
+    h.get_workouts.return_value = {"workouts": [w], "page_count": 1}
+    mock_hevy_cls.return_value = h; mock_gclient.return_value = MagicMock()
+    mock_db.is_synced.return_value = False
+    mock_merge.return_value = MergeResult(merged=False, force_fresh_upload=False, fallback_reason="no match")
+    from hevy2garmin.sync import sync
+    stats = sync(config={"hevy_api_key": "t", "merge_mode": True,
+                         "sync": {"grace_period_minutes": 120},
+                         "hr_fusion": {"enabled": True}}, limit=1)
+    mock_upload.assert_not_called()   # dedup: nothing uploaded
+    assert stats["no_hr"] == 0        # so no_hr must not fire
+    assert stats["synced"] == 1

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -203,3 +203,70 @@ class TestSync:
             result = sync(limit=1, hevy_api_key="test", garmin_email="e", garmin_password="p")
             mock_db.mark_synced.assert_called_once()
             assert result["synced"] == 1
+
+
+@patch("hevy2garmin.sync.db")
+@patch("hevy2garmin.sync.get_client")
+@patch("hevy2garmin.sync.HevyClient")
+@patch("hevy2garmin.sync.attempt_merge")
+@patch("hevy2garmin.sync.generate_fit", return_value={"exercises": 1, "total_sets": 1, "calories": 100, "avg_hr": None})
+@patch("hevy2garmin.sync.upload_fit", return_value={"activity_id": 222})
+@patch("hevy2garmin.sync.find_activity_by_start_time", return_value=None)
+@patch("hevy2garmin.sync.rename_activity")
+@patch("hevy2garmin.sync.set_description")
+@patch("hevy2garmin.sync.generate_description", return_value="d")
+@patch("hevy2garmin.hr.hr_for_sync")
+def test_hr_empty_retries_once_then_counts_no_hr(mock_hr, *rest):
+    from hevy2garmin.merge import MergeResult
+    (mock_desc, mock_setdesc, mock_rename, mock_find, mock_upload,
+     mock_fit, mock_merge, mock_hevy_cls, mock_gclient, mock_db) = rest
+    mock_hr.return_value = None
+    now = datetime.now(timezone.utc)
+    w = {"id": "w1", "title": "Push",
+         "start_time": (now - timedelta(hours=4)).isoformat(),
+         "end_time": (now - timedelta(hours=3)).isoformat(),
+         "updated_at": now.isoformat(), "exercises": [{"title": "Bench Press (Barbell)", "sets": [{"type": "normal", "weight_kg": 60, "reps": 8}]}]}
+    h = MagicMock(); h.get_workout_count.return_value = 1
+    h.get_workouts.return_value = {"workouts": [w], "page_count": 1}
+    mock_hevy_cls.return_value = h; mock_gclient.return_value = MagicMock()
+    mock_db.is_synced.return_value = False
+    mock_merge.return_value = MergeResult(merged=False, force_fresh_upload=True, fallback_reason="no match")
+    from hevy2garmin.sync import sync
+    stats = sync(config={"hevy_api_key": "t", "merge_mode": True,
+                         "sync": {"grace_period_minutes": 120},
+                         "hr_fusion": {"enabled": True}}, limit=1)
+    assert mock_hr.call_count == 2
+    assert stats["no_hr"] == 1
+
+
+@patch("hevy2garmin.sync.db")
+@patch("hevy2garmin.sync.get_client")
+@patch("hevy2garmin.sync.HevyClient")
+@patch("hevy2garmin.sync.attempt_merge")
+@patch("hevy2garmin.sync.generate_fit", return_value={"exercises": 1, "total_sets": 1, "calories": 100, "avg_hr": None})
+@patch("hevy2garmin.sync.upload_fit", return_value={"activity_id": 222})
+@patch("hevy2garmin.sync.find_activity_by_start_time", return_value=None)
+@patch("hevy2garmin.sync.rename_activity")
+@patch("hevy2garmin.sync.set_description")
+@patch("hevy2garmin.sync.generate_description", return_value="d")
+@patch("hevy2garmin.hr.hr_for_sync")
+def test_hr_fusion_disabled_no_retry_no_count(mock_hr, *rest):
+    from hevy2garmin.merge import MergeResult
+    (mock_desc, mock_setdesc, mock_rename, mock_find, mock_upload,
+     mock_fit, mock_merge, mock_hevy_cls, mock_gclient, mock_db) = rest
+    now = datetime.now(timezone.utc)
+    w = {"id": "w1", "title": "Push",
+         "start_time": (now - timedelta(hours=4)).isoformat(),
+         "end_time": (now - timedelta(hours=3)).isoformat(),
+         "updated_at": now.isoformat(), "exercises": [{"title": "Bench Press (Barbell)", "sets": [{"type": "normal", "weight_kg": 60, "reps": 8}]}]}
+    h = MagicMock(); h.get_workout_count.return_value = 1
+    h.get_workouts.return_value = {"workouts": [w], "page_count": 1}
+    mock_hevy_cls.return_value = h; mock_gclient.return_value = MagicMock()
+    mock_db.is_synced.return_value = False
+    mock_merge.return_value = MergeResult(merged=False, force_fresh_upload=True, fallback_reason="no match")
+    from hevy2garmin.sync import sync
+    stats = sync(config={"hevy_api_key": "t", "merge_mode": True,
+                         "sync": {"grace_period_minutes": 120},
+                         "hr_fusion": {"enabled": False}}, limit=1)
+    assert mock_hr.call_count == 0
+    assert stats["no_hr"] == 0


### PR DESCRIPTION
## What

Watch-recorded workouts synced unreliably: hevy2garmin often ran before the Garmin watch activity had landed, uploaded a fresh activity, and the watch copy showed up later, leaving two activities (the "totally random" reports on r/Hevy). Fresh uploads also sometimes landed without HR, silently.

This adds three things on the bulk `sync()` path (CLI + self-hosted autosync):

- **Grace period** (`sync.grace_period_minutes`, default 120). Automatic runs defer a just-finished workout until it is older than the grace window, so the watch activity has time to land and it merges into one activity instead of duplicating. Manual "Sync now" bypasses (explicit intent).
- **HR reliability.** On the fresh-upload path, the HR fetch retries once if empty, and an upload that lands without HR is counted (`no_hr`) and logged, instead of the old silent best-effort. Merges are untouched (they keep native watch HR); the dedup path does not count.
- **Duplicate detection (log-only).** A best-effort scan finds workouts that ended up with both a tool-created (`DEVELOPMENT`) and a watch activity and reports a count, plus a manual `/api/scan-duplicates` endpoint. It never deletes anything. New counts (`deferred`, `no_hr`, `duplicates`) surface in the sync result.

## Scope

**Self-hosted / CLI only.** The Vercel cron uses a separate duplicated sync path (`_do_sync_one`), which is intentionally untouched here. Bringing this to Vercel by unifying the two paths (keeping the serverless one-workout-per-invocation behavior) is tracked in #206.

## Tests

New tests across `tests/test_config.py`, `tests/test_sync.py`, `tests/test_reconcile.py` cover: grace defer / old-enough / manual-bypass; HR retry + `no_hr` count + fusion-disabled + no-count-on-dedup; reconcile detect / single / error-safe; and the scan wiring. Full suite: **264 passed, 7 skipped**. Import + CLI checks pass. No version bump (release separately).

Closes #205
