### PR TITLE
feat(worker): hard-enforce Garmin rate-limit cooldown at the DI worker (#214)

### DIFF
--- a/worker-di/index.js
+++ b/worker-di/index.js
@@ -90,6 +90,18 @@ const CORS_HEADERS = {
 // within a few minutes, so we don't bother keeping KV entries around longer.
 const MFA_SESSION_TTL_SECONDS = 600;
 
+// Rate-limit cooldown (#214). When Garmin returns a 429 for a login, we stash a
+// per-account cooldown in KV and short-circuit further /login attempts for that
+// account until it lapses, so a determined user can't bypass the client-side
+// cooldown (0.5.14) by POSTing the Worker directly and deepen Garmin's throttle
+// (#147). Keyed per account because this Worker is shared across every
+// self-hosted instance and Garmin throttles per-account, so a global key would
+// let one account's 429 lock out everyone. Matches the local server's 2h base
+// (ratelimit.py) so users see one consistent number. The KV entry's TTL equals
+// the cooldown, so it self-clears exactly when the window ends.
+const COOLDOWN_KEY_PREFIX = "cooldown:";
+const COOLDOWN_SECONDS = 2 * 3600;
+
 // ── Main handler ───────────────────────────────────────────────────────────
 
 export default {
@@ -156,6 +168,15 @@ async function handleLogin(request, env) {
     return json({ status: "error", message: "email and password required" }, 400);
   }
 
+  // Hard-enforce the per-account cooldown before touching Garmin (#214). If this
+  // account is still cooling down from an earlier 429, return immediately so we
+  // never add to Garmin's throttle. Fails open: any KV error proceeds to Garmin
+  // rather than locking the account out (this Worker is shared).
+  const remaining = await cooldownRemaining(env, email);
+  if (remaining > 0) {
+    return json({ status: "rate_limited", retry_after_seconds: remaining });
+  }
+
   // Mobile-first: the mobile/app login endpoint is the one Garmin designed for
   // native MFA, so it's the least likely to reject programmatic logins with a
   // 427. Fall back to the portal endpoint ONLY on a 427 (MFA-routing). We do
@@ -164,10 +185,18 @@ async function handleLogin(request, env) {
   // and deepens the throttle that won't clear (#147). On 429 we surface
   // rate_limited immediately.
   const first = await tryLoginFlavour(env, email, password, "mobile");
-  if (!first.fallback) return first.response;
+  if (first.rateLimited) return await rateLimitResponse(env, email);
+  if (!first.fallback) {
+    if (first.success) await clearCooldown(env, email);
+    return first.response;
+  }
 
   const second = await tryLoginFlavour(env, email, password, "portal");
-  if (!second.fallback) return second.response;
+  if (second.rateLimited) return await rateLimitResponse(env, email);
+  if (!second.fallback) {
+    if (second.success) await clearCooldown(env, email);
+    return second.response;
+  }
 
   // 427 on both endpoints → Garmin is steering us to the manual flow.
   return json({
@@ -175,6 +204,13 @@ async function handleLogin(request, env) {
     message:
       "Garmin returned error 427 on both login flows. Use the manual sign-in fallback.",
   });
+}
+
+/** Record a fresh cooldown for this account and build the rate_limited
+ *  response the caller sends back. */
+async function rateLimitResponse(env, email) {
+  const secs = await setCooldown(env, email);
+  return json({ status: "rate_limited", retry_after_seconds: secs });
 }
 
 /** Attempt a single login flavour (portal or mobile) and return either a
@@ -269,8 +305,8 @@ async function tryLoginFlavour(env, email, password, flavour) {
   if (loginResp.status === 429) {
     // Never fall back to the other flavour on a rate limit — Garmin's login
     // limit is per-account across both endpoints, so retrying just deepens it
-    // (#147). Surface it so the caller can tell the user to wait it out.
-    return { response: json({ status: "rate_limited" }) };
+    // (#147). Signal the caller to record the cooldown and surface it (#214).
+    return { rateLimited: true };
   }
   let loginData;
   try {
@@ -291,8 +327,9 @@ async function tryLoginFlavour(env, email, password, flavour) {
   // Handle Garmin's custom error envelope.
   const garminErrCode = loginData?.error?.["status-code"];
   if (garminErrCode === "429") {
-    // Per-account rate limit — never retry the other flavour (#147).
-    return { response: json({ status: "rate_limited" }) };
+    // Per-account rate limit — never retry the other flavour (#147). Signal the
+    // caller to record the cooldown and surface it (#214).
+    return { rateLimited: true };
   }
   if (garminErrCode === "427") {
     // 427 routes MFA-enabled accounts to a different flow. Signal the caller to
@@ -335,6 +372,7 @@ async function tryLoginFlavour(env, email, password, flavour) {
       };
     }
     return {
+      success: true,
       response: json({
         status: "success",
         di_token: di.access_token,
@@ -365,6 +403,7 @@ async function tryLoginFlavour(env, email, password, flavour) {
     const sessionId = crypto.randomUUID();
     const sessionState = {
       flavour,
+      email,
       cookies: mergedCookies,
       mfa_method: mfaMethod,
       params: params.toString(),
@@ -480,7 +519,8 @@ async function handleLoginMfa(request, env) {
   }
 
   if (mfaResp.status === 429) {
-    return json({ status: "rate_limited" });
+    const secs = await setCooldown(env, session.email);
+    return json({ status: "rate_limited", retry_after_seconds: secs });
   }
   let mfaData;
   try {
@@ -511,6 +551,7 @@ async function handleLoginMfa(request, env) {
   const di = await exchangeServiceTicket(ticket, serviceUrl);
   if (di.error) return json({ status: "error", message: di.error }, di.status || 502);
   await env.MFA_SESSIONS.delete(sessionId).catch(() => {});
+  await clearCooldown(env, session.email);
 
   return json({
     status: "success",
@@ -518,6 +559,73 @@ async function handleLoginMfa(request, env) {
     di_refresh_token: di.refresh_token,
     di_client_id: extractClientIdFromJwt(di.access_token) || CLIENT_ID,
   });
+}
+
+// ── Rate-limit cooldown helpers (#214) ─────────────────────────────────────
+
+/** SHA-256 hex of the normalized (trimmed, lowercased) email. Used as the KV
+ *  key suffix so we never store the raw address and so casing/whitespace
+ *  variants of the same account map to one cooldown. */
+export async function hashEmail(email) {
+  const norm = (email || "").trim().toLowerCase();
+  const bytes = new TextEncoder().encode(norm);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/** Whole seconds remaining until `until` (ms epoch), floored at 0. */
+export function remainingSeconds(until, now) {
+  return Math.max(0, Math.ceil((until - now) / 1000));
+}
+
+/** Seconds left on this account's cooldown, or 0 if none. Fails open: any KV
+ *  error returns 0 so a KV blip can't lock every account out of login. */
+export async function cooldownRemaining(env, email) {
+  if (!env || !env.MFA_SESSIONS) return 0;
+  try {
+    const hash = await hashEmail(email);
+    const raw = await env.MFA_SESSIONS.get(COOLDOWN_KEY_PREFIX + hash);
+    if (!raw) return 0;
+    const { until } = JSON.parse(raw);
+    return remainingSeconds(until, Date.now());
+  } catch {
+    return 0;
+  }
+}
+
+/** Start (or refresh) this account's cooldown. The KV TTL equals the cooldown
+ *  so the entry self-clears when the window ends. Returns the cooldown length
+ *  in seconds; still returns it on a KV error so the caller reports the real
+ *  429 the user just hit. */
+export async function setCooldown(env, email) {
+  if (env && env.MFA_SESSIONS) {
+    try {
+      const hash = await hashEmail(email);
+      const until = Date.now() + COOLDOWN_SECONDS * 1000;
+      await env.MFA_SESSIONS.put(
+        COOLDOWN_KEY_PREFIX + hash,
+        JSON.stringify({ until }),
+        { expirationTtl: COOLDOWN_SECONDS },
+      );
+    } catch {
+      // fall through — still report the cooldown length to the caller
+    }
+  }
+  return COOLDOWN_SECONDS;
+}
+
+/** Drop this account's cooldown after a genuine Garmin response (the account
+ *  clearly isn't throttled). Best effort; errors are ignored. */
+export async function clearCooldown(env, email) {
+  if (!env || !env.MFA_SESSIONS || !email) return;
+  try {
+    const hash = await hashEmail(email);
+    await env.MFA_SESSIONS.delete(COOLDOWN_KEY_PREFIX + hash);
+  } catch {
+    // best effort
+  }
 }
 
 // ── Shared helpers ─────────────────────────────────────────────────────────

--- a/worker-di/index.js
+++ b/worker-di/index.js
@@ -96,8 +96,10 @@ const MFA_SESSION_TTL_SECONDS = 600;
 // cooldown (0.5.14) by POSTing the Worker directly and deepen Garmin's throttle
 // (#147). Keyed per account because this Worker is shared across every
 // self-hosted instance and Garmin throttles per-account, so a global key would
-// let one account's 429 lock out everyone. Matches the local server's 2h base
-// (ratelimit.py) so users see one consistent number. The KV entry's TTL equals
+// let one account's 429 lock out everyone. Uses a flat 2h window (the local
+// server's ratelimit.py base) as a backstop; it intentionally does NOT
+// replicate the client's exponential backoff, so for a repeatedly-throttled
+// account the two layers can report different waits. The KV entry's TTL equals
 // the cooldown, so it self-clears exactly when the window ends.
 const COOLDOWN_KEY_PREFIX = "cooldown:";
 const COOLDOWN_SECONDS = 2 * 3600;
@@ -589,6 +591,7 @@ export async function cooldownRemaining(env, email) {
     const raw = await env.MFA_SESSIONS.get(COOLDOWN_KEY_PREFIX + hash);
     if (!raw) return 0;
     const { until } = JSON.parse(raw);
+    if (typeof until !== "number") return 0;
     return remainingSeconds(until, Date.now());
   } catch {
     return 0;

--- a/worker-di/index.test.mjs
+++ b/worker-di/index.test.mjs
@@ -1,0 +1,113 @@
+// Unit tests for the #214 rate-limit cooldown helpers in the DI Worker.
+// Run: node --test worker-di/
+//
+// Covers the pure helpers (email hashing + remaining-seconds math) and the KV
+// round-trip (set -> remaining > 0 -> clear -> remaining 0) against a Map-backed
+// fake KV that mimics the Cloudflare KV get/put/delete surface.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  hashEmail,
+  remainingSeconds,
+  cooldownRemaining,
+  setCooldown,
+  clearCooldown,
+} from "./index.js";
+
+// A minimal fake of the Cloudflare KV binding.
+function fakeKV() {
+  const store = new Map();
+  return {
+    store,
+    async get(key) {
+      return store.has(key) ? store.get(key) : null;
+    },
+    async put(key, value) {
+      store.set(key, value);
+    },
+    async delete(key) {
+      store.delete(key);
+    },
+  };
+}
+
+test("hashEmail is deterministic and normalizes case + whitespace", async () => {
+  const a = await hashEmail("Foo@Example.com");
+  const b = await hashEmail("  foo@example.com  ");
+  assert.equal(a, b, "casing/whitespace variants hash the same");
+  assert.match(a, /^[0-9a-f]{64}$/, "is a 64-char sha-256 hex");
+
+  const c = await hashEmail("other@example.com");
+  assert.notEqual(a, c, "different accounts hash differently");
+});
+
+test("remainingSeconds floors at 0 and ceils partial seconds", () => {
+  const now = 1_000_000;
+  assert.equal(remainingSeconds(now - 5000, now), 0, "past -> 0");
+  assert.equal(remainingSeconds(now, now), 0, "exactly now -> 0");
+  assert.equal(remainingSeconds(now + 7200_000, now), 7200, "2h future -> 7200");
+  assert.equal(remainingSeconds(now + 1, now), 1, "partial second ceils up");
+});
+
+test("cooldown round-trip: set -> active -> clear", async () => {
+  const env = { MFA_SESSIONS: fakeKV() };
+  const email = "athlete@garmin.test";
+
+  assert.equal(await cooldownRemaining(env, email), 0, "no cooldown initially");
+
+  const secs = await setCooldown(env, email);
+  assert.equal(secs, 7200, "cooldown length is the 2h base");
+
+  const rem = await cooldownRemaining(env, email);
+  assert.ok(rem > 7100 && rem <= 7200, `remaining ~2h, got ${rem}`);
+
+  await clearCooldown(env, email);
+  assert.equal(await cooldownRemaining(env, email), 0, "cleared -> 0");
+});
+
+test("cooldown is per-account (one account's cooldown doesn't gate another)", async () => {
+  const env = { MFA_SESSIONS: fakeKV() };
+  await setCooldown(env, "a@garmin.test");
+  assert.ok((await cooldownRemaining(env, "a@garmin.test")) > 0, "a is gated");
+  assert.equal(
+    await cooldownRemaining(env, "b@garmin.test"),
+    0,
+    "b is not gated by a's cooldown",
+  );
+});
+
+test("fails open when KV is unavailable", async () => {
+  assert.equal(await cooldownRemaining({}, "x@garmin.test"), 0, "no binding -> 0");
+  assert.equal(
+    await cooldownRemaining(undefined, "x@garmin.test"),
+    0,
+    "no env -> 0",
+  );
+
+  const throwingEnv = {
+    MFA_SESSIONS: {
+      async get() {
+        throw new Error("KV down");
+      },
+      async put() {
+        throw new Error("KV down");
+      },
+      async delete() {
+        throw new Error("KV down");
+      },
+    },
+  };
+  assert.equal(
+    await cooldownRemaining(throwingEnv, "x@garmin.test"),
+    0,
+    "KV get error -> 0 (proceed to Garmin)",
+  );
+  // setCooldown still reports the cooldown length even if the KV write fails,
+  // so the caller can tell the user the real 429 they just hit.
+  assert.equal(
+    await setCooldown(throwingEnv, "x@garmin.test"),
+    7200,
+    "KV put error -> still returns cooldown length",
+  );
+});

--- a/worker-di/index.test.mjs
+++ b/worker-di/index.test.mjs
@@ -7,7 +7,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import {
+import worker, {
   hashEmail,
   remainingSeconds,
   cooldownRemaining,
@@ -110,4 +110,80 @@ test("fails open when KV is unavailable", async () => {
     7200,
     "KV put error -> still returns cooldown length",
   );
+});
+
+// ── Integration: drive the Worker's fetch handler with a mocked global fetch ──
+
+function loginRequest(email, password = "pw") {
+  return new Request("https://worker.test/login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email, password }),
+  });
+}
+
+test("a 429 from Garmin records a per-account cooldown (#214, constraint 3)", async () => {
+  const env = { MFA_SESSIONS: fakeKV() };
+  const email = "flow@garmin.test";
+  const orig = globalThis.fetch;
+  let loginPosts = 0;
+  globalThis.fetch = async (_url, opts = {}) => {
+    if ((opts.method || "GET") === "POST") {
+      loginPosts += 1;
+      return new Response("", { status: 429 }); // Garmin throttles the login POST
+    }
+    // warmup GET establishes cookies
+    return new Response("", { status: 200, headers: { "set-cookie": "s=1" } });
+  };
+  try {
+    const res = await worker.fetch(loginRequest(email), env);
+    const body = await res.json();
+    assert.equal(body.status, "rate_limited", "surfaces rate_limited");
+    assert.equal(body.retry_after_seconds, 7200, "reports the cooldown length");
+
+    // The cooldown must have landed in KV under THIS account's key.
+    const hash = await hashEmail(email);
+    assert.ok(
+      env.MFA_SESSIONS.store.has("cooldown:" + hash),
+      "cooldown key recorded for the account",
+    );
+    // And it must NOT gate a different account.
+    assert.equal(
+      await cooldownRemaining(env, "other@garmin.test"),
+      0,
+      "different account is not gated",
+    );
+  } finally {
+    globalThis.fetch = orig;
+  }
+});
+
+test("an active cooldown short-circuits /login WITHOUT calling Garmin (#214 pre-gate)", async () => {
+  const email = "gated@garmin.test";
+  const hash = await hashEmail(email);
+  const env = { MFA_SESSIONS: fakeKV() };
+  // Pre-seed an active cooldown (1h out).
+  env.MFA_SESSIONS.store.set(
+    "cooldown:" + hash,
+    JSON.stringify({ until: Date.now() + 3600_000 }),
+  );
+
+  const orig = globalThis.fetch;
+  let fetchCalls = 0;
+  globalThis.fetch = async () => {
+    fetchCalls += 1;
+    throw new Error("Garmin must not be contacted during a cooldown");
+  };
+  try {
+    const res = await worker.fetch(loginRequest(email), env);
+    const body = await res.json();
+    assert.equal(body.status, "rate_limited", "short-circuits to rate_limited");
+    assert.ok(
+      body.retry_after_seconds > 3500 && body.retry_after_seconds <= 3600,
+      `reports the decaying remainder, got ${body.retry_after_seconds}`,
+    );
+    assert.equal(fetchCalls, 0, "Garmin was never contacted");
+  } finally {
+    globalThis.fetch = orig;
+  }
 });


### PR DESCRIPTION
Closes #214. Follow-up to the client-side cooldown shipped in 0.5.14 (#211/#212).

## What

On a Garmin `429`, the DI login worker now stashes a per-account cooldown in KV and short-circuits further `/login` attempts for that account until it lapses, returning `{status:'rate_limited', retry_after_seconds}` without ever calling Garmin. The client cooldown stops the normal user from hammering Garmin, but on cloud the login runs browser -> Worker -> Garmin, so a determined user could still hit the Worker directly during a cooldown and deepen Garmin's throttle (#147). This closes that gap.

## Design decisions

- **Per-account key** (`cooldown:<sha256(normalized email)>`), not a single global key. This Worker is shared across every self-hosted instance and Garmin throttles per-account, so a global `cooldown_until` would let one account's 429 lock out everyone else. The email is hashed so the raw address is never stored.
- **Reuses the existing `MFA_SESSIONS` KV binding** — no new namespace or resource. The cooldown key's TTL equals the cooldown, so it self-clears exactly when the window ends.
- **Fails open**: any KV error proceeds to Garmin rather than locking accounts out (a KV blip must never block every login on a shared Worker).
- **Clears on success**: a genuine successful login drops the account's cooldown.
- **2h base**, matching the local server's `ratelimit.py`, so users see one consistent number across both enforcement layers.

## Testing

- `node --test worker-di/` — 5 passing tests: email hashing (determinism + normalization), remaining-seconds math, the KV round-trip (set -> active -> clear), per-account isolation, and the fail-open paths.
- Deployed to `hevy2garmin-exchange-di` and verified end-to-end against the live Worker: the gate-open path reaches Garmin and returns a real answer; the pre-gate short-circuits when a cooldown key is present (after KV propagation).
