### PR TITLE
fix(merge): strip only the offending exercise name (0.5.16, #222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.16] - 2026-07-13
+
+### Fixed
+- Merge mode: when Garmin rejects one exercise's name as an invalid sub-category, only that exercise's name is now stripped instead of every name in the workout. The offender is found by bisecting the payload (the atomic PUT gives no per-exercise error), so the rest of your exercises keep their real names. Falls back to stripping all names only if several exercises are rejected. (#222)
+
 ## [0.5.15] - 2026-07-10
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hevy2garmin"
-version = "0.5.15"
+version = "0.5.16"
 description = "Sync Hevy gym workouts to Garmin Connect — exercise mapping, FIT file generation, and automatic upload"
 readme = "README.md"
 license = "MIT"

--- a/src/hevy2garmin/merge.py
+++ b/src/hevy2garmin/merge.py
@@ -161,6 +161,74 @@ def _strip_exercise_names(payload: dict) -> dict:
     return stripped
 
 
+def _named_exercise_keys(payload: dict) -> list[tuple]:
+    """Distinct ``(category, name)`` of exercises that carry a name, first-seen
+    order. These are the candidates Garmin might reject as an invalid sub-category."""
+    keys: list[tuple] = []
+    seen: set[tuple] = set()
+    for s in payload.get("exerciseSets", []):
+        for ex in s.get("exercises", []):
+            name = ex.get("name")
+            if name is None:
+                continue
+            k = (ex.get("category"), name)
+            if k not in seen:
+                seen.add(k)
+                keys.append(k)
+    return keys
+
+
+def _strip_names_for(payload: dict, bad: set) -> dict:
+    """Copy of the payload with the name removed only for exercises whose
+    ``(category, name)`` is in ``bad`` (category kept)."""
+    stripped = dict(payload)
+    stripped["exerciseSets"] = [
+        {
+            **s,
+            "exercises": [
+                {**ex, "name": None} if (ex.get("category"), ex.get("name")) in bad else ex
+                for ex in s.get("exercises", [])
+            ],
+        }
+        for s in payload.get("exerciseSets", [])
+    ]
+    return stripped
+
+
+def _push_stripping_offenders(client, activity_id: int, payload: dict) -> None:
+    """Land the sets while keeping as many exercise names as possible.
+
+    Garmin's exerciseSets PUT is atomic and reports no per-exercise error, so when
+    it rejects a name as an invalid sub-category we bisect: strip a half of the
+    distinct exercises, retry, and narrow to the offender(s), then strip only those
+    names (category kept). Bounded to ~log2(n) extra PUTs, only on this rare path.
+    Falls back to stripping every name if it can't converge (multiple offenders
+    split across halves). Raises on any non-subcategory error."""
+    keys = _named_exercise_keys(payload)
+    if len(keys) <= 1:
+        push_exercise_sets(client, activity_id, _strip_exercise_names(payload))
+        return
+    cand = keys
+    while len(cand) > 1:
+        mid = len(cand) // 2
+        head = cand[:mid]
+        try:
+            push_exercise_sets(client, activity_id, _strip_names_for(payload, set(head)))
+            cand = head          # stripping head fixed it → offender(s) in head
+        except Exception as e:   # noqa: BLE001
+            if not _is_subcategory_rejection(e):
+                raise
+            cand = cand[mid:]    # still rejected → offender(s) in the tail
+    # Narrowed to one candidate: strip just it. If that still fails there is more
+    # than one offender split across halves, so fall back to stripping every name.
+    try:
+        push_exercise_sets(client, activity_id, _strip_names_for(payload, set(cand)))
+    except Exception as e:  # noqa: BLE001
+        if not _is_subcategory_rejection(e):
+            raise
+        push_exercise_sets(client, activity_id, _strip_exercise_names(payload))
+
+
 def _is_subcategory_rejection(exc: Exception) -> bool:
     """True when a push failed because Garmin rejected an exercise
     ``(category, subcategory)`` pair (HTTP 400 "Invalid Sub-Category"). The
@@ -426,10 +494,10 @@ def attempt_merge(
         if _is_subcategory_rejection(e):
             logger.warning(
                 "  exerciseSets rejected a subcategory for activity %s (%s); "
-                "retrying without exercise names", activity_id, e,
+                "retrying, stripping only the offending exercise name(s)", activity_id, e,
             )
             try:
-                push_exercise_sets(client, activity_id, _strip_exercise_names(payload))
+                _push_stripping_offenders(client, activity_id, payload)
                 _consecutive_failures = 0
             except Exception as e2:
                 _consecutive_failures += 1

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -547,19 +547,26 @@ def test_subcategory_400_retries_without_names(mock_gen, mock_desc, mock_rename,
     mock_find.return_value = act
     mock_get.return_value = {"exerciseSets": []}
     mock_gen.return_value = "Bench: 3 sets"
-    # first push rejected, the names-stripped retry succeeds
-    mock_push.side_effect = [
-        RuntimeError("API Error 400 - Invalid Sub-Category Passed in the request"),
-        None,
-    ]
+    # First push (full payload) is rejected; the strip retry(s) then succeed. The
+    # surgical strip (#222) bisects, so it may take a few PUTs — accept any.
+    calls: list = []
+
+    def push_side_effect(client, aid, payload):
+        calls.append(payload)
+        if len(calls) == 1:
+            raise RuntimeError("API Error 400 - Invalid Sub-Category Passed in the request")
+        return None
+
+    mock_push.side_effect = push_side_effect
 
     result = attempt_merge(MagicMock(), HEVY_WORKOUT, MagicMock(), watch_strategy="merge")
 
     assert result.merged is True
-    assert mock_push.call_count == 2
-    retry_payload = mock_push.call_args_list[1].args[2]
-    active = [s for s in retry_payload["exerciseSets"] if s["setType"] == "ACTIVE"]
-    assert active and all(ex["name"] is None for s in active for ex in s["exercises"])
+    assert len(calls) >= 2  # retried after the subcategory rejection
+    # The landed retry stripped at least one exercise name (category kept).
+    landed = calls[-1]
+    all_names = [ex.get("name") for s in landed["exerciseSets"] for ex in s.get("exercises", [])]
+    assert any(n is None for n in all_names)
 
 
 @patch("hevy2garmin.merge.time.sleep")

--- a/tests/test_surgical_strip.py
+++ b/tests/test_surgical_strip.py
@@ -1,0 +1,98 @@
+"""Surgical exercise-name stripping on a Garmin subcategory rejection (#222).
+
+Regression guard: one exercise Garmin rejects used to blank EVERY exercise name in
+the merged activity. Now only the offending name is stripped; the rest are kept.
+"""
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from hevy2garmin import merge  # noqa: E402
+
+
+def _payload(exercises):
+    """exercises: list of (category, name) — one exercise per set."""
+    return {
+        "exerciseSets": [
+            {"order": i, "exercises": [{"category": c, "name": n, "probability": None}]}
+            for i, (c, n) in enumerate(exercises)
+        ]
+    }
+
+
+def _accepted_names(payload):
+    names = {}
+    for s in payload["exerciseSets"]:
+        for ex in s["exercises"]:
+            names[ex["category"]] = ex["name"]
+    return names
+
+
+def test_single_offender_keeps_the_other_names():
+    payload = _payload([
+        ("BENCH_PRESS", "BARBELL_BENCH_PRESS"),
+        ("SHOULDER_PRESS", "BAD_SHOULDER_NAME"),   # the one Garmin rejects
+        ("CURL", "BARBELL_BICEPS_CURL"),
+        ("TRICEPS_EXTENSION", "CABLE_KICKBACK"),
+    ])
+    offender = ("SHOULDER_PRESS", "BAD_SHOULDER_NAME")
+    accepted = {}
+
+    def fake_push(client, aid, p):
+        for s in p["exerciseSets"]:
+            for ex in s["exercises"]:
+                if (ex["category"], ex["name"]) == offender:  # still named → rejected
+                    raise Exception("HTTP 400: Invalid Sub-Category Passed in the request")
+        accepted["payload"] = p  # this one landed
+
+    with patch.object(merge, "push_exercise_sets", side_effect=fake_push):
+        merge._push_stripping_offenders(None, 123, payload)
+
+    names = _accepted_names(accepted["payload"])
+    assert names["SHOULDER_PRESS"] is None                  # offender stripped
+    assert names["BENCH_PRESS"] == "BARBELL_BENCH_PRESS"    # kept
+    assert names["CURL"] == "BARBELL_BICEPS_CURL"           # kept
+    assert names["TRICEPS_EXTENSION"] == "CABLE_KICKBACK"   # kept
+
+
+def test_multiple_offenders_fall_back_to_stripping_all():
+    payload = _payload([
+        ("BENCH_PRESS", "GOOD_1"),
+        ("SHOULDER_PRESS", "BAD_1"),
+        ("CURL", "GOOD_2"),
+        ("TRICEPS_EXTENSION", "BAD_2"),
+    ])
+    bad = {("SHOULDER_PRESS", "BAD_1"), ("TRICEPS_EXTENSION", "BAD_2")}
+    accepted = {}
+
+    def fake_push(client, aid, p):
+        for s in p["exerciseSets"]:
+            for ex in s["exercises"]:
+                if (ex["category"], ex["name"]) in bad:
+                    raise Exception("Invalid Sub-Category")
+        accepted["payload"] = p
+
+    with patch.object(merge, "push_exercise_sets", side_effect=fake_push):
+        merge._push_stripping_offenders(None, 123, payload)
+
+    # Can't keep any (offenders split across halves) → every name stripped.
+    for name in _accepted_names(accepted["payload"]).values():
+        assert name is None
+
+
+def test_single_exercise_strips_that_one():
+    payload = _payload([("SHOULDER_PRESS", "BAD")])
+    accepted = {}
+
+    def fake_push(client, aid, p):
+        ex = p["exerciseSets"][0]["exercises"][0]
+        if ex["name"] == "BAD":
+            raise Exception("invalid sub-category")
+        accepted["payload"] = p
+
+    with patch.object(merge, "push_exercise_sets", side_effect=fake_push):
+        merge._push_stripping_offenders(None, 123, payload)
+
+    assert accepted["payload"]["exerciseSets"][0]["exercises"][0]["name"] is None


### PR DESCRIPTION
Closes #222.

Garmin's exerciseSets PUT is atomic — one exercise whose name it rejects as an invalid sub-category 400s the whole payload. The 0.5.12 fix retried with EVERY name stripped, so one bad exercise blanked the whole workout's names (silas_christopher on r/Hevy: "no exercise names").

Now: on a subcategory rejection, bisect the payload to find the offender(s) and strip only those names (category kept), keeping the rest. Falls back to stripping all names only if several are rejected. Bounded to ~log2(n) extra PUTs, only on the rare reject path.

Tests: 3 new (single-offender keeps names, multi-offender fallback, single-exercise); existing subcategory test updated for the bisection; full suite 287 passed. Ships as 0.5.16.