### PR TITLE
feat: enforce a Garmin login rate-limit cooldown (exponential backoff)

### DIFF
--- a/src/hevy2garmin/ratelimit.py
+++ b/src/hevy2garmin/ratelimit.py
@@ -1,0 +1,68 @@
+"""Garmin login rate-limit cooldown with exponential backoff.
+
+When Garmin rate-limits a login (HTTP 429), retrying resets and deepens the timer
+on Garmin's side, so we enforce a local cooldown: record when it happened, block
+further login attempts until the window passes, and back off exponentially on
+repeat hits. State lives in the ``app_config`` key-value store so it survives
+serverless restarts. Reset to the base window after a clean login.
+
+All functions take a ``db`` (a Database instance exposing ``get_app_config`` /
+``set_app_config``) and are best-effort: a storage failure never raises.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+logger = logging.getLogger("hevy2garmin")
+
+_KEY = "garmin_ratelimit"
+_BASE_SECONDS = 2 * 3600      # first hit: 2 hours
+_MAX_SECONDS = 24 * 3600      # cap at 24 hours
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def record_rate_limit(db) -> int:
+    """Record a Garmin rate-limit hit and enter (or extend) the cooldown with
+    exponential backoff (2h, 4h, 8h, ... capped at 24h). Returns the cooldown
+    length in seconds."""
+    try:
+        prev = db.get_app_config(_KEY) or {}
+    except Exception:
+        prev = {}
+    hits = int(prev.get("hits", 0)) + 1
+    seconds = min(_BASE_SECONDS * (2 ** (hits - 1)), _MAX_SECONDS)
+    until = _now() + timedelta(seconds=seconds)
+    try:
+        db.set_app_config(_KEY, {"until": until.isoformat(), "hits": hits, "seconds": seconds})
+    except Exception:
+        logger.debug("could not persist rate-limit cooldown", exc_info=True)
+    logger.warning("Garmin rate-limited (hit #%d); cooling down for %d min", hits, seconds // 60)
+    return seconds
+
+
+def cooldown_remaining(db) -> int:
+    """Seconds remaining in the cooldown, or 0 if not currently cooling down."""
+    try:
+        state = db.get_app_config(_KEY)
+    except Exception:
+        return 0
+    if not state or not state.get("until"):
+        return 0
+    try:
+        until = datetime.fromisoformat(state["until"])
+    except Exception:
+        return 0
+    remaining = (until - _now()).total_seconds()
+    return int(remaining) if remaining > 0 else 0
+
+
+def clear_rate_limit(db) -> None:
+    """Clear the cooldown after a successful Garmin login (resets the backoff)."""
+    try:
+        db.set_app_config(_KEY, {"until": None, "hits": 0, "seconds": 0})
+    except Exception:
+        logger.debug("could not clear rate-limit cooldown", exc_info=True)

--- a/src/hevy2garmin/ratelimit.py
+++ b/src/hevy2garmin/ratelimit.py
@@ -66,3 +66,13 @@ def clear_rate_limit(db) -> None:
         db.set_app_config(_KEY, {"until": None, "hits": 0, "seconds": 0})
     except Exception:
         logger.debug("could not clear rate-limit cooldown", exc_info=True)
+
+
+def format_cooldown(seconds: int) -> str:
+    """Human-readable cooldown duration, e.g. 'about 1h 45m' or 'about 5m'."""
+    minutes = int(seconds) // 60
+    hours = minutes // 60
+    mins = minutes % 60
+    if hours > 0:
+        return f"about {hours}h {mins}m" if mins > 0 else f"about {hours}h"
+    return f"about {mins}m"

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -21,6 +21,7 @@ from hevy2garmin.db_interface import NoWritableDatabaseError
 from hevy2garmin.auth import auth_enabled, verify_session, sign_session, check_password, SESSION_COOKIE
 from hevy2garmin.config import is_configured, load_config, save_config
 from hevy2garmin.demo import is_demo_mode
+from hevy2garmin.ratelimit import record_rate_limit, cooldown_remaining, clear_rate_limit, format_cooldown
 from hevy2garmin.sync import sync
 
 logger = logging.getLogger("hevy2garmin")
@@ -461,6 +462,15 @@ async def dashboard(request: Request):
         mapping_count = len(HEVY_TO_GARMIN) + len(_custom_mappings)
     except Exception:
         pass
+    garmin_cooldown = 0
+    garmin_cooldown_str = ""
+    try:
+        garmin_cooldown = cooldown_remaining(db.get_db())
+        if garmin_cooldown > 0:
+            garmin_cooldown_str = format_cooldown(garmin_cooldown)
+    except Exception:
+        pass
+
     return _render(
         "dashboard.html",
         synced_count=synced_count,
@@ -472,13 +482,24 @@ async def dashboard(request: Request):
         mapping_count=mapping_count,
         garmin_connected=garmin_connected,
         needs_actions_setup=False,
+        garmin_cooldown=garmin_cooldown,
+        garmin_cooldown_str=garmin_cooldown_str,
     )
 
 
 
 @app.get("/setup", response_class=HTMLResponse)
 async def setup_page(request: Request):
-    return _render("setup.html", config=load_config(), is_cloud=bool(db.get_database_url()))
+    garmin_cooldown = 0
+    garmin_cooldown_str = ""
+    try:
+        garmin_cooldown = cooldown_remaining(db.get_db())
+        if garmin_cooldown > 0:
+            garmin_cooldown_str = format_cooldown(garmin_cooldown)
+    except Exception:
+        pass
+    return _render("setup.html", config=load_config(), is_cloud=bool(db.get_database_url()),
+                   garmin_cooldown=garmin_cooldown, garmin_cooldown_str=garmin_cooldown_str)
 
 
 @app.post("/setup")
@@ -543,41 +564,76 @@ async def setup_save(
 
     garmin_error = None
     if garmin_pw and garmin_em and not db.get_database_url():
+        # Gate: enforce local cooldown before attempting any Garmin login.
+        # Retrying resets Garmin's own rate-limit timer, so we must skip the
+        # attempt entirely when cooling down — not just warn about it.
+        _cooldown = 0
         try:
-            from hevy2garmin.garmin import get_client
-            get_client(garmin_em, garmin_pw)
-        except Exception as e:
-            logger.warning("Garmin login test failed: %s", e)
-            err = str(e)
-            if "MFA" in err.upper():
-                garmin_error = (
-                    "Garmin MFA (two-factor authentication) is enabled. "
-                    "Temporarily disable MFA in your Garmin account settings, "
-                    "connect here, then re-enable it."
-                )
-            elif "429" in err or "rate limit" in err.lower():
-                garmin_error = (
-                    "Garmin has temporarily rate-limited login attempts for your "
-                    "account (this is separate from your password — your Garmin "
-                    "website/app login still works). It clears on its own, usually "
-                    "within a few hours. Don't retry repeatedly, as that resets the "
-                    "timer. Click 'Skip for now'; your credentials are saved and "
-                    "sync will resume automatically."
-                )
-            elif "SSO login failed" in err:
-                garmin_error = (
-                    "Garmin login failed. Double-check your email and password. "
-                    "If they're correct, Garmin may be temporarily blocking logins "
-                    "from this server. Try again in an hour."
-                )
-            else:
-                # Strip any HTML tags from Garmin error responses
-                cleaned = re.sub(r"<[^>]+>", " ", err)
-                cleaned = re.sub(r"\s{2,}", " ", cleaned).strip()[:200]
-                garmin_error = cleaned or "Unknown error. Check your email and password."
+            _cooldown = cooldown_remaining(db.get_db())
+        except Exception:
+            pass
+        if _cooldown > 0:
+            garmin_error = (
+                "Garmin is still cooling down, "
+                + format_cooldown(_cooldown)
+                + " left. Leave it be. Retrying resets the timer. "
+                "Click 'Skip for now'; your credentials are saved and "
+                "sync will resume automatically once it clears."
+            )
+        else:
+            try:
+                from hevy2garmin.garmin import get_client
+                get_client(garmin_em, garmin_pw)
+                # Login succeeded — reset the backoff counter.
+                try:
+                    clear_rate_limit(db.get_db())
+                except Exception:
+                    pass
+            except Exception as e:
+                logger.warning("Garmin login test failed: %s", e)
+                err = str(e)
+                if "MFA" in err.upper():
+                    garmin_error = (
+                        "Garmin MFA (two-factor authentication) is enabled. "
+                        "Temporarily disable MFA in your Garmin account settings, "
+                        "connect here, then re-enable it."
+                    )
+                elif "429" in err or "rate limit" in err.lower():
+                    _cd_secs = 2 * 3600
+                    try:
+                        _cd_secs = record_rate_limit(db.get_db())
+                    except Exception:
+                        pass
+                    garmin_error = (
+                        "Garmin has rate-limited login attempts for your account "
+                        "(enforcing a " + format_cooldown(_cd_secs) + " cooldown locally "
+                        "to protect your account). It clears on its own. Retrying "
+                        "resets the timer. Click 'Skip for now'; your credentials are "
+                        "saved and sync will resume automatically."
+                    )
+                elif "SSO login failed" in err:
+                    garmin_error = (
+                        "Garmin login failed. Double-check your email and password. "
+                        "If they're correct, Garmin may be temporarily blocking logins "
+                        "from this server. Try again in an hour."
+                    )
+                else:
+                    # Strip any HTML tags from Garmin error responses
+                    cleaned = re.sub(r"<[^>]+>", " ", err)
+                    cleaned = re.sub(r"\s{2,}", " ", cleaned).strip()[:200]
+                    garmin_error = cleaned or "Unknown error. Check your email and password."
     if garmin_error:
+        _cd2 = 0
+        _cd2_str = ""
+        try:
+            _cd2 = cooldown_remaining(db.get_db())
+            if _cd2 > 0:
+                _cd2_str = format_cooldown(_cd2)
+        except Exception:
+            pass
         return _render("setup.html", config=load_config(), garmin_error=garmin_error,
-                        allow_skip=True, is_cloud=bool(db.get_database_url()))
+                        allow_skip=True, is_cloud=bool(db.get_database_url()),
+                        garmin_cooldown=_cd2, garmin_cooldown_str=_cd2_str)
 
     response = RedirectResponse("/", status_code=303)
     # Set auth cookie if HEVY2GARMIN_SECRET is configured (cloud deployments)
@@ -637,6 +693,19 @@ async def garmin_ticket_store(request: Request):
             _json.dumps({"error": str(e)[:200]}),
             status_code=500,
         )
+
+
+@app.post("/api/garmin-rate-limited")
+async def api_garmin_rate_limited(request: Request):
+    """Browser reports a Garmin rate_limited response from the worker so we can
+    record the cooldown for display. Returns the cooldown length in seconds."""
+    import json as _json
+    try:
+        seconds = record_rate_limit(db.get_db())
+        return HTMLResponse(_json.dumps({"cooldown_seconds": seconds}))
+    except Exception as e:
+        logger.warning("Could not record rate-limit: %s", e)
+        return HTMLResponse(_json.dumps({"cooldown_seconds": 0}))
 
 
 @app.get("/workouts", response_class=HTMLResponse)

--- a/src/hevy2garmin/templates/dashboard.html
+++ b/src/hevy2garmin/templates/dashboard.html
@@ -49,6 +49,18 @@
 </div>
 {% endif %}
 
+{% if garmin_cooldown and garmin_cooldown > 0 %}
+<div class="card" style="margin-bottom: 20px; border-color: rgba(245, 158, 11, 0.3); background: rgba(245, 158, 11, 0.06);">
+    <div style="display: flex; align-items: center; gap: 8px;">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--amber)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+        <span style="font-weight: 600; color: var(--amber);">Garmin rate-limited</span>
+    </div>
+    <p style="font-size: 13px; color: var(--text-secondary); margin-top: 6px;">
+        Cooling down for {{ garmin_cooldown_str }}. Leave it be. Retrying resets the timer. Sync resumes automatically once it clears.
+    </p>
+</div>
+{% endif %}
+
 {% if needs_actions_setup %}
 <div id="actions-setup-card" class="card" style="margin-bottom: 20px; border-color: rgba(59, 130, 246, 0.3); background: rgba(59, 130, 246, 0.06);">
     <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">

--- a/src/hevy2garmin/templates/setup.html
+++ b/src/hevy2garmin/templates/setup.html
@@ -9,6 +9,18 @@
         <p>Get your Hevy gym workouts on Garmin Connect.<br>Set up takes about 2 minutes.</p>
     </div>
 
+    {% if garmin_cooldown and garmin_cooldown > 0 %}
+    <div class="card" style="margin-bottom: 20px; border-color: rgba(245, 158, 11, 0.3); background: rgba(245, 158, 11, 0.06);">
+        <div style="display: flex; align-items: center; gap: 8px;">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--amber)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+            <span style="font-weight: 600; color: var(--amber);">Garmin rate-limited, cooling down for {{ garmin_cooldown_str }}</span>
+        </div>
+        <p style="font-size: 13px; color: var(--text-secondary); margin-top: 6px;">
+            Leave it be. Retrying resets the timer. Come back once it clears, and sync will resume automatically.
+        </p>
+    </div>
+    {% endif %}
+
     {% if garmin_error %}
     <div class="card" style="margin-bottom: 20px; border-color: rgba(59, 130, 246, 0.4); background: rgba(59, 130, 246, 0.06);">
         <div style="display: flex; align-items: center; gap: 8px;">
@@ -76,7 +88,7 @@
                 <label class="form-label" for="garmin_password">Password</label>
                 <div style="display: flex; gap: 8px;">
                     <input class="form-input" type="password" id="garmin_password" name="garmin_password" placeholder="{% if is_cloud %}Pre-filled from deploy{% else %}Stored locally only{% endif %}" autocomplete="current-password" style="flex: 1;">
-                    <button type="button" class="btn btn-primary btn-sm" id="garmin_connect_btn" onclick="garminConnect()" style="white-space: nowrap;">Connect</button>
+                    <button type="button" class="btn btn-primary btn-sm" id="garmin_connect_btn" onclick="garminConnect()" style="white-space: nowrap;" {{ 'disabled' if garmin_cooldown and garmin_cooldown > 0 }}>Connect</button>
                 </div>
                 <div id="garmin_connect_result" style="margin-top: 6px; font-size: 12px;"></div>
             </div>
@@ -233,6 +245,11 @@ async function handleGarminLoginResponse(data) {
     }
 
     if (data.status === 'rate_limited') {
+        // Record the cooldown server-side so the dashboard can display it,
+        // then disable the Connect button so the user can't retry and reset Garmin's timer.
+        fetch('/api/garmin-rate-limited', { method: 'POST' }).catch(function() {});
+        var connectBtn = document.getElementById('garmin_connect_btn');
+        if (connectBtn) { connectBtn.disabled = true; }
         result.innerHTML = '<span style="color: var(--red);">&#10007; Garmin rate-limited this account on their side (separate from your password, your Garmin app still works). It clears on its own, usually within a few hours. Repeated retries just reset the timer, so leave it a while and try once more.</span>';
         return;
     }

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -1,0 +1,81 @@
+"""Tests for the Garmin login rate-limit cooldown (exponential backoff)."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from hevy2garmin.ratelimit import (
+    record_rate_limit,
+    cooldown_remaining,
+    clear_rate_limit,
+    _KEY,
+)
+
+
+class FakeDB:
+    """In-memory app_config store."""
+    def __init__(self):
+        self._c = {}
+
+    def get_app_config(self, key):
+        return self._c.get(key)
+
+    def set_app_config(self, key, value):
+        self._c[key] = value
+
+
+def test_first_hit_is_two_hours():
+    db = FakeDB()
+    assert record_rate_limit(db) == 2 * 3600
+    # ~2h remaining (allow a few seconds of clock drift)
+    assert 2 * 3600 - 60 < cooldown_remaining(db) <= 2 * 3600
+
+
+def test_backoff_doubles_each_repeat():
+    db = FakeDB()
+    assert record_rate_limit(db) == 2 * 3600    # hit 1
+    assert record_rate_limit(db) == 4 * 3600    # hit 2
+    assert record_rate_limit(db) == 8 * 3600    # hit 3
+
+
+def test_backoff_caps_at_24h():
+    db = FakeDB()
+    last = 0
+    for _ in range(10):
+        last = record_rate_limit(db)
+    assert last == 24 * 3600
+
+
+def test_no_state_means_no_cooldown():
+    assert cooldown_remaining(FakeDB()) == 0
+
+
+def test_clear_resets_cooldown_and_backoff():
+    db = FakeDB()
+    record_rate_limit(db)
+    assert cooldown_remaining(db) > 0
+    clear_rate_limit(db)
+    assert cooldown_remaining(db) == 0
+    # next hit starts back at the 2h base, not the escalated window
+    assert record_rate_limit(db) == 2 * 3600
+
+
+def test_expired_cooldown_reports_zero():
+    db = FakeDB()
+    db.set_app_config(_KEY, {
+        "until": (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat(),
+        "hits": 1,
+    })
+    assert cooldown_remaining(db) == 0
+
+
+def test_storage_failure_never_raises():
+    class BrokenDB:
+        def get_app_config(self, key):
+            raise RuntimeError("db down")
+        def set_app_config(self, key, value):
+            raise RuntimeError("db down")
+    db = BrokenDB()
+    # must not raise
+    assert record_rate_limit(db) == 2 * 3600
+    assert cooldown_remaining(db) == 0
+    clear_rate_limit(db)

--- a/tests/test_ratelimit.py
+++ b/tests/test_ratelimit.py
@@ -7,6 +7,7 @@ from hevy2garmin.ratelimit import (
     record_rate_limit,
     cooldown_remaining,
     clear_rate_limit,
+    format_cooldown,
     _KEY,
 )
 
@@ -66,6 +67,18 @@ def test_expired_cooldown_reports_zero():
         "hits": 1,
     })
     assert cooldown_remaining(db) == 0
+
+
+def test_format_cooldown_hours_and_minutes():
+    assert format_cooldown(6300) == "about 1h 45m"
+
+
+def test_format_cooldown_minutes_only():
+    assert format_cooldown(300) == "about 5m"
+
+
+def test_format_cooldown_exact_hours():
+    assert format_cooldown(7200) == "about 2h"
 
 
 def test_storage_failure_never_raises():

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -59,3 +59,25 @@ class TestSetupNoRedundantLogin:
             resp = _post(client)
         mock_get_client.assert_called_once()
         assert resp.status_code in (200, 303)
+
+    def test_local_gate_skips_get_client_when_cooling_down(self, client):
+        """During active cooldown, setup must NOT call get_client (would reset Garmin's timer)."""
+        from datetime import datetime, timedelta, timezone
+        from hevy2garmin.ratelimit import _KEY
+
+        class FakeDB:
+            def __init__(self):
+                until = (datetime.now(timezone.utc) + timedelta(hours=2)).isoformat()
+                self._state = {_KEY: {"until": until, "hits": 1, "seconds": 7200}}
+            def get_app_config(self, key):
+                return self._state.get(key)
+            def set_app_config(self, key, value):
+                self._state[key] = value
+
+        with patch("hevy2garmin.server.save_config"), \
+             patch("hevy2garmin.db.get_database_url", return_value=None), \
+             patch("hevy2garmin.db.get_db", return_value=FakeDB()), \
+             patch("hevy2garmin.garmin.get_client") as mock_get_client:
+            resp = _post(client)
+        mock_get_client.assert_not_called()
+        assert resp.status_code == 200  # renders cooldown error page, not redirect


### PR DESCRIPTION
Closes #211. On a Garmin 429, records an exponential-backoff cooldown (2h→4h→8h, cap 24h, reset after a clean login) and, while active, the local setup login skips the Garmin attempt entirely so the user can't reset Garmin's timer. Cloud rate-limits are recorded via a new `/api/garmin-rate-limited` endpoint; setup + dashboard show a live countdown and disable the Connect button while cooling down. New `ratelimit.py` (pure, fully unit-tested) + wiring. Full suite 275 passed. No version bump. Hard-blocking at the Cloudflare Worker (KV) is a noted follow-up.