### PR TITLE
chore(release): 0.5.15 unify sync paths for Vercel cron merge-reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.15] - 2026-07-10
+
+### Changed
+- Unified the bulk sync and per-workout cron sync paths behind a single `sync_one_workout()` helper. The Vercel cron now gets the same merge-reliability behavior (grace period, heart-rate retry, duplicate awareness) that the CLI and autosync paths already had. Thanks @donndonn for the contribution (#208, closes #206).
+
+### Fixed
+- The description toggle is now respected on the web sync path, and calories and average heart rate carry through on the merge path.
+
 ## [0.5.14] - 2026-07-09
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hevy2garmin"
-version = "0.5.14"
+version = "0.5.15"
 description = "Sync Hevy gym workouts to Garmin Connect — exercise mapping, FIT file generation, and automatic upload"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Release 0.5.15.

Ships the #208 unification (thanks @donndonn) to PyPI. `sync_one_workout()` is now the single per-workout path shared by the bulk CLI/autosync sync and the Vercel cron, so grace-period race prevention, heart-rate retry, and duplicate awareness apply on the cloud path too.

- Changed: unified sync paths (Vercel cron now gets merge-reliability)
- Fixed: description toggle respected on the web path, calories/avg HR carried through on the merge path

Closes #206.
