### PR TITLE
fix(cli): context-aware 'Not configured' message (0.5.17, #224)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.17] - 2026-07-13
+
+### Fixed
+- The "Not configured" error is now context-aware. On the cloud / GitHub Actions path (DATABASE_URL set) it no longer tells you to run `hevy2garmin init` (a local interactive wizard that can't run in Actions); instead it points you to finish setup in the dashboard and to make sure `DATABASE_URL` matches your deployment's database. (#224)
+
 ## [0.5.16] - 2026-07-13
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hevy2garmin"
-version = "0.5.16"
+version = "0.5.17"
 description = "Sync Hevy gym workouts to Garmin Connect — exercise mapping, FIT file generation, and automatic upload"
 readme = "README.md"
 license = "MIT"

--- a/src/hevy2garmin/cli.py
+++ b/src/hevy2garmin/cli.py
@@ -13,10 +13,30 @@ from hevy2garmin.mapper import save_custom_mapping
 from hevy2garmin.sync import sync
 
 
+def _not_configured_message() -> str:
+    """Context-aware 'not configured' guidance. On the cloud/Actions path
+    (DATABASE_URL set) 'hevy2garmin init' is the wrong advice — the real fix is
+    the dashboard setup + a matching DATABASE_URL."""
+    from hevy2garmin.db import get_database_url
+
+    if get_database_url():
+        return (
+            "✗ Not configured: no Hevy/Garmin credentials found in the database.\n"
+            "  Finish setup in your deployed dashboard (add your Hevy API key and connect\n"
+            "  Garmin), and make sure the DATABASE_URL here is the SAME database your\n"
+            "  deployment uses (check the GitHub secret matches your Vercel env var)."
+        )
+    return (
+        "✗ Not configured. On GitHub Actions / cloud, set the DATABASE_URL secret to your\n"
+        "  deployment's database (the same Neon URL your dashboard uses). Running locally?\n"
+        "  Run: hevy2garmin init"
+    )
+
+
 def _require_config(args: argparse.Namespace) -> None:
     """Check config exists, error if not (unless credentials passed via flags)."""
     if not is_configured() and not args.hevy_api_key:
-        print("✗ Not configured. Run: hevy2garmin init")
+        print(_not_configured_message())
         sys.exit(1)
 
 
@@ -115,7 +135,7 @@ def cmd_sync(args: argparse.Namespace) -> None:
 def cmd_status(args: argparse.Namespace) -> None:
     """Show sync status."""
     if not is_configured():
-        print("✗ Not configured. Run: hevy2garmin init")
+        print(_not_configured_message())
         sys.exit(1)
 
     count = db.get_synced_count()

--- a/tests/test_not_configured_message.py
+++ b/tests/test_not_configured_message.py
@@ -1,0 +1,21 @@
+"""The 'not configured' message must be context-aware (#224): telling a cloud /
+GitHub Actions user to run 'hevy2garmin init' (a local interactive wizard) is
+wrong — the real fix there is the dashboard setup + a matching DATABASE_URL."""
+from unittest.mock import patch
+
+from hevy2garmin.cli import _not_configured_message
+
+
+def test_cloud_path_points_to_dashboard_not_init():
+    with patch("hevy2garmin.db.get_database_url", return_value="postgres://x/db"):
+        msg = _not_configured_message()
+    assert "dashboard" in msg.lower()
+    assert "DATABASE_URL" in msg
+    assert "hevy2garmin init" not in msg  # wrong advice for the cloud path
+
+
+def test_local_path_mentions_init_and_the_secret():
+    with patch("hevy2garmin.db.get_database_url", return_value=None):
+        msg = _not_configured_message()
+    assert "hevy2garmin init" in msg
+    assert "DATABASE_URL" in msg  # also nudges cloud users to set the secret


### PR DESCRIPTION
Closes #224.

`hevy2garmin sync` on GitHub Actions printed `✗ Not configured. Run: hevy2garmin init` — but `init` is a local interactive wizard, useless in Actions. The real cause is no credentials in the database at `DATABASE_URL` (setup not completed in the dashboard, or a `DATABASE_URL` secret that doesn't match the deployment). r/Hevy user AgentChung hit this and couldn't tell what to fix.

Now the message is context-aware: on the cloud path it points to the dashboard setup + a matching `DATABASE_URL`; locally it still says run `hevy2garmin init`.

Tests: 2 new (cloud vs local message); full suite 289 passed. Ships as 0.5.17.