### PR TITLE
fix: unify CLI and web sync through sync_one_workout

### DIFF
--- a/src/hevy2garmin/db.py
+++ b/src/hevy2garmin/db.py
@@ -132,3 +132,18 @@ def get_cached_hr(hevy_id: str, **kw) -> dict | None:
 def cache_hr(hevy_id: str, data: dict, **kw) -> None:
     """Cache HR data for a workout."""
     return get_db().cache_hr(hevy_id, data)
+
+
+def get_stale_synced(workouts: list[dict], **kw) -> list[str]:
+    """Return hevy_ids of synced workouts edited on Hevy since sync."""
+    return get_db().get_stale_synced(workouts)
+
+
+def get_app_config(key: str, **kw) -> dict | None:
+    """Get a JSON value from the generic key-value app cache."""
+    return get_db().get_app_config(key)
+
+
+def set_app_config(key: str, value: dict, **kw) -> None:
+    """Store a JSON value in the generic key-value app cache."""
+    return get_db().set_app_config(key, value)

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -1300,11 +1300,13 @@ async def api_sync_single(request: Request, workout_id: str):
             reset_circuit_breaker()
 
         garmin_client = get_client(config.get("garmin_email"))
+        # Manual single-workout upload from the workouts page — bypass grace.
         sync_one_workout(
             workout,
             cfg=config,
             garmin_client=garmin_client,
             force_upload=force_upload,
+            respect_grace=False,
             database=db.get_db(),
         )
 
@@ -1674,7 +1676,8 @@ async def api_sync_one(request: Request):
         return JSONResponse({"error": "Sync already running", "busy": True})
 
     try:
-        return await _do_sync_one(request)
+        # Manual Sync Now — bypass grace so the user gets an immediate upload.
+        return await _do_sync_one(request, respect_grace=False)
     finally:
         _sync_executing.release()
 
@@ -1716,8 +1719,12 @@ def _scan_for_unsynced(hevy, is_synced, total_count, failed_ids, on_page=None):
     return unsynced, unmapped
 
 
-async def _do_sync_one(request: Request):
-    """Inner sync logic, called with _sync_executing lock held."""
+async def _do_sync_one(request: Request, *, respect_grace: bool = False):
+    """Inner sync logic, called with _sync_executing lock held.
+
+    ``respect_grace`` is True for Vercel cron (wait for watch data) and False
+    for manual Sync Now.
+    """
     from fastapi.responses import JSONResponse
 
     config = load_config()
@@ -1744,65 +1751,98 @@ async def _do_sync_one(request: Request):
             {"workouts": data.get("workouts", []), "page_count": data.get("page_count", 1)},
         )
 
-    unsynced, unmapped_found = _scan_for_unsynced(
-        hevy, db.is_synced, total_count, _failed_ids, on_page=_cache_page
-    )
-    # Update unmapped cache in DB
-    if unmapped_found:
-        _db.set_app_config("unmapped_exercises", unmapped_found)
+    # Skip ids that are already failed this session, or deferred by grace this
+    # invocation (cron continues to the next older unsynced workout).
+    skip_ids = set(_failed_ids)
+    deferred_count = 0
+    unsynced = None
+    unmapped_found: dict[str, int] = {}
+    garmin_client = None
 
-    if not unsynced:
-        return JSONResponse({"synced": 0, "remaining": 0, "done": True})
+    from hevy2garmin.sync import _workout_within_grace, sync_one_workout
 
-    # Sync this one workout
-    try:
-        from hevy2garmin.garmin import get_client
-        from hevy2garmin.merge import reset_circuit_breaker
-        from hevy2garmin.sync import sync_one_workout
-
-        if config.get("merge_mode", True):
-            reset_circuit_breaker()
-
-        garmin_client = get_client(config.get("garmin_email"))
-        sync_one_workout(
-            unsynced,
-            cfg=config,
-            garmin_client=garmin_client,
-            database=db.get_db(),
+    while True:
+        unsynced, unmapped_found = _scan_for_unsynced(
+            hevy, db.is_synced, total_count, skip_ids, on_page=_cache_page
         )
+        if unmapped_found:
+            _db.set_app_config("unmapped_exercises", unmapped_found)
 
-        remaining = hevy.get_workout_count() - db.get_synced_count()
-        return JSONResponse({"synced": 1, "title": unsynced["title"], "remaining": max(0, remaining), "done": remaining <= 0})
-    except Exception as e:
-        logger.error("Sync failed for %s: %s", unsynced.get("title", "?"), str(e)[:300])
-        err = str(e)
+        if not unsynced:
+            if deferred_count:
+                return JSONResponse({
+                    "synced": 0,
+                    "deferred": deferred_count,
+                    "remaining": remaining,
+                    "done": remaining <= 0,
+                })
+            return JSONResponse({"synced": 0, "remaining": 0, "done": True})
 
-        # Hevy API key invalid — hard stop, point to setup
-        from hevy2garmin.hevy import HevyAuthError
-        if isinstance(e, HevyAuthError):
-            return JSONResponse({"synced": 0, "error": "Hevy API key is invalid or expired. Go to Setup to enter a new key.", "remaining": -1, "done": False}, status_code=401)
+        # Defer before Garmin auth when possible (cron cold starts).
+        grace_minutes = config.get("sync", {}).get("grace_period_minutes", 120)
+        if respect_grace and _workout_within_grace(unsynced, grace_minutes):
+            sync_one_workout(unsynced, cfg=config, respect_grace=True)
+            deferred_count += 1
+            skip_ids.add(unsynced["id"])
+            continue
 
-        # Auth errors are hard stops — user needs to reconnect
-        if "Login failed" in err or "OAuth" in err or "token" in err:
-            return JSONResponse({"synced": 0, "error": "Garmin connection expired. Go to Setup to reconnect.", "remaining": -1, "done": False}, status_code=500)
+        try:
+            from hevy2garmin.garmin import get_client
+            from hevy2garmin.merge import reset_circuit_breaker
 
-        # EU consent error — hard stop with clear instructions
-        if "upload consent" in err.lower() or "EU location" in err:
-            return JSONResponse({
-                "synced": 0,
-                "error": "Garmin requires upload consent. Open connect.garmin.com/modern/settings, scroll to Data, enable Device Upload, then try again.",
-                "eu_consent": True,
-                "remaining": -1, "done": False
-            }, status_code=500)
+            if config.get("merge_mode", True):
+                reset_circuit_breaker()
 
-        # Other upload errors — skip this workout for now, don't mark as synced
-        # Track in-memory so we don't retry it in the same sync session
-        _failed_ids.add(unsynced["id"])
-        remaining = hevy.get_workout_count() - db.get_synced_count() - len(_failed_ids)
-        logger.warning("Skipping failed workout %s (will retry next session), %d remaining", unsynced["title"], remaining)
-        return JSONResponse({"synced": 0, "skipped_error": True, "title": unsynced["title"], "remaining": max(0, remaining), "done": remaining <= 0})
+            if garmin_client is None:
+                garmin_client = get_client(config.get("garmin_email"))
+            one = sync_one_workout(
+                unsynced,
+                cfg=config,
+                garmin_client=garmin_client,
+                respect_grace=False,  # already checked above
+                database=db.get_db(),
+            )
 
+            remaining = hevy.get_workout_count() - db.get_synced_count()
+            payload = {
+                "synced": 1,
+                "title": unsynced["title"],
+                "remaining": max(0, remaining),
+                "done": remaining <= 0,
+            }
+            if deferred_count:
+                payload["deferred"] = deferred_count
+            if one.no_hr:
+                payload["no_hr"] = 1
+            return JSONResponse(payload)
+        except Exception as e:
+            logger.error("Sync failed for %s: %s", unsynced.get("title", "?"), str(e)[:300])
+            err = str(e)
 
+            # Hevy API key invalid — hard stop, point to setup
+            from hevy2garmin.hevy import HevyAuthError
+            if isinstance(e, HevyAuthError):
+                return JSONResponse({"synced": 0, "error": "Hevy API key is invalid or expired. Go to Setup to enter a new key.", "remaining": -1, "done": False}, status_code=401)
+
+            # Auth errors are hard stops — user needs to reconnect
+            if "Login failed" in err or "OAuth" in err or "token" in err:
+                return JSONResponse({"synced": 0, "error": "Garmin connection expired. Go to Setup to reconnect.", "remaining": -1, "done": False}, status_code=500)
+
+            # EU consent error — hard stop with clear instructions
+            if "upload consent" in err.lower() or "EU location" in err:
+                return JSONResponse({
+                    "synced": 0,
+                    "error": "Garmin requires upload consent. Open connect.garmin.com/modern/settings, scroll to Data, enable Device Upload, then try again.",
+                    "eu_consent": True,
+                    "remaining": -1, "done": False
+                }, status_code=500)
+
+            # Other upload errors — skip this workout for now, don't mark as synced
+            # Track in-memory so we don't retry it in the same sync session
+            _failed_ids.add(unsynced["id"])
+            remaining = hevy.get_workout_count() - db.get_synced_count() - len(_failed_ids)
+            logger.warning("Skipping failed workout %s (will retry next session), %d remaining", unsynced["title"], remaining)
+            return JSONResponse({"synced": 0, "skipped_error": True, "title": unsynced["title"], "remaining": max(0, remaining), "done": remaining <= 0})
 
 
 @app.get("/api/cron/sync")
@@ -1817,8 +1857,17 @@ async def cron_sync(request: Request):
         if auth != f"Bearer {cron_secret}":
             return JSONResponse({"error": "Unauthorized"}, status_code=401)
 
-    # Reuse sync-one logic
-    return await api_sync_one(request)
+    if is_demo_mode():
+        return JSONResponse({"status": "demo", "message": "Sync disabled in demo mode"})
+
+    if not _acquire_sync_lock():
+        return JSONResponse({"error": "Sync already running", "busy": True})
+
+    try:
+        # Cron/autosync — respect grace so watch activities can land first.
+        return await _do_sync_one(request, respect_grace=True)
+    finally:
+        _sync_executing.release()
 
 
 def run_server(host: str = "0.0.0.0", port: int = 8000) -> None:

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -1781,7 +1781,11 @@ async def _do_sync_one(request: Request, *, respect_grace: bool = False):
         # Defer before Garmin auth when possible (cron cold starts).
         grace_minutes = config.get("sync", {}).get("grace_period_minutes", 120)
         if respect_grace and _workout_within_grace(unsynced, grace_minutes):
-            sync_one_workout(unsynced, cfg=config, respect_grace=True)
+            logger.info(
+                "Deferring %s — within %d min grace; waiting for watch data",
+                unsynced["id"],
+                grace_minutes,
+            )
             deferred_count += 1
             skip_ids.add(unsynced["id"])
             continue

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -190,7 +190,7 @@ def _run_autosync() -> None:
     logger.info("Auto-sync: running scheduled sync")
     hevy_auth_failed = False
     try:
-        result = sync(limit=10, dry_run=False, respect_grace=True)
+        result = sync(limit=10, dry_run=False, record_log=False, respect_grace=True)
     except Exception as e:
         from hevy2garmin.hevy import HevyAuthError
         if isinstance(e, HevyAuthError):
@@ -1271,7 +1271,7 @@ async def api_sync(request: Request):
         return HTMLResponse('<div class="toast toast-error">Another sync is already running. Please wait.</div>')
 
     try:
-        result = sync(**sync_kwargs, respect_grace=False)
+        result = sync(**sync_kwargs, record_log=False, respect_grace=False)
     except Exception as e:
         result = {"synced": 0, "skipped": 0, "failed": 1, "unmapped": [], "error": str(e)}
     finally:
@@ -1285,43 +1285,28 @@ async def api_sync(request: Request):
 async def api_sync_single(request: Request, workout_id: str):
     try:
         from hevy2garmin.hevy import HevyClient
-        from hevy2garmin.fit import generate_fit
-        from hevy2garmin.garmin import get_client, rename_activity, set_description, upload_fit, generate_description, find_activity_by_start_time
-        import tempfile
+        from hevy2garmin.garmin import get_client
+        from hevy2garmin.merge import reset_circuit_breaker
+        from hevy2garmin.sync import sync_one_workout
 
-        # force_upload=true skips dedup (used by re-sync after edit)
         force_upload = request.query_params.get("force") == "1"
 
         config = load_config()
-        # Fetch the exact workout by ID — scanning only the first page missed
-        # older workouts for users with more than a page of history (#165).
         workout = HevyClient(api_key=config.get("hevy_api_key")).get_workout(workout_id)
         if not workout:
             return HTMLResponse('<td colspan="5">Workout not found</td>')
 
+        if config.get("merge_mode", True):
+            reset_circuit_breaker()
+
         garmin_client = get_client(config.get("garmin_email"))
-        workout_start = workout.get("start_time")
-
-        # Dedup: check if activity already exists on Garmin (skip if force)
-        existing_id = None
-        if not force_upload and workout_start:
-            existing_id = find_activity_by_start_time(garmin_client, workout_start)
-
-        from hevy2garmin.hr import hr_for_sync
-        hr_samples = hr_for_sync(db, garmin_client, workout, config)
-        with tempfile.TemporaryDirectory() as tmp:
-            fit_path = f"{tmp}/{workout_id}.fit"
-            result = generate_fit(workout, hr_samples=hr_samples, output_path=fit_path)
-            if existing_id:
-                aid = existing_id
-                logger.info("Activity already on Garmin (%s), skipping upload", aid)
-            else:
-                upload_result = upload_fit(garmin_client, fit_path, workout_start=workout_start)
-                aid = upload_result.get("activity_id")
-            if aid:
-                rename_activity(garmin_client, aid, workout["title"])
-                set_description(garmin_client, aid, generate_description(workout, calories=result.get("calories"), avg_hr=result.get("avg_hr")))
-            db.mark_synced(hevy_id=workout_id, garmin_activity_id=str(aid) if aid else None, title=workout["title"], calories=result.get("calories"), avg_hr=result.get("avg_hr"), hevy_updated_at=workout.get("updated_at"))
+        sync_one_workout(
+            workout,
+            cfg=config,
+            garmin_client=garmin_client,
+            force_upload=force_upload,
+            database=db.get_db(),
+        )
 
         start = (workout.get("start_time") or "")[:16]
         return HTMLResponse(f'<tr><td><span class="badge badge-success">✓ Synced</span></td><td>{start}</td><td><strong>{workout["title"]}</strong></td><td>{len(workout.get("exercises", []))}</td><td></td></tr>')
@@ -1742,9 +1727,6 @@ async def _do_sync_one(request: Request):
         return JSONResponse({"error": "Hevy API key not configured"}, status_code=400)
 
     from hevy2garmin.hevy import HevyClient
-    from hevy2garmin.garmin import get_client, upload_fit, rename_activity, set_description, generate_description
-    from hevy2garmin.fit import generate_fit
-    import tempfile
 
     hevy = HevyClient(api_key=hevy_api_key)
 
@@ -1774,99 +1756,19 @@ async def _do_sync_one(request: Request):
 
     # Sync this one workout
     try:
-        from hevy2garmin.garmin import find_activity_by_start_time
-        from hevy2garmin.merge import attempt_merge
+        from hevy2garmin.garmin import get_client
+        from hevy2garmin.merge import reset_circuit_breaker
+        from hevy2garmin.sync import sync_one_workout
+
+        if config.get("merge_mode", True):
+            reset_circuit_breaker()
+
         garmin_client = get_client(config.get("garmin_email"))
-        workout_start = unsynced.get("start_time")
-        merge_mode = config.get("merge_mode", True)
-        sync_method = "upload"
-        merge_forced_fresh = False
-        merge_delete_id = None
-
-        # Merge mode: try to enhance a watch-recorded activity with Hevy data
-        if merge_mode:
-            merge_result = attempt_merge(
-                garmin_client, unsynced, db.get_db(),
-                overlap_threshold=config.get("merge_overlap_pct", 70) / 100.0,
-                max_drift_minutes=config.get("merge_max_drift_min", 20),
-                activity_types=set(config.get("merge_activity_types", ["strength_training"])),
-                watch_strategy=config.get("merge_watch_strategy", "replace"),
-            )
-            if merge_result.merged:
-                aid = merge_result.activity_id
-                result = {"calories": 0, "avg_hr": None}
-                # Generate FIT just for calorie estimate
-                with tempfile.TemporaryDirectory() as tmp:
-                    fit_path = f"{tmp}/{unsynced['id']}.fit"
-                    result = generate_fit(unsynced, hr_samples=None, output_path=fit_path)
-                sync_method = "merge"
-                db.mark_synced(
-                    hevy_id=unsynced["id"],
-                    garmin_activity_id=str(aid),
-                    title=unsynced["title"],
-                    calories=result.get("calories"),
-                    avg_hr=result.get("avg_hr"),
-                    hevy_updated_at=unsynced.get("updated_at"),
-                    sync_method=sync_method,
-                )
-                remaining = hevy.get_workout_count() - db.get_synced_count()
-                return JSONResponse({"synced": 1, "title": unsynced["title"], "remaining": max(0, remaining), "done": remaining <= 0})
-            merge_forced_fresh = merge_result.force_fresh_upload
-            merge_delete_id = merge_result.delete_after_upload
-
-        # HR enrichment for the uploaded FIT (#158): merged HR (AirPods-preferred,
-        # watch fill), best-effort. Computed after the merge early-return so the
-        # merge path doesn't pay for an HR fetch it won't upload.
-        from hevy2garmin.hr import hr_for_sync
-        hr_samples = hr_for_sync(db, garmin_client, unsynced, config)
-
-        # Dedup: check if this workout already exists on Garmin before uploading.
-        # Prevents duplicates when a prior sync uploaded successfully but crashed
-        # before marking the workout as synced in the DB. Skip it when the merge
-        # asked for a fresh named upload (#159), else it finds the watch activity.
-        existing_id = None
-        if workout_start and not merge_forced_fresh:
-            existing_id = find_activity_by_start_time(garmin_client, workout_start)
-
-        if existing_id:
-            logger.info("Activity already on Garmin (%s), skipping upload for %s", existing_id, unsynced["title"])
-            aid = existing_id
-            # Still generate FIT to get calorie estimate
-            with tempfile.TemporaryDirectory() as tmp:
-                fit_path = f"{tmp}/{unsynced['id']}.fit"
-                result = generate_fit(unsynced, hr_samples=hr_samples, output_path=fit_path)
-            rename_activity(garmin_client, aid, unsynced["title"])
-            desc = generate_description(unsynced, calories=result.get("calories"), avg_hr=result.get("avg_hr"))
-            set_description(garmin_client, aid, desc)
-            sync_method = "upload_fallback"
-        else:
-            with tempfile.TemporaryDirectory() as tmp:
-                fit_path = f"{tmp}/{unsynced['id']}.fit"
-                result = generate_fit(unsynced, hr_samples=hr_samples, output_path=fit_path)
-                upload_result = upload_fit(garmin_client, fit_path, workout_start=workout_start)
-                aid = upload_result.get("activity_id")
-                if aid and merge_delete_id:
-                    # "replace" strategy (#159): named upload succeeded, delete the
-                    # watch recording so the workout is a single activity.
-                    try:
-                        from hevy2garmin.garmin import delete_activity
-                        delete_activity(garmin_client, merge_delete_id)
-                        logger.info("Removed watch copy %s (replaced by %s)", merge_delete_id, aid)
-                    except Exception as e:
-                        logger.warning("Could not delete watch activity %s: %s", merge_delete_id, e)
-                if aid:
-                    rename_activity(garmin_client, aid, unsynced["title"])
-                    desc = generate_description(unsynced, calories=result.get("calories"), avg_hr=result.get("avg_hr"))
-                    set_description(garmin_client, aid, desc)
-
-        db.mark_synced(
-            hevy_id=unsynced["id"],
-            garmin_activity_id=str(aid) if aid else None,
-            title=unsynced["title"],
-            calories=result.get("calories"),
-            avg_hr=result.get("avg_hr"),
-            hevy_updated_at=unsynced.get("updated_at"),
-            sync_method=sync_method,
+        sync_one_workout(
+            unsynced,
+            cfg=config,
+            garmin_client=garmin_client,
+            database=db.get_db(),
         )
 
         remaining = hevy.get_workout_count() - db.get_synced_count()

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -39,7 +39,7 @@ logger = logging.getLogger("hevy2garmin")
 class SyncOneResult:
     """Outcome of syncing a single Hevy workout."""
 
-    status: str  # "synced" | "dry_run"
+    status: str  # "synced" | "dry_run" | "deferred"
     activity_id: int | None = None
     sync_method: str = "upload"
     merged: bool = False
@@ -47,6 +47,18 @@ class SyncOneResult:
     calories: int | None = None
     avg_hr: int | None = None
     no_hr: bool = False
+
+
+def _workout_within_grace(workout: dict, grace_minutes: int) -> bool:
+    """True when the workout ended less than ``grace_minutes`` ago."""
+    if grace_minutes <= 0:
+        return False
+    end_raw = workout.get("end_time") or workout.get("endTime", "")
+    end_dt = _parse_timestamp(end_raw)
+    if end_dt is None or end_dt.tzinfo is None:
+        return False
+    age_min = (datetime.now(timezone.utc) - end_dt).total_seconds() / 60.0
+    return age_min < grace_minutes
 
 
 def fetch_workouts(
@@ -106,9 +118,13 @@ def sync_one_workout(
     garmin_client=None,
     dry_run: bool = False,
     force_upload: bool = False,
+    respect_grace: bool = False,
     database: Any | None = None,
 ) -> SyncOneResult:
     """Sync one Hevy workout to Garmin (merge, FIT upload, or dry-run).
+
+    When ``respect_grace`` is True (autosync/cron), too-new workouts return
+    ``status="deferred"`` so a watch activity can land before we upload.
 
     Raises on FIT generation / upload failures so callers can map errors.
     """
@@ -116,6 +132,25 @@ def sync_one_workout(
     wid = workout.get("id", "unknown")
     title = workout.get("title", "Workout")
     start_time = workout.get("start_time") or workout.get("startTime", "")
+
+    grace_minutes = cfg.get("sync", {}).get("grace_period_minutes", 120)
+    if respect_grace and _workout_within_grace(workout, grace_minutes):
+        end_raw = workout.get("end_time") or workout.get("endTime", "")
+        end_dt = _parse_timestamp(end_raw)
+        age_min = (
+            (datetime.now(timezone.utc) - end_dt).total_seconds() / 60.0
+            if end_dt is not None
+            else 0.0
+        )
+        logger.info(
+            "  Deferring %s — ended %.0f min ago (< %d min grace); waiting for watch data",
+            wid,
+            age_min,
+            grace_minutes,
+        )
+        return SyncOneResult(status="deferred")
+
+    logger.info("Syncing: %s (%s)", title, wid)
 
     merge_mode = cfg.get("merge_mode", True)
     merge_overlap_pct = cfg.get("merge_overlap_pct", 70) / 100.0
@@ -293,7 +328,6 @@ def sync(
     garmin_password = overrides.get("garmin_password") or cfg.get("garmin_password", "")
     garmin_token_dir = cfg.get("garmin_token_dir", "~/.garminconnect")
     skip_existing = cfg.get("sync", {}).get("skip_existing", True)
-    grace_minutes = cfg.get("sync", {}).get("grace_period_minutes", 120)
 
     if not limit and not fetch_all and not since:
         limit = cfg.get("sync", {}).get("default_limit", 10)
@@ -338,26 +372,6 @@ def sync(
             stats["skipped"] += 1
             continue
 
-        # Grace period: on automatic runs, wait until the workout has had time
-        # for its Garmin watch activity to land, so we merge instead of
-        # uploading a duplicate. Manual syncs pass respect_grace=False.
-        if respect_grace and grace_minutes > 0:
-            end_raw = workout.get("end_time") or workout.get("endTime", "")
-            end_dt = _parse_timestamp(end_raw)
-            if end_dt is not None and end_dt.tzinfo is not None:
-                age_min = (datetime.now(timezone.utc) - end_dt).total_seconds() / 60.0
-                if age_min < grace_minutes:
-                    logger.info(
-                        "  Deferring %s — ended %.0f min ago (< %d min grace); waiting for watch data",
-                        wid,
-                        age_min,
-                        grace_minutes,
-                    )
-                    stats["deferred"] += 1
-                    continue
-
-        logger.info("Syncing: %s (%s)", title, wid)
-
         for ex in workout.get("exercises", []):
             ex_name = ex.get("title") or ex.get("name", "")
             cat, _, _ = lookup_exercise(ex_name, ex.get("exercise_template_id"))
@@ -370,7 +384,12 @@ def sync(
                 cfg=cfg,
                 garmin_client=garmin_client,
                 dry_run=dry_run,
+                respect_grace=respect_grace,
             )
+            if one.status == "deferred":
+                stats["deferred"] += 1
+                continue
+
             if one.status == "dry_run":
                 stats["synced"] += 1
             elif one.merged:

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import logging
 import os
 import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
-
-from datetime import datetime, timezone
 
 from hevy2garmin import db
 from hevy2garmin.config import load_config
@@ -24,7 +24,7 @@ from hevy2garmin.garmin import (
 )
 from hevy2garmin.hevy import HevyClient
 from hevy2garmin.mapper import lookup_exercise
-from hevy2garmin.merge import attempt_merge, reset_circuit_breaker, MergeResult
+from hevy2garmin.merge import attempt_merge, reset_circuit_breaker
 
 try:  # rate-limit HR fetches like other Garmin data calls
     from garmin_auth import RateLimiter
@@ -33,6 +33,20 @@ except Exception:  # pragma: no cover
     _hr_limiter = None
 
 logger = logging.getLogger("hevy2garmin")
+
+
+@dataclass
+class SyncOneResult:
+    """Outcome of syncing a single Hevy workout."""
+
+    status: str  # "synced" | "dry_run"
+    activity_id: int | None = None
+    sync_method: str = "upload"
+    merged: bool = False
+    merge_fallback: bool = False
+    calories: int | None = None
+    avg_hr: int | None = None
+    no_hr: bool = False
 
 
 def fetch_workouts(
@@ -78,6 +92,174 @@ def fetch_workouts(
     return all_workouts
 
 
+def _estimate_fit_stats(workout: dict, hr_samples: list[int] | None = None) -> dict:
+    """Generate a FIT file in a temp dir to obtain calorie/HR estimates."""
+    with tempfile.TemporaryDirectory() as tmp:
+        fit_path = str(Path(tmp) / f"{workout.get('id', 'workout')}.fit")
+        return generate_fit(workout, hr_samples=hr_samples, output_path=fit_path)
+
+
+def sync_one_workout(
+    workout: dict,
+    *,
+    cfg: dict[str, Any],
+    garmin_client=None,
+    dry_run: bool = False,
+    force_upload: bool = False,
+    database: Any | None = None,
+) -> SyncOneResult:
+    """Sync one Hevy workout to Garmin (merge, FIT upload, or dry-run).
+
+    Raises on FIT generation / upload failures so callers can map errors.
+    """
+    merge_store = database if database is not None else db
+    wid = workout.get("id", "unknown")
+    title = workout.get("title", "Workout")
+    start_time = workout.get("start_time") or workout.get("startTime", "")
+
+    merge_mode = cfg.get("merge_mode", True)
+    merge_overlap_pct = cfg.get("merge_overlap_pct", 70) / 100.0
+    merge_max_drift_min = cfg.get("merge_max_drift_min", 20)
+    merge_activity_types = set(cfg.get("merge_activity_types", ["strength_training"]))
+    merge_watch_strategy = cfg.get("merge_watch_strategy", "replace")
+    description_enabled = cfg.get("description_enabled", True)
+
+    merge_forced_fresh = False
+    merge_delete_id = None
+
+    if merge_mode and garmin_client and not dry_run:
+        merge_result = attempt_merge(
+            garmin_client,
+            workout,
+            merge_store,
+            overlap_threshold=merge_overlap_pct,
+            max_drift_minutes=merge_max_drift_min,
+            activity_types=merge_activity_types,
+            watch_strategy=merge_watch_strategy,
+        )
+        if merge_result.merged:
+            fit_stats = _estimate_fit_stats(workout)
+            db.mark_synced(
+                hevy_id=wid,
+                garmin_activity_id=str(merge_result.activity_id),
+                title=title,
+                calories=fit_stats.get("calories"),
+                avg_hr=fit_stats.get("avg_hr"),
+                hevy_updated_at=workout.get("updated_at"),
+                sync_method="merge",
+            )
+            logger.info("  ⚡ Enhanced → Garmin activity %s", merge_result.activity_id)
+            return SyncOneResult(
+                status="synced",
+                activity_id=merge_result.activity_id,
+                sync_method="merge",
+                merged=True,
+                calories=fit_stats.get("calories"),
+                avg_hr=fit_stats.get("avg_hr"),
+            )
+
+        logger.info("  Merge fallback: %s", merge_result.fallback_reason)
+        merge_forced_fresh = merge_result.force_fresh_upload
+        merge_delete_id = merge_result.delete_after_upload
+        merge_fallback = True
+    else:
+        merge_fallback = False
+
+    hr_samples = None
+    hr_fusion_on = cfg.get("hr_fusion", {}).get("enabled", True)
+    if not dry_run and hr_fusion_on:
+        from hevy2garmin.hr import hr_for_sync
+
+        hr_samples = hr_for_sync(db, garmin_client, workout, cfg, _hr_limiter)
+        if not hr_samples:
+            # One retry — the watch's daily HR for this window may not
+            # have settled on the first try.
+            hr_samples = hr_for_sync(db, garmin_client, workout, cfg, _hr_limiter)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        fit_path = str(Path(tmp) / f"{wid}.fit")
+        result = generate_fit(workout, hr_samples=hr_samples, output_path=fit_path)
+        logger.info(
+            "  FIT: %d exercises, %d sets, %d cal",
+            result["exercises"],
+            result["total_sets"],
+            result["calories"],
+        )
+
+        if dry_run:
+            logger.info("  [DRY RUN] Would upload %s", fit_path)
+            return SyncOneResult(
+                status="dry_run",
+                merge_fallback=merge_fallback,
+                calories=result.get("calories"),
+                avg_hr=result.get("avg_hr"),
+            )
+
+        existing_id = None
+        uploaded = False
+        if start_time and not force_upload and not merge_forced_fresh:
+            existing_id = find_activity_by_start_time(garmin_client, start_time)
+
+        if existing_id:
+            logger.info("  Activity already on Garmin (%s), skipping upload", existing_id)
+            activity_id = existing_id
+        else:
+            upload_result = upload_fit(garmin_client, fit_path, workout_start=start_time)
+            activity_id = upload_result.get("activity_id")
+            uploaded = bool(activity_id)
+            if activity_id and merge_delete_id:
+                try:
+                    delete_activity(garmin_client, merge_delete_id)
+                    logger.info(
+                        "  Removed watch copy %s (replaced by %s)",
+                        merge_delete_id,
+                        activity_id,
+                    )
+                except Exception as e:
+                    logger.warning(
+                        "Could not delete watch activity %s: %s",
+                        merge_delete_id,
+                        e,
+                    )
+
+        if activity_id:
+            rename_activity(garmin_client, activity_id, title)
+            if description_enabled:
+                desc = generate_description(
+                    workout,
+                    calories=result.get("calories"),
+                    avg_hr=result.get("avg_hr"),
+                )
+                set_description(garmin_client, activity_id, desc)
+
+        sync_method = "upload_fallback" if merge_mode else "upload"
+        db.mark_synced(
+            hevy_id=wid,
+            garmin_activity_id=str(activity_id) if activity_id else None,
+            title=title,
+            calories=result.get("calories"),
+            avg_hr=result.get("avg_hr"),
+            hevy_updated_at=workout.get("updated_at"),
+            sync_method=sync_method,
+        )
+        no_hr = bool(hr_fusion_on and uploaded and not hr_samples)
+        if no_hr:
+            logger.warning(
+                "  ⚠ No heart-rate data available for %s — activity uploaded without HR",
+                wid,
+            )
+        logger.info("  ✓ Synced → Garmin activity %s", activity_id)
+        return SyncOneResult(
+            status="synced",
+            activity_id=activity_id,
+            sync_method=sync_method,
+            merge_fallback=merge_fallback,
+            calories=result.get("calories"),
+            avg_hr=result.get("avg_hr"),
+            no_hr=no_hr,
+        )
+
+
 def sync(
     config: dict[str, Any] | None = None,
     limit: int | None = None,
@@ -85,6 +267,8 @@ def sync(
     fetch_all: bool = False,
     dry_run: bool = False,
     respect_grace: bool = True,
+    record_log: bool = True,
+    log_trigger: str | None = None,
     **overrides: Any,
 ) -> dict:
     """Sync Hevy workouts to Garmin Connect.
@@ -95,6 +279,9 @@ def sync(
         since: ISO date — sync workouts after this date.
         fetch_all: Sync entire Hevy history.
         dry_run: Generate FIT files but don't upload.
+        respect_grace: Defer too-new workouts when True (autosync/cron).
+        record_log: Persist a sync_log row when True.
+        log_trigger: Override sync_log trigger (default: cli or github-actions).
         **overrides: Override config values (hevy_api_key, garmin_email, garmin_password).
 
     Returns:
@@ -125,12 +312,18 @@ def sync(
         logger.info("Authenticated successfully")
 
     merge_mode = cfg.get("merge_mode", True)
-    merge_overlap_pct = cfg.get("merge_overlap_pct", 70) / 100.0  # convert % to decimal
-    merge_max_drift_min = cfg.get("merge_max_drift_min", 20)
-    merge_activity_types = set(cfg.get("merge_activity_types", ["strength_training"]))
-    merge_watch_strategy = cfg.get("merge_watch_strategy", "replace")
-    description_enabled = cfg.get("description_enabled", True)
-    stats = {"synced": 0, "skipped": 0, "failed": 0, "total": len(workouts), "unmapped": [], "merged": 0, "merge_fallback": 0, "deferred": 0, "no_hr": 0, "duplicates": 0}
+    stats = {
+        "synced": 0,
+        "skipped": 0,
+        "failed": 0,
+        "total": len(workouts),
+        "unmapped": [],
+        "merged": 0,
+        "merge_fallback": 0,
+        "deferred": 0,
+        "no_hr": 0,
+        "duplicates": 0,
+    }
 
     if merge_mode:
         reset_circuit_breaker()
@@ -139,7 +332,6 @@ def sync(
     for workout in workouts:
         wid = workout.get("id", "unknown")
         title = workout.get("title", "Workout")
-        start_time = workout.get("start_time") or workout.get("startTime", "")
 
         if skip_existing and db.is_synced(wid):
             logger.debug("Skipping %s (%s) — already synced", wid, title)
@@ -155,13 +347,17 @@ def sync(
             if end_dt is not None and end_dt.tzinfo is not None:
                 age_min = (datetime.now(timezone.utc) - end_dt).total_seconds() / 60.0
                 if age_min < grace_minutes:
-                    logger.info("  Deferring %s — ended %.0f min ago (< %d min grace); waiting for watch data", wid, age_min, grace_minutes)
+                    logger.info(
+                        "  Deferring %s — ended %.0f min ago (< %d min grace); waiting for watch data",
+                        wid,
+                        age_min,
+                        grace_minutes,
+                    )
                     stats["deferred"] += 1
                     continue
 
         logger.info("Syncing: %s (%s)", title, wid)
 
-        # Track unmapped exercises
         for ex in workout.get("exercises", []):
             ex_name = ex.get("title") or ex.get("name", "")
             cat, _, _ = lookup_exercise(ex_name, ex.get("exercise_template_id"))
@@ -169,111 +365,32 @@ def sync(
                 stats["unmapped"].append(ex_name)
 
         try:
-            # ── Merge mode: try to enhance a watch-recorded activity ──
-            merge_forced_fresh = False
-            merge_delete_id = None
-            if merge_mode and garmin_client and not dry_run:
-                merge_result = attempt_merge(garmin_client, workout, db, overlap_threshold=merge_overlap_pct, max_drift_minutes=merge_max_drift_min, activity_types=merge_activity_types, watch_strategy=merge_watch_strategy)
-                if merge_result.merged:
-                    db.mark_synced(
-                        hevy_id=wid,
-                        garmin_activity_id=str(merge_result.activity_id),
-                        title=title,
-                        hevy_updated_at=workout.get("updated_at"),
-                        sync_method="merge",
-                    )
-                    stats["synced"] += 1
-                    stats["merged"] += 1
-                    logger.info("  ⚡ Enhanced → Garmin activity %s", merge_result.activity_id)
-                    continue
-                else:
-                    logger.info("  Merge fallback: %s", merge_result.fallback_reason)
-                    stats["merge_fallback"] += 1
-                    merge_forced_fresh = merge_result.force_fresh_upload
-                    merge_delete_id = merge_result.delete_after_upload
-
-            # ── Standard upload path (FIT generation) ──
-            # Embed merged HR (AirPods-preferred, watch fill) so it reaches
-            # Garmin Connect, not just the dashboard (#158). Best-effort.
-            hr_samples = None
-            hr_fusion_on = cfg.get("hr_fusion", {}).get("enabled", True)
-            if not dry_run and hr_fusion_on:
-                from hevy2garmin.hr import hr_for_sync
-                hr_samples = hr_for_sync(db, garmin_client, workout, cfg, _hr_limiter)
-                if not hr_samples:
-                    # One retry — the watch's daily HR for this window may not
-                    # have settled on the first try.
-                    hr_samples = hr_for_sync(db, garmin_client, workout, cfg, _hr_limiter)
-
-            with tempfile.TemporaryDirectory() as tmp:
-                fit_path = str(Path(tmp) / f"{wid}.fit")
-                result = generate_fit(workout, hr_samples=hr_samples, output_path=fit_path)
-                logger.info(
-                    "  FIT: %d exercises, %d sets, %d cal",
-                    result["exercises"], result["total_sets"], result["calories"],
-                )
-
-                if dry_run:
-                    logger.info("  [DRY RUN] Would upload %s", fit_path)
-                    stats["synced"] += 1
-                    continue
-
-                # Dedup: check if activity already exists on Garmin. Skip the
-                # check when the merge wants a fresh upload (#159) — otherwise it
-                # would find the watch activity and refuse to upload the named one.
-                existing_id = None
-                uploaded = False
-                if start_time and not merge_forced_fresh:
-                    existing_id = find_activity_by_start_time(garmin_client, start_time)
-                if existing_id:
-                    logger.info("  Activity already on Garmin (%s), skipping upload", existing_id)
-                    activity_id = existing_id
-                else:
-                    upload_result = upload_fit(garmin_client, fit_path, workout_start=start_time)
-                    activity_id = upload_result.get("activity_id")
-                    uploaded = bool(activity_id)
-                    # "replace" strategy (#159): the named upload succeeded, so
-                    # delete the watch recording to keep a single activity.
-                    if activity_id and merge_delete_id:
-                        try:
-                            delete_activity(garmin_client, merge_delete_id)
-                            logger.info("  Removed watch copy %s (replaced by %s)", merge_delete_id, activity_id)
-                        except Exception as e:
-                            logger.warning("Could not delete watch activity %s: %s", merge_delete_id, e)
-
-                if activity_id:
-                    rename_activity(garmin_client, activity_id, title)
-                    if description_enabled:
-                        desc = generate_description(
-                            workout,
-                            calories=result.get("calories"),
-                            avg_hr=result.get("avg_hr"),
-                        )
-                        set_description(garmin_client, activity_id, desc)
-
-                sync_method = "upload_fallback" if merge_mode else "upload"
-                db.mark_synced(
-                    hevy_id=wid,
-                    garmin_activity_id=str(activity_id) if activity_id else None,
-                    title=title,
-                    calories=result.get("calories"),
-                    avg_hr=result.get("avg_hr"),
-                    hevy_updated_at=workout.get("updated_at"),
-                    sync_method=sync_method,
-                )
-                if hr_fusion_on and uploaded and not hr_samples:
-                    logger.warning("  ⚠ No heart-rate data available for %s — activity uploaded without HR", wid)
-                    stats["no_hr"] += 1
+            one = sync_one_workout(
+                workout,
+                cfg=cfg,
+                garmin_client=garmin_client,
+                dry_run=dry_run,
+            )
+            if one.status == "dry_run":
                 stats["synced"] += 1
-                logger.info("  ✓ Synced → Garmin activity %s", activity_id)
-
+            elif one.merged:
+                stats["synced"] += 1
+                stats["merged"] += 1
+            else:
+                stats["synced"] += 1
+                if one.merge_fallback:
+                    stats["merge_fallback"] += 1
+            if one.no_hr:
+                stats["no_hr"] += 1
         except Exception as e:
             logger.error("  ✗ Failed to sync %s: %s", wid, e)
             stats["failed"] += 1
 
     if stats["unmapped"]:
         logger.warning("\nUnmapped exercises: %s", ", ".join(stats["unmapped"]))
-        logger.warning("Add custom mappings: hevy2garmin map \"Exercise Name\" --category N --subcategory N")
+        logger.warning(
+            'Add custom mappings: hevy2garmin map "Exercise Name" --category N --subcategory N'
+        )
 
     # Log-only duplicate scan (best-effort; never breaks a sync).
     if not dry_run and garmin_client:
@@ -282,19 +399,24 @@ def sync(
             dups = detect_duplicates(garmin_client, workouts, _hr_limiter)
             stats["duplicates"] = len(dups)
             if dups:
-                logger.warning("Found %d possible duplicate activity pair(s) from past races", len(dups))
+                logger.warning(
+                    "Found %d possible duplicate activity pair(s) from past races",
+                    len(dups),
+                )
         except Exception:
             logger.debug("duplicate scan skipped", exc_info=True)
 
-    # Record to sync log (shows up in dashboard)
-    trigger = "cli"
-    if os.environ.get("GITHUB_ACTIONS"):
-        trigger = "github-actions"
-    db.record_sync_log(
-        synced=stats["synced"],
-        skipped=stats["skipped"],
-        failed=stats["failed"],
-        trigger=trigger,
-    )
+    if record_log:
+        trigger = log_trigger
+        if trigger is None:
+            trigger = "cli"
+            if os.environ.get("GITHUB_ACTIONS"):
+                trigger = "github-actions"
+        db.record_sync_log(
+            synced=stats["synced"],
+            skipped=stats["skipped"],
+            failed=stats["failed"],
+            trigger=trigger,
+        )
 
     return stats

--- a/tests/test_autosync.py
+++ b/tests/test_autosync.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
+from unittest.mock import MagicMock, patch
+
 import pytest
 
+from hevy2garmin import server
 from hevy2garmin.server import (
     _acquire_sync_lock,
     _build_sync_workflow_yaml,
@@ -74,6 +79,45 @@ class TestSyncLock:
         assert _acquire_sync_lock() is True
         assert _acquire_sync_lock() is False  # Already held
         _sync_executing.release()
+
+
+class TestCronGraceDeferral:
+    def test_all_fresh_workouts_are_deferred_without_calling_sync_helper(self) -> None:
+        """Cron returns a useful response when every candidate is in grace."""
+        workout = {"id": "fresh-1", "title": "Fresh", "exercises": []}
+        hevy = MagicMock()
+        hevy.get_workout_count.return_value = 1
+        database = MagicMock()
+
+        with (
+            patch.object(
+                server,
+                "load_config",
+                return_value={
+                    "hevy_api_key": "test-key",
+                    "sync": {"grace_period_minutes": 120},
+                },
+            ),
+            patch("hevy2garmin.hevy.HevyClient", return_value=hevy),
+            patch.object(server.db, "get_db", return_value=database),
+            patch.object(server.db, "get_synced_count", return_value=0),
+            patch.object(
+                server,
+                "_scan_for_unsynced",
+                side_effect=[(workout, {}), (None, {})],
+            ),
+            patch("hevy2garmin.sync._workout_within_grace", return_value=True),
+            patch("hevy2garmin.sync.sync_one_workout") as sync_one,
+        ):
+            response = asyncio.run(server._do_sync_one(MagicMock(), respect_grace=True))
+
+        assert json.loads(response.body) == {
+            "synced": 0,
+            "deferred": 1,
+            "remaining": 1,
+            "done": False,
+        }
+        sync_one.assert_not_called()
 
 
 class TestBuildSyncWorkflowYaml:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -301,6 +301,43 @@ class TestSyncOneWorkout:
             mock_merge.assert_called_once()
             assert result.merged is True
 
+    def test_respect_grace_defers_fresh_workout(self, sample_workout: dict) -> None:
+        now = datetime.now(timezone.utc)
+        fresh = {
+            **sample_workout,
+            "start_time": (now - timedelta(minutes=30)).isoformat(),
+            "end_time": (now - timedelta(minutes=10)).isoformat(),
+        }
+        with patch("hevy2garmin.sync.attempt_merge") as mock_merge:
+            result = sync_one_workout(
+                fresh,
+                cfg={"merge_mode": True, "sync": {"grace_period_minutes": 120}},
+                garmin_client=MagicMock(),
+                respect_grace=True,
+            )
+            assert result.status == "deferred"
+            mock_merge.assert_not_called()
+
+    def test_respect_grace_false_bypasses(self, sample_workout: dict) -> None:
+        now = datetime.now(timezone.utc)
+        fresh = {
+            **sample_workout,
+            "start_time": (now - timedelta(minutes=20)).isoformat(),
+            "end_time": (now - timedelta(minutes=5)).isoformat(),
+        }
+        with patch("hevy2garmin.sync.db"), \
+             patch("hevy2garmin.sync.attempt_merge") as mock_merge, \
+             patch("hevy2garmin.sync._estimate_fit_stats", return_value={"calories": 100, "avg_hr": 90}):
+            mock_merge.return_value = MergeResult(merged=True, activity_id=777)
+            result = sync_one_workout(
+                fresh,
+                cfg={"merge_mode": True, "sync": {"grace_period_minutes": 120}},
+                garmin_client=MagicMock(),
+                respect_grace=False,
+            )
+            assert result.status == "synced"
+            assert result.merged is True
+
 
 @patch("hevy2garmin.sync.db")
 @patch("hevy2garmin.sync.get_client")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -3,12 +3,10 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone, timedelta
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
-
-from hevy2garmin.sync import fetch_workouts, sync
+from hevy2garmin.merge import MergeResult
+from hevy2garmin.sync import fetch_workouts, sync, sync_one_workout
 
 
 def _iso(dt):
@@ -33,7 +31,6 @@ def test_grace_defers_too_new_workout(mock_merge, mock_hevy_cls, mock_gclient, m
     mock_hevy_cls.return_value = h
     mock_gclient.return_value = MagicMock()
     mock_db.is_synced.return_value = False
-    from hevy2garmin.sync import sync
     stats = sync(config={"hevy_api_key": "t", "merge_mode": True,
                          "sync": {"grace_period_minutes": 120}}, limit=1)
     assert stats["deferred"] == 1
@@ -47,7 +44,6 @@ def test_grace_defers_too_new_workout(mock_merge, mock_hevy_cls, mock_gclient, m
 @patch("hevy2garmin.sync.HevyClient")
 @patch("hevy2garmin.sync.attempt_merge")
 def test_grace_processes_old_enough_workout(mock_merge, mock_hevy_cls, mock_gclient, mock_db):
-    from hevy2garmin.merge import MergeResult
     now = datetime.now(timezone.utc)
     old = {"id": "w1", "title": "Push",
            "start_time": _iso(now - timedelta(hours=5)),
@@ -58,9 +54,9 @@ def test_grace_processes_old_enough_workout(mock_merge, mock_hevy_cls, mock_gcli
     mock_hevy_cls.return_value = h; mock_gclient.return_value = MagicMock()
     mock_db.is_synced.return_value = False
     mock_merge.return_value = MergeResult(merged=True, activity_id=99)
-    from hevy2garmin.sync import sync
-    stats = sync(config={"hevy_api_key": "t", "merge_mode": True,
-                         "sync": {"grace_period_minutes": 120}}, limit=1)
+    with patch("hevy2garmin.sync._estimate_fit_stats", return_value={"calories": 100, "avg_hr": 90}):
+        stats = sync(config={"hevy_api_key": "t", "merge_mode": True,
+                             "sync": {"grace_period_minutes": 120}}, limit=1)
     assert stats["deferred"] == 0
     assert stats["synced"] == 1
 
@@ -70,7 +66,6 @@ def test_grace_processes_old_enough_workout(mock_merge, mock_hevy_cls, mock_gcli
 @patch("hevy2garmin.sync.HevyClient")
 @patch("hevy2garmin.sync.attempt_merge")
 def test_manual_run_bypasses_grace(mock_merge, mock_hevy_cls, mock_gclient, mock_db):
-    from hevy2garmin.merge import MergeResult
     now = datetime.now(timezone.utc)
     fresh = {"id": "w1", "title": "Push",
              "start_time": _iso(now - timedelta(minutes=20)),
@@ -81,10 +76,10 @@ def test_manual_run_bypasses_grace(mock_merge, mock_hevy_cls, mock_gclient, mock
     mock_hevy_cls.return_value = h; mock_gclient.return_value = MagicMock()
     mock_db.is_synced.return_value = False
     mock_merge.return_value = MergeResult(merged=True, activity_id=99)
-    from hevy2garmin.sync import sync
-    stats = sync(config={"hevy_api_key": "t", "merge_mode": True,
-                         "sync": {"grace_period_minutes": 120}},
-                 limit=1, respect_grace=False)
+    with patch("hevy2garmin.sync._estimate_fit_stats", return_value={"calories": 100, "avg_hr": 90}):
+        stats = sync(config={"hevy_api_key": "t", "merge_mode": True,
+                             "sync": {"grace_period_minutes": 120}},
+                     limit=1, respect_grace=False)
     assert stats["deferred"] == 0
     assert stats["synced"] == 1
 
@@ -138,7 +133,7 @@ class TestSync:
             mock_hevy.get_workouts.return_value = {"workouts": [sample_workout], "page_count": 1}
             mock_db.is_synced.return_value = False
 
-            result = sync(dry_run=True, limit=1, hevy_api_key="test")
+            result = sync(dry_run=True, limit=1, hevy_api_key="test", respect_grace=False)
 
             mock_garmin.assert_not_called()
             assert result["synced"] == 1
@@ -152,7 +147,7 @@ class TestSync:
             mock_hevy.get_workouts.return_value = {"workouts": [sample_workout], "page_count": 1}
             mock_db.is_synced.return_value = True
 
-            result = sync(dry_run=True, limit=1, hevy_api_key="test")
+            result = sync(dry_run=True, limit=1, hevy_api_key="test", respect_grace=False)
             assert result["skipped"] == 1
             assert result["synced"] == 0
 
@@ -165,7 +160,7 @@ class TestSync:
             mock_hevy.get_workouts.return_value = {"workouts": [sample_workout_unmapped], "page_count": 1}
             mock_db.is_synced.return_value = False
 
-            result = sync(dry_run=True, limit=1, hevy_api_key="test")
+            result = sync(dry_run=True, limit=1, hevy_api_key="test", respect_grace=False)
             assert "Invented Exercise 99" in result["unmapped"]
 
     def test_handles_fit_generation_failure(self) -> None:
@@ -184,7 +179,7 @@ class TestSync:
             mock_hevy.get_workouts.return_value = {"workouts": [bad_workout], "page_count": 1}
             mock_db.is_synced.return_value = False
 
-            result = sync(dry_run=True, limit=1, hevy_api_key="test")
+            result = sync(dry_run=True, limit=1, hevy_api_key="test", respect_grace=False)
             assert result["failed"] == 1
 
     def test_records_to_db_after_success(self, sample_workout: dict) -> None:
@@ -193,16 +188,118 @@ class TestSync:
              patch("hevy2garmin.sync.get_client") as mock_garmin_client, \
              patch("hevy2garmin.sync.upload_fit") as mock_upload, \
              patch("hevy2garmin.sync.rename_activity"), \
-             patch("hevy2garmin.sync.set_description"):
+             patch("hevy2garmin.sync.set_description"), \
+             patch("hevy2garmin.hr.hr_for_sync", return_value=None):
             mock_hevy = MockHevy.return_value
             mock_hevy.get_workout_count.return_value = 1
             mock_hevy.get_workouts.return_value = {"workouts": [sample_workout], "page_count": 1}
             mock_db.is_synced.return_value = False
             mock_upload.return_value = {"upload_id": "123", "activity_id": 456}
 
-            result = sync(limit=1, hevy_api_key="test", garmin_email="e", garmin_password="p")
+            result = sync(
+                limit=1,
+                hevy_api_key="test",
+                garmin_email="e",
+                garmin_password="p",
+                respect_grace=False,
+            )
             mock_db.mark_synced.assert_called_once()
             assert result["synced"] == 1
+
+    def test_record_log_disabled(self, sample_workout: dict) -> None:
+        with patch("hevy2garmin.sync.HevyClient") as MockHevy, \
+             patch("hevy2garmin.sync.db") as mock_db, \
+             patch("hevy2garmin.sync.get_client"), \
+             patch("hevy2garmin.sync.sync_one_workout") as mock_one:
+            mock_hevy = MockHevy.return_value
+            mock_hevy.get_workout_count.return_value = 1
+            mock_hevy.get_workouts.return_value = {"workouts": [sample_workout], "page_count": 1}
+            mock_db.is_synced.return_value = False
+            from hevy2garmin.sync import SyncOneResult
+            mock_one.return_value = SyncOneResult(status="synced")
+
+            sync(limit=1, hevy_api_key="test", record_log=False)
+
+            mock_db.record_sync_log.assert_not_called()
+
+    def test_record_log_enabled(self, sample_workout: dict) -> None:
+        with patch("hevy2garmin.sync.HevyClient") as MockHevy, \
+             patch("hevy2garmin.sync.db") as mock_db, \
+             patch("hevy2garmin.sync.get_client"), \
+             patch("hevy2garmin.sync.sync_one_workout") as mock_one:
+            mock_hevy = MockHevy.return_value
+            mock_hevy.get_workout_count.return_value = 1
+            mock_hevy.get_workouts.return_value = {"workouts": [sample_workout], "page_count": 1}
+            mock_db.is_synced.return_value = False
+            from hevy2garmin.sync import SyncOneResult
+            mock_one.return_value = SyncOneResult(status="synced")
+
+            sync(limit=1, hevy_api_key="test", log_trigger="manual")
+
+            mock_db.record_sync_log.assert_called_once_with(
+                synced=1, skipped=0, failed=0, trigger="manual",
+            )
+
+
+class TestSyncOneWorkout:
+    def test_merge_success_stores_calories(self, sample_workout: dict) -> None:
+        with patch("hevy2garmin.sync.db") as mock_db, \
+             patch("hevy2garmin.sync.attempt_merge") as mock_merge, \
+             patch("hevy2garmin.sync._estimate_fit_stats", return_value={"calories": 250, "avg_hr": 120}):
+            mock_merge.return_value = MergeResult(merged=True, activity_id=999)
+            garmin = MagicMock()
+
+            result = sync_one_workout(
+                sample_workout,
+                cfg={"merge_mode": True},
+                garmin_client=garmin,
+            )
+
+            assert result.merged is True
+            assert result.calories == 250
+            mock_db.mark_synced.assert_called_once_with(
+                hevy_id=sample_workout["id"],
+                garmin_activity_id="999",
+                title=sample_workout["title"],
+                calories=250,
+                avg_hr=120,
+                hevy_updated_at=sample_workout.get("updated_at"),
+                sync_method="merge",
+            )
+
+    def test_description_disabled_skips_set_description(self, sample_workout: dict) -> None:
+        with patch("hevy2garmin.sync.db") as mock_db, \
+             patch("hevy2garmin.sync.attempt_merge", return_value=MergeResult(merged=False, fallback_reason="No match")), \
+             patch("hevy2garmin.hr.hr_for_sync", return_value=None), \
+             patch("hevy2garmin.sync.generate_fit", return_value={"exercises": 2, "total_sets": 5, "calories": 100, "avg_hr": 90}), \
+             patch("hevy2garmin.sync.find_activity_by_start_time", return_value=None), \
+             patch("hevy2garmin.sync.upload_fit", return_value={"activity_id": 456}), \
+             patch("hevy2garmin.sync.rename_activity"), \
+             patch("hevy2garmin.sync.set_description") as mock_set_desc, \
+             patch("hevy2garmin.sync.generate_description", return_value="desc"):
+            garmin = MagicMock()
+            cfg = {"merge_mode": False, "description_enabled": False}
+
+            sync_one_workout(sample_workout, cfg=cfg, garmin_client=garmin)
+
+            mock_set_desc.assert_not_called()
+            mock_db.mark_synced.assert_called_once()
+
+    def test_single_upload_attempts_merge(self, sample_workout: dict) -> None:
+        with patch("hevy2garmin.sync.db"), \
+             patch("hevy2garmin.sync.attempt_merge") as mock_merge, \
+             patch("hevy2garmin.sync._estimate_fit_stats", return_value={"calories": 100, "avg_hr": 90}):
+            mock_merge.return_value = MergeResult(merged=True, activity_id=777)
+            garmin = MagicMock()
+
+            result = sync_one_workout(
+                sample_workout,
+                cfg={"merge_mode": True},
+                garmin_client=garmin,
+            )
+
+            mock_merge.assert_called_once()
+            assert result.merged is True
 
 
 @patch("hevy2garmin.sync.db")
@@ -217,7 +314,6 @@ class TestSync:
 @patch("hevy2garmin.sync.generate_description", return_value="d")
 @patch("hevy2garmin.hr.hr_for_sync")
 def test_hr_empty_retries_once_then_counts_no_hr(mock_hr, *rest):
-    from hevy2garmin.merge import MergeResult
     (mock_desc, mock_setdesc, mock_rename, mock_find, mock_upload,
      mock_fit, mock_merge, mock_hevy_cls, mock_gclient, mock_db) = rest
     mock_hr.return_value = None
@@ -231,7 +327,6 @@ def test_hr_empty_retries_once_then_counts_no_hr(mock_hr, *rest):
     mock_hevy_cls.return_value = h; mock_gclient.return_value = MagicMock()
     mock_db.is_synced.return_value = False
     mock_merge.return_value = MergeResult(merged=False, force_fresh_upload=True, fallback_reason="no match")
-    from hevy2garmin.sync import sync
     stats = sync(config={"hevy_api_key": "t", "merge_mode": True,
                          "sync": {"grace_period_minutes": 120},
                          "hr_fusion": {"enabled": True}}, limit=1)
@@ -251,7 +346,6 @@ def test_hr_empty_retries_once_then_counts_no_hr(mock_hr, *rest):
 @patch("hevy2garmin.sync.generate_description", return_value="d")
 @patch("hevy2garmin.hr.hr_for_sync")
 def test_hr_fusion_disabled_no_retry_no_count(mock_hr, *rest):
-    from hevy2garmin.merge import MergeResult
     (mock_desc, mock_setdesc, mock_rename, mock_find, mock_upload,
      mock_fit, mock_merge, mock_hevy_cls, mock_gclient, mock_db) = rest
     now = datetime.now(timezone.utc)
@@ -264,7 +358,6 @@ def test_hr_fusion_disabled_no_retry_no_count(mock_hr, *rest):
     mock_hevy_cls.return_value = h; mock_gclient.return_value = MagicMock()
     mock_db.is_synced.return_value = False
     mock_merge.return_value = MergeResult(merged=False, force_fresh_upload=True, fallback_reason="no match")
-    from hevy2garmin.sync import sync
     stats = sync(config={"hevy_api_key": "t", "merge_mode": True,
                          "sync": {"grace_period_minutes": 120},
                          "hr_fusion": {"enabled": False}}, limit=1)
@@ -286,7 +379,6 @@ def test_hr_fusion_disabled_no_retry_no_count(mock_hr, *rest):
 def test_no_hr_not_counted_on_dedup_path(mock_hr, *rest):
     """When the activity already exists on Garmin (dedup, no upload), no_hr must
     NOT fire — nothing was uploaded, and the existing activity may have its own HR."""
-    from hevy2garmin.merge import MergeResult
     (mock_desc, mock_setdesc, mock_rename, mock_find, mock_upload,
      mock_fit, mock_merge, mock_hevy_cls, mock_gclient, mock_db) = rest
     mock_hr.return_value = None
@@ -300,7 +392,6 @@ def test_no_hr_not_counted_on_dedup_path(mock_hr, *rest):
     mock_hevy_cls.return_value = h; mock_gclient.return_value = MagicMock()
     mock_db.is_synced.return_value = False
     mock_merge.return_value = MergeResult(merged=False, force_fresh_upload=False, fallback_reason="no match")
-    from hevy2garmin.sync import sync
     stats = sync(config={"hevy_api_key": "t", "merge_mode": True,
                          "sync": {"grace_period_minutes": 120},
                          "hr_fusion": {"enabled": True}}, limit=1)
@@ -315,7 +406,6 @@ def test_no_hr_not_counted_on_dedup_path(mock_hr, *rest):
 @patch("hevy2garmin.sync.attempt_merge")
 @patch("hevy2garmin.reconcile.detect_duplicates")
 def test_sync_runs_duplicate_scan(mock_detect, mock_merge, mock_hevy_cls, mock_gclient, mock_db):
-    from hevy2garmin.merge import MergeResult
     now = datetime.now(timezone.utc)
     w = {"id": "w1", "title": "Push",
          "start_time": (now - timedelta(hours=4)).isoformat(),
@@ -327,8 +417,8 @@ def test_sync_runs_duplicate_scan(mock_detect, mock_merge, mock_hevy_cls, mock_g
     mock_db.is_synced.return_value = False
     mock_merge.return_value = MergeResult(merged=True, activity_id=99)
     mock_detect.return_value = [{"workout_id": "w1", "tool_activity_id": 1, "watch_activity_id": 2}]
-    from hevy2garmin.sync import sync
-    stats = sync(config={"hevy_api_key": "t", "merge_mode": True,
-                         "sync": {"grace_period_minutes": 120}}, limit=1)
+    with patch("hevy2garmin.sync._estimate_fit_stats", return_value={"calories": 100, "avg_hr": 90}):
+        stats = sync(config={"hevy_api_key": "t", "merge_mode": True,
+                             "sync": {"grace_period_minutes": 120}}, limit=1)
     assert stats["duplicates"] == 1
     mock_detect.assert_called_once()


### PR DESCRIPTION
## Summary

- Extract `sync_one_workout()` so CLI `sync()`, dashboard `_do_sync_one` (incl. Vercel cron), and workouts-page `api_sync_single` share one merge → HR → FIT → upload pipeline
- Fixes drift between paths: workouts upload now attempts merge, `description_enabled` is honored on web, merge success stores calories/avg_hr everywhere, and web auto/bulk sync no longer double-writes `sync_log`
- Folds #207 merge-reliability into the shared helper so web/cron get grace, HR retry, and `no_hr` too
- Also includes `fix(db): expose app_config wrappers for merge backups` (needed for merge-mode backups via the `db` module)

Closes #206.

## Changes

| Area | What changed |
|------|----------------|
| [`sync.py`](src/hevy2garmin/sync.py) | New `sync_one_workout()` + `SyncOneResult`; grace/`hr_fusion`/HR retry/`no_hr` live here; `sync()` loops over it; `record_log` / `log_trigger` to avoid double logging |
| [`server.py`](src/hevy2garmin/server.py) | `_do_sync_one` and `api_sync_single` call the shared helper; cron `respect_grace=True`, Sync Now `False`; auto/bulk pass `record_log=False` |
| [`tests/test_sync.py`](tests/test_sync.py) | Coverage for shared helper, merge-on-single, `description_enabled`, `record_log`, and grace on `sync_one_workout` |

## Test plan

- [x] `pytest` (full suite — 282 passed)
- [ ] CLI: `hevy2garmin sync --dry-run` still works
- [ ] Dashboard Sync Now syncs one workout per request (bypasses grace; merge when a watch activity matches)
- [ ] Vercel cron defers too-new workouts (`respect_grace=True`) and continues to an older unsynced one when possible
- [ ] Workouts page Upload attempts merge (same as dashboard)
- [ ] Settings: turn off “activity description” → web sync does not set description
- [ ] Auto-sync / bulk sync: only one `sync_log` row per run (correct trigger)

Made with [Cursor](https://cursor.com)