### PR TITLE
feat(sync): safe Garmin upload recovery and web controls

### DIFF
--- a/src/hevy2garmin/cli.py
+++ b/src/hevy2garmin/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import getpass
 import logging
+import json
 import sys
 
 from hevy2garmin import db
@@ -238,6 +239,75 @@ def cmd_map(args: argparse.Namespace) -> None:
     print(f"  Saved to ~/.hevy2garmin/custom_mappings.json")
 
 
+def cmd_pending(args: argparse.Namespace) -> None:
+    rows = [db.get_pending(args.hevy_id)] if args.hevy_id else db.list_pending()
+    rows = [row for row in rows if row]
+    if not rows:
+        print("No pending uploads.")
+        return
+    for row in rows:
+        print(json.dumps(row, indent=2, default=str, sort_keys=True))
+
+
+def _garmin_client_from_config():
+    cfg = load_config()
+    from hevy2garmin.garmin import get_client
+    return get_client(cfg.get("garmin_email"), cfg.get("garmin_password", ""), cfg.get("garmin_token_dir", "~/.garminconnect"))
+
+
+def cmd_reconcile(args: argparse.Namespace) -> None:
+    from hevy2garmin.sync import reconcile_pending
+    result = reconcile_pending(db.get_db(), _garmin_client_from_config(), args.hevy_id)
+    print(f"{args.hevy_id}: {result.status}")
+
+
+def cmd_retry_failed(args: argparse.Namespace) -> None:
+    if not args.confirm:
+        print("✗ retry-failed requires --confirm")
+        sys.exit(1)
+    store = db.get_db()
+    pending = store.get_pending(args.hevy_id)
+    if not pending or pending.get("phase") != "failed":
+        print("✗ Operation is not definitively failed; reconcile or abandon it instead")
+        sys.exit(1)
+    from hevy2garmin.sync import reconcile_pending, sync_one_workout
+    reconcile_pending(store, _garmin_client_from_config(), args.hevy_id)
+    pending = store.get_pending(args.hevy_id)
+    if not pending or pending.get("phase") != "failed":
+        print("✗ Operation is no longer eligible for retry")
+        sys.exit(1)
+    workout = (pending.get("payload") or {}).get("workout")
+    if not workout:
+        print("✗ Pending operation has no recoverable workout payload")
+        sys.exit(1)
+    store.delete_pending(args.hevy_id)
+    result = sync_one_workout(workout, cfg=load_config(), garmin_client=_garmin_client_from_config(), force_upload=True, database=store)
+    print(f"{args.hevy_id}: {result.status}")
+
+
+def cmd_abandon_pending(args: argparse.Namespace) -> None:
+    if args.confirm != args.hevy_id:
+        print(f"✗ confirm the risk with: --confirm {args.hevy_id}")
+        sys.exit(1)
+    if not db.delete_pending(args.hevy_id):
+        print(f"✗ No pending operation found for {args.hevy_id}")
+        sys.exit(1)
+    logging.getLogger("hevy2garmin").warning("ABANDONED pending Garmin upload for %s; an orphan may still appear", args.hevy_id)
+    print(f"✓ Abandoned pending operation for {args.hevy_id}")
+
+
+def cmd_mark_synced(args: argparse.Namespace) -> None:
+    if args.garmin_id is not None and args.garmin_id <= 0:
+        print("✗ Garmin ID must be a positive integer"); sys.exit(1)
+    db.resolve_terminal(args.hevy_id, status="manual", garmin_activity_id=str(args.garmin_id) if args.garmin_id else None, reason=(args.reason or "")[:1000], source="manual")
+    print(f"✓ Marked {args.hevy_id} as synced")
+
+
+def cmd_skip(args: argparse.Namespace) -> None:
+    db.resolve_terminal(args.hevy_id, status="skipped", reason=(args.reason or "")[:1000], source="manual")
+    print(f"✓ Skipped {args.hevy_id}")
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog="hevy2garmin",
@@ -284,6 +354,19 @@ def main() -> None:
     unsync_parser.add_argument("--confirm", action="store_true", help="Required with --all")
     unsync_parser.add_argument("--delete", action="store_true", help="Also delete the Garmin activity")
 
+    pending_parser = subparsers.add_parser("pending", help="List or inspect parked uploads")
+    pending_parser.add_argument("hevy_id", nargs="?")
+    reconcile_parser = subparsers.add_parser("reconcile", help="Recover a parked upload without resubmitting")
+    reconcile_parser.add_argument("hevy_id")
+    retry_parser = subparsers.add_parser("retry-failed", help="Explicitly retry a definitive rejection")
+    retry_parser.add_argument("hevy_id"); retry_parser.add_argument("--confirm", action="store_true")
+    abandon_parser = subparsers.add_parser("abandon-pending", help="Release a parked upload block")
+    abandon_parser.add_argument("hevy_id"); abandon_parser.add_argument("--confirm", metavar="HEVY_ID")
+    manual_parser = subparsers.add_parser("mark-synced", help="Manually mark a workout terminal")
+    manual_parser.add_argument("hevy_id"); manual_parser.add_argument("--garmin-id", type=int); manual_parser.add_argument("--reason")
+    skip_parser = subparsers.add_parser("skip", help="Permanently skip a workout")
+    skip_parser.add_argument("hevy_id"); skip_parser.add_argument("--reason")
+
     # serve
     serve_parser = subparsers.add_parser("serve", help="Start web dashboard")
     serve_parser.add_argument("-p", "--port", type=int, default=8123, help="Port (default: 8123)")
@@ -312,6 +395,12 @@ def main() -> None:
             "unmapped": cmd_unmapped,
             "map": cmd_map,
             "unsync": cmd_unsync,
+            "pending": cmd_pending,
+            "reconcile": cmd_reconcile,
+            "retry-failed": cmd_retry_failed,
+            "abandon-pending": cmd_abandon_pending,
+            "mark-synced": cmd_mark_synced,
+            "skip": cmd_skip,
         }
         commands[args.command](args)
     except RuntimeError as e:

--- a/src/hevy2garmin/db.py
+++ b/src/hevy2garmin/db.py
@@ -175,3 +175,11 @@ def complete_pending(hevy_id: str, terminal: dict, **kw) -> None:
 
 def resolve_terminal(hevy_id: str, **kwargs) -> None:
     return get_db().resolve_terminal(hevy_id, **kwargs)
+
+
+def get_workout_states(hevy_ids: list[str], **kw) -> dict[str, dict]:
+    return get_db().get_workout_states(hevy_ids)
+
+
+def get_terminal_counts(**kw) -> dict[str, int]:
+    return get_db().get_terminal_counts()

--- a/src/hevy2garmin/db.py
+++ b/src/hevy2garmin/db.py
@@ -147,3 +147,31 @@ def get_app_config(key: str, **kw) -> dict | None:
 def set_app_config(key: str, value: dict, **kw) -> None:
     """Store a JSON value in the generic key-value app cache."""
     return get_db().set_app_config(key, value)
+
+
+def claim_pending(hevy_id: str, payload: dict, **kw) -> bool:
+    return get_db().claim_pending(hevy_id, payload)
+
+
+def get_pending(hevy_id: str, **kw) -> dict | None:
+    return get_db().get_pending(hevy_id)
+
+
+def list_pending(**kw) -> list[dict]:
+    return get_db().list_pending()
+
+
+def update_pending(hevy_id: str, **changes) -> None:
+    return get_db().update_pending(hevy_id, **changes)
+
+
+def delete_pending(hevy_id: str, **kw) -> bool:
+    return get_db().delete_pending(hevy_id)
+
+
+def complete_pending(hevy_id: str, terminal: dict, **kw) -> None:
+    return get_db().complete_pending(hevy_id, terminal)
+
+
+def resolve_terminal(hevy_id: str, **kwargs) -> None:
+    return get_db().resolve_terminal(hevy_id, **kwargs)

--- a/src/hevy2garmin/db_interface.py
+++ b/src/hevy2garmin/db_interface.py
@@ -124,3 +124,11 @@ class Database(ABC):
         source: str | None = None,
     ) -> None:
         """Atomically create a manual/skipped terminal state and clear pending."""
+
+    @abstractmethod
+    def get_workout_states(self, hevy_ids: list[str]) -> dict[str, dict]:
+        """Batch-fetch terminal and pending state with terminal precedence."""
+
+    @abstractmethod
+    def get_terminal_counts(self) -> dict[str, int]:
+        """Return uploaded, manual, skipped, and total terminal counts."""

--- a/src/hevy2garmin/db_interface.py
+++ b/src/hevy2garmin/db_interface.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import Any
 
 
 class NoWritableDatabaseError(RuntimeError):
@@ -87,3 +88,39 @@ class Database(ABC):
     @abstractmethod
     def set_app_config(self, key: str, value: dict) -> None:
         """Store a JSON value in the generic key-value app cache."""
+
+    @abstractmethod
+    def claim_pending(self, hevy_id: str, payload: dict[str, Any]) -> bool:
+        """Atomically claim submission authority for a workout."""
+
+    @abstractmethod
+    def get_pending(self, hevy_id: str) -> dict | None:
+        """Return one unfinished upload operation."""
+
+    @abstractmethod
+    def list_pending(self) -> list[dict]:
+        """Return unfinished upload operations, newest first."""
+
+    @abstractmethod
+    def update_pending(self, hevy_id: str, **changes: Any) -> None:
+        """Persist selected pending-operation fields."""
+
+    @abstractmethod
+    def delete_pending(self, hevy_id: str) -> bool:
+        """Abandon an unfinished operation."""
+
+    @abstractmethod
+    def complete_pending(self, hevy_id: str, terminal: dict[str, Any]) -> None:
+        """Atomically upsert terminal state and remove pending state."""
+
+    @abstractmethod
+    def resolve_terminal(
+        self,
+        hevy_id: str,
+        *,
+        status: str,
+        garmin_activity_id: str | None = None,
+        reason: str | None = None,
+        source: str | None = None,
+    ) -> None:
+        """Atomically create a manual/skipped terminal state and clear pending."""

--- a/src/hevy2garmin/db_postgres.py
+++ b/src/hevy2garmin/db_postgres.py
@@ -389,6 +389,41 @@ class PostgresDatabase(Database):
                 cur.execute("DELETE FROM pending_uploads WHERE hevy_id=%s", (hevy_id,))
             conn.commit()
 
+    def get_workout_states(self, hevy_ids: list[str]) -> dict[str, dict]:
+        if not hevy_ids:
+            return {}
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT hevy_id, status, garmin_activity_id, resolution_reason, resolution_source FROM synced_workouts WHERE hevy_id = ANY(%s)", (hevy_ids,))
+                states = {
+                    row["hevy_id"]: {
+                        "kind": "terminal", "status": row["status"] or "success",
+                        "garmin_activity_id": row["garmin_activity_id"],
+                        "reason": row["resolution_reason"], "source": row["resolution_source"],
+                    }
+                    for row in cur.fetchall()
+                }
+                cur.execute("SELECT hevy_id, phase, next_step, last_error, attempt_count, delete_attempt_count, garmin_activity_id FROM pending_uploads WHERE hevy_id = ANY(%s)", (hevy_ids,))
+                for row in cur.fetchall():
+                    if row["hevy_id"] not in states:
+                        states[row["hevy_id"]] = {
+                            "kind": "pending", "status": row["phase"],
+                            "next_step": row["next_step"], "last_error": row["last_error"],
+                            "attempt_count": row["attempt_count"],
+                            "delete_attempt_count": row["delete_attempt_count"],
+                            "garmin_activity_id": row["garmin_activity_id"],
+                        }
+                return states
+
+    def get_terminal_counts(self) -> dict[str, int]:
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT COALESCE(status, 'success') AS status, COUNT(*) AS count FROM synced_workouts GROUP BY COALESCE(status, 'success')")
+                raw = {row["status"]: row["count"] for row in cur.fetchall()}
+        result = {"uploaded": raw.get("success", 0), "manual": raw.get("manual", 0), "skipped": raw.get("skipped", 0)}
+        result["terminal"] = sum(result.values())
+        return result
+
     def get_custom_mappings(self) -> dict[str, tuple[int, int]]:
         with self._get_conn() as conn:
             with conn.cursor() as cur:

--- a/src/hevy2garmin/db_postgres.py
+++ b/src/hevy2garmin/db_postgres.py
@@ -79,6 +79,25 @@ class PostgresDatabase(Database):
                     )
                 """)
                 cur.execute("""
+                    CREATE TABLE IF NOT EXISTS pending_uploads (
+                        hevy_id TEXT PRIMARY KEY,
+                        phase TEXT NOT NULL,
+                        next_step TEXT,
+                        upload_id TEXT,
+                        garmin_activity_id TEXT,
+                        watch_activity_id TEXT,
+                        pre_upload_ids JSONB NOT NULL DEFAULT '[]',
+                        payload JSONB NOT NULL DEFAULT '{}',
+                        resolution_source TEXT,
+                        attempt_count INTEGER NOT NULL DEFAULT 0,
+                        delete_attempt_count INTEGER NOT NULL DEFAULT 0,
+                        last_error TEXT,
+                        locked_until TIMESTAMPTZ,
+                        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                    )
+                """)
+                cur.execute("""
                     CREATE TABLE IF NOT EXISTS platform_credentials (
                         platform VARCHAR(50) PRIMARY KEY,
                         auth_type VARCHAR(20) NOT NULL DEFAULT 'oauth',
@@ -95,16 +114,11 @@ class PostgresDatabase(Database):
                         subcategory INTEGER NOT NULL DEFAULT 0
                     )
                 """)
-                # Migration: add hevy_updated_at if missing
-                try:
-                    cur.execute("ALTER TABLE synced_workouts ADD COLUMN hevy_updated_at TEXT")
-                except Exception:
-                    conn.rollback()
-                # Migration: add sync_method column (merge mode)
-                try:
-                    cur.execute("ALTER TABLE synced_workouts ADD COLUMN sync_method TEXT DEFAULT 'upload'")
-                except Exception:
-                    conn.rollback()
+                cur.execute("ALTER TABLE synced_workouts ADD COLUMN IF NOT EXISTS hevy_updated_at TEXT")
+                cur.execute("ALTER TABLE synced_workouts ADD COLUMN IF NOT EXISTS sync_method TEXT DEFAULT 'upload'")
+                cur.execute("ALTER TABLE synced_workouts ADD COLUMN IF NOT EXISTS resolution_reason TEXT")
+                cur.execute("ALTER TABLE synced_workouts ADD COLUMN IF NOT EXISTS resolved_at TIMESTAMPTZ")
+                cur.execute("ALTER TABLE synced_workouts ADD COLUMN IF NOT EXISTS resolution_source TEXT")
                 cur.execute("""
                     CREATE TABLE IF NOT EXISTS app_cache (
                         key TEXT PRIMARY KEY,
@@ -165,6 +179,7 @@ class PostgresDatabase(Database):
                         avg_hr = EXCLUDED.avg_hr,
                         hevy_updated_at = EXCLUDED.hevy_updated_at,
                         sync_method = EXCLUDED.sync_method,
+                        status = 'success',
                         synced_at = NOW()
                     """,
                     (hevy_id, garmin_activity_id, title, calories, avg_hr, hevy_updated_at, sync_method),
@@ -287,6 +302,91 @@ class PostgresDatabase(Database):
                     """,
                     (key, json.dumps(value)),
                 )
+            conn.commit()
+
+    def claim_pending(self, hevy_id: str, payload: dict) -> bool:
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    INSERT INTO pending_uploads (hevy_id, phase, payload)
+                    VALUES (%s, 'preparing', %s) ON CONFLICT (hevy_id) DO NOTHING
+                """, (hevy_id, json.dumps(payload)))
+                claimed = cur.rowcount == 1
+            conn.commit()
+        return claimed
+
+    @staticmethod
+    def _pending_dict(row) -> dict:
+        result = dict(row)
+        for key, empty in (("pre_upload_ids", []), ("payload", {})):
+            if isinstance(result.get(key), str):
+                result[key] = json.loads(result[key])
+            elif result.get(key) is None:
+                result[key] = empty
+        return result
+
+    def get_pending(self, hevy_id: str) -> dict | None:
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT * FROM pending_uploads WHERE hevy_id=%s", (hevy_id,))
+                row = cur.fetchone()
+                return self._pending_dict(row) if row else None
+
+    def list_pending(self) -> list[dict]:
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT * FROM pending_uploads ORDER BY created_at DESC")
+                return [self._pending_dict(row) for row in cur.fetchall()]
+
+    def update_pending(self, hevy_id: str, **changes) -> None:
+        allowed = {"phase", "next_step", "upload_id", "garmin_activity_id", "watch_activity_id", "pre_upload_ids", "payload", "resolution_source", "attempt_count", "delete_attempt_count", "last_error", "locked_until"}
+        changes = {k: v for k, v in changes.items() if k in allowed}
+        if not changes:
+            return
+        for key in ("pre_upload_ids", "payload"):
+            if key in changes:
+                changes[key] = json.dumps(changes[key])
+        assignments = ", ".join(f"{key}=%s" for key in changes)
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(f"UPDATE pending_uploads SET {assignments}, updated_at=NOW() WHERE hevy_id=%s", (*changes.values(), hevy_id))
+            conn.commit()
+
+    def delete_pending(self, hevy_id: str) -> bool:
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM pending_uploads WHERE hevy_id=%s", (hevy_id,)); deleted = cur.rowcount > 0
+            conn.commit()
+        return deleted
+
+    def complete_pending(self, hevy_id: str, terminal: dict) -> None:
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    INSERT INTO synced_workouts
+                      (hevy_id, garmin_activity_id, title, calories, avg_hr, hevy_updated_at, sync_method, status)
+                    VALUES (%s,%s,%s,%s,%s,%s,%s,'success')
+                    ON CONFLICT (hevy_id) DO UPDATE SET garmin_activity_id=EXCLUDED.garmin_activity_id,
+                      title=EXCLUDED.title, calories=EXCLUDED.calories, avg_hr=EXCLUDED.avg_hr,
+                      hevy_updated_at=EXCLUDED.hevy_updated_at, sync_method=EXCLUDED.sync_method,
+                      status='success', synced_at=NOW()
+                """, (hevy_id, terminal.get("garmin_activity_id"), terminal.get("title", ""), terminal.get("calories"), terminal.get("avg_hr"), terminal.get("hevy_updated_at"), terminal.get("sync_method", "upload")))
+                cur.execute("DELETE FROM pending_uploads WHERE hevy_id=%s", (hevy_id,))
+            conn.commit()
+
+    def resolve_terminal(self, hevy_id: str, *, status: str, garmin_activity_id: str | None = None, reason: str | None = None, source: str | None = None) -> None:
+        if status not in {"manual", "skipped"}:
+            raise ValueError("manual resolution status must be manual or skipped")
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    INSERT INTO synced_workouts (hevy_id, garmin_activity_id, status, resolution_reason, resolved_at, resolution_source)
+                    VALUES (%s,%s,%s,%s,NOW(),%s)
+                    ON CONFLICT (hevy_id) DO UPDATE SET garmin_activity_id=EXCLUDED.garmin_activity_id,
+                      status=EXCLUDED.status, resolution_reason=EXCLUDED.resolution_reason,
+                      resolved_at=NOW(), resolution_source=EXCLUDED.resolution_source, synced_at=NOW()
+                """, (hevy_id, garmin_activity_id, status, reason, source))
+                cur.execute("DELETE FROM pending_uploads WHERE hevy_id=%s", (hevy_id,))
             conn.commit()
 
     def get_custom_mappings(self) -> dict[str, tuple[int, int]]:

--- a/src/hevy2garmin/db_sqlite.py
+++ b/src/hevy2garmin/db_sqlite.py
@@ -360,3 +360,48 @@ class SQLiteDatabase(Database):
         """, (hevy_id, garmin_activity_id, status, reason, source))
         conn.execute("DELETE FROM pending_uploads WHERE hevy_id=?", (hevy_id,))
         conn.commit(); conn.close()
+
+    def get_workout_states(self, hevy_ids: list[str]) -> dict[str, dict]:
+        if not hevy_ids:
+            return {}
+        placeholders = ",".join("?" for _ in hevy_ids)
+        conn = self._get_conn(); conn.row_factory = sqlite3.Row
+        terminal = conn.execute(
+            f"SELECT hevy_id, status, garmin_activity_id, resolution_reason, resolution_source FROM synced_workouts WHERE hevy_id IN ({placeholders})",
+            hevy_ids,
+        ).fetchall()
+        states = {
+            row["hevy_id"]: {
+                "kind": "terminal", "status": row["status"] or "success",
+                "garmin_activity_id": row["garmin_activity_id"],
+                "reason": row["resolution_reason"], "source": row["resolution_source"],
+            }
+            for row in terminal
+        }
+        try:
+            pending = conn.execute(
+                f"SELECT hevy_id, phase, next_step, last_error, attempt_count, delete_attempt_count, garmin_activity_id FROM pending_uploads WHERE hevy_id IN ({placeholders})",
+                hevy_ids,
+            ).fetchall()
+        except sqlite3.OperationalError:
+            pending = []
+        conn.close()
+        for row in pending:
+            if row["hevy_id"] not in states:
+                states[row["hevy_id"]] = {
+                    "kind": "pending", "status": row["phase"],
+                    "next_step": row["next_step"], "last_error": row["last_error"],
+                    "attempt_count": row["attempt_count"],
+                    "delete_attempt_count": row["delete_attempt_count"],
+                    "garmin_activity_id": row["garmin_activity_id"],
+                }
+        return states
+
+    def get_terminal_counts(self) -> dict[str, int]:
+        conn = self._get_conn()
+        rows = conn.execute("SELECT COALESCE(status, 'success'), COUNT(*) FROM synced_workouts GROUP BY COALESCE(status, 'success')").fetchall()
+        conn.close()
+        raw = dict(rows)
+        result = {"uploaded": raw.get("success", 0), "manual": raw.get("manual", 0), "skipped": raw.get("skipped", 0)}
+        result["terminal"] = sum(result.values())
+        return result

--- a/src/hevy2garmin/db_sqlite.py
+++ b/src/hevy2garmin/db_sqlite.py
@@ -64,6 +64,31 @@ class SQLiteDatabase(Database):
                 trigger TEXT DEFAULT 'manual'
             )
         """)
+        try:
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS pending_uploads (
+                hevy_id TEXT PRIMARY KEY,
+                phase TEXT NOT NULL,
+                next_step TEXT,
+                upload_id TEXT,
+                garmin_activity_id TEXT,
+                watch_activity_id TEXT,
+                pre_upload_ids TEXT NOT NULL DEFAULT '[]',
+                payload TEXT NOT NULL DEFAULT '{}',
+                resolution_source TEXT,
+                attempt_count INTEGER NOT NULL DEFAULT 0,
+                delete_attempt_count INTEGER NOT NULL DEFAULT 0,
+                last_error TEXT,
+                locked_until TEXT,
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+                )
+            """)
+        except sqlite3.OperationalError as exc:
+            # A legacy database may intentionally be mounted read-only for
+            # status/dashboard views. Reads remain backward compatible.
+            if "readonly" not in str(exc).lower():
+                raise
         conn.execute("""
             CREATE TABLE IF NOT EXISTS hr_cache (
                 hevy_id TEXT PRIMARY KEY,
@@ -81,6 +106,15 @@ class SQLiteDatabase(Database):
             conn.execute("ALTER TABLE synced_workouts ADD COLUMN sync_method TEXT DEFAULT 'upload'")
         except Exception:
             pass  # Column already exists
+        for column, definition in (
+            ("resolution_reason", "TEXT"),
+            ("resolved_at", "TEXT"),
+            ("resolution_source", "TEXT"),
+        ):
+            try:
+                conn.execute(f"ALTER TABLE synced_workouts ADD COLUMN {column} {definition}")
+            except sqlite3.OperationalError:
+                pass
         conn.execute("""
             CREATE TABLE IF NOT EXISTS app_cache (
                 key TEXT PRIMARY KEY,
@@ -121,8 +155,14 @@ class SQLiteDatabase(Database):
         conn = self._get_conn()
         conn.execute(
             """
-            INSERT OR REPLACE INTO synced_workouts (hevy_id, garmin_activity_id, title, calories, avg_hr, hevy_updated_at, sync_method)
-            VALUES (?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO synced_workouts (hevy_id, garmin_activity_id, title, calories, avg_hr, hevy_updated_at, sync_method, status)
+            VALUES (?, ?, ?, ?, ?, ?, ?, 'success')
+            ON CONFLICT(hevy_id) DO UPDATE SET
+                garmin_activity_id=excluded.garmin_activity_id,
+                title=excluded.title, calories=excluded.calories,
+                avg_hr=excluded.avg_hr, hevy_updated_at=excluded.hevy_updated_at,
+                sync_method=excluded.sync_method, status='success',
+                synced_at=datetime('now')
             """,
             (hevy_id, garmin_activity_id, title, calories, avg_hr, hevy_updated_at, sync_method),
         )
@@ -243,3 +283,80 @@ class SQLiteDatabase(Database):
         )
         conn.commit()
         conn.close()
+
+    def claim_pending(self, hevy_id: str, payload: dict) -> bool:
+        conn = self._get_conn()
+        cur = conn.execute(
+            "INSERT OR IGNORE INTO pending_uploads (hevy_id, phase, payload) VALUES (?, 'preparing', ?)",
+            (hevy_id, json.dumps(payload)),
+        )
+        claimed = cur.rowcount == 1
+        conn.commit()
+        conn.close()
+        return claimed
+
+    @staticmethod
+    def _pending_dict(row: sqlite3.Row) -> dict:
+        result = dict(row)
+        result["pre_upload_ids"] = json.loads(result.get("pre_upload_ids") or "[]")
+        result["payload"] = json.loads(result.get("payload") or "{}")
+        return result
+
+    def get_pending(self, hevy_id: str) -> dict | None:
+        conn = self._get_conn(); conn.row_factory = sqlite3.Row
+        row = conn.execute("SELECT * FROM pending_uploads WHERE hevy_id=?", (hevy_id,)).fetchone()
+        conn.close()
+        return self._pending_dict(row) if row else None
+
+    def list_pending(self) -> list[dict]:
+        conn = self._get_conn(); conn.row_factory = sqlite3.Row
+        rows = conn.execute("SELECT * FROM pending_uploads ORDER BY created_at DESC").fetchall()
+        conn.close()
+        return [self._pending_dict(row) for row in rows]
+
+    def update_pending(self, hevy_id: str, **changes) -> None:
+        allowed = {"phase", "next_step", "upload_id", "garmin_activity_id", "watch_activity_id", "pre_upload_ids", "payload", "resolution_source", "attempt_count", "delete_attempt_count", "last_error", "locked_until"}
+        changes = {k: v for k, v in changes.items() if k in allowed}
+        if not changes:
+            return
+        for key in ("pre_upload_ids", "payload"):
+            if key in changes:
+                changes[key] = json.dumps(changes[key])
+        assignments = ", ".join(f"{key}=?" for key in changes)
+        conn = self._get_conn()
+        conn.execute(f"UPDATE pending_uploads SET {assignments}, updated_at=datetime('now') WHERE hevy_id=?", (*changes.values(), hevy_id))
+        conn.commit(); conn.close()
+
+    def delete_pending(self, hevy_id: str) -> bool:
+        conn = self._get_conn(); cur = conn.execute("DELETE FROM pending_uploads WHERE hevy_id=?", (hevy_id,))
+        conn.commit(); conn.close(); return cur.rowcount > 0
+
+    def complete_pending(self, hevy_id: str, terminal: dict) -> None:
+        conn = self._get_conn()
+        conn.execute("""
+            INSERT INTO synced_workouts
+              (hevy_id, garmin_activity_id, title, calories, avg_hr, hevy_updated_at, sync_method, status)
+            VALUES (?, ?, ?, ?, ?, ?, ?, 'success')
+            ON CONFLICT(hevy_id) DO UPDATE SET
+              garmin_activity_id=excluded.garmin_activity_id, title=excluded.title,
+              calories=excluded.calories, avg_hr=excluded.avg_hr,
+              hevy_updated_at=excluded.hevy_updated_at, sync_method=excluded.sync_method,
+              status='success', synced_at=datetime('now')
+        """, (hevy_id, terminal.get("garmin_activity_id"), terminal.get("title", ""), terminal.get("calories"), terminal.get("avg_hr"), terminal.get("hevy_updated_at"), terminal.get("sync_method", "upload")))
+        conn.execute("DELETE FROM pending_uploads WHERE hevy_id=?", (hevy_id,))
+        conn.commit(); conn.close()
+
+    def resolve_terminal(self, hevy_id: str, *, status: str, garmin_activity_id: str | None = None, reason: str | None = None, source: str | None = None) -> None:
+        if status not in {"manual", "skipped"}:
+            raise ValueError("manual resolution status must be manual or skipped")
+        conn = self._get_conn()
+        conn.execute("""
+            INSERT INTO synced_workouts (hevy_id, garmin_activity_id, status, resolution_reason, resolved_at, resolution_source)
+            VALUES (?, ?, ?, ?, datetime('now'), ?)
+            ON CONFLICT(hevy_id) DO UPDATE SET garmin_activity_id=excluded.garmin_activity_id,
+              status=excluded.status, resolution_reason=excluded.resolution_reason,
+              resolved_at=datetime('now'), resolution_source=excluded.resolution_source,
+              synced_at=datetime('now')
+        """, (hevy_id, garmin_activity_id, status, reason, source))
+        conn.execute("DELETE FROM pending_uploads WHERE hevy_id=?", (hevy_id,))
+        conn.commit(); conn.close()

--- a/src/hevy2garmin/garmin.py
+++ b/src/hevy2garmin/garmin.py
@@ -19,6 +19,10 @@ logger = logging.getLogger("hevy2garmin")
 _limiter = RateLimiter(delay=1.0, max_retries=3, base_wait=30)
 
 
+class GarminUploadRejected(RuntimeError):
+    """Garmin definitively rejected an import without accepting an activity."""
+
+
 def get_client(
     email: str | None = None,
     password: str | None = None,
@@ -111,6 +115,8 @@ def upload_fit(client: Garmin, fit_path: str | Path, workout_start: str | None =
         failures = detail.get("failures", [])
         if failures:
             logger.warning("  Upload failures: %s", failures)
+            if not activity_id and not successes:
+                raise GarminUploadRejected(f"Garmin rejected upload: {failures}")
         logger.info("  Upload result: upload_id=%s activity_id=%s", upload_id, activity_id)
     else:
         logger.info("  Upload response: %s", str(resp)[:200])
@@ -132,6 +138,23 @@ def upload_fit(client: Garmin, fit_path: str | Path, workout_start: str | None =
         logger.warning("  Could not find activity ID after upload. Workout will appear as 'Strength Training' on Garmin.")
 
     return {"upload_id": upload_id, "activity_id": activity_id}
+
+
+def activities_for_workout(client: Garmin, workout: dict) -> list[dict]:
+    """Fetch all Garmin activities in the workout's conservative date window."""
+    from datetime import datetime, timedelta
+
+    start_raw = workout.get("start_time") or workout.get("startTime", "")
+    end_raw = workout.get("end_time") or workout.get("endTime", "") or start_raw
+    try:
+        start = datetime.fromisoformat(start_raw.replace("Z", "+00:00"))
+        end = datetime.fromisoformat(end_raw.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        raise ValueError("workout has no valid time window")
+    date_from = (start - timedelta(days=1)).date().isoformat()
+    date_to = (end + timedelta(days=1)).date().isoformat()
+    activities = _limiter.call(client.get_activities_by_date, date_from, date_to)
+    return list(activities or [])
 
 
 def find_activity_by_start_time(

--- a/src/hevy2garmin/garmin.py
+++ b/src/hevy2garmin/garmin.py
@@ -142,19 +142,40 @@ def upload_fit(client: Garmin, fit_path: str | Path, workout_start: str | None =
 
 def activities_for_workout(client: Garmin, workout: dict) -> list[dict]:
     """Fetch all Garmin activities in the workout's conservative date window."""
-    from datetime import datetime, timedelta
+    from datetime import timedelta
 
     start_raw = workout.get("start_time") or workout.get("startTime", "")
     end_raw = workout.get("end_time") or workout.get("endTime", "") or start_raw
     try:
-        start = datetime.fromisoformat(start_raw.replace("Z", "+00:00"))
-        end = datetime.fromisoformat(end_raw.replace("Z", "+00:00"))
+        start = parse_iso(start_raw)
+        end = parse_iso(end_raw)
     except (ValueError, TypeError):
         raise ValueError("workout has no valid time window")
     date_from = (start - timedelta(days=1)).date().isoformat()
     date_to = (end + timedelta(days=1)).date().isoformat()
     activities = _limiter.call(client.get_activities_by_date, date_from, date_to)
     return list(activities or [])
+
+
+def activity_matches_start_time(
+    activity: dict,
+    target_start: str,
+    window_minutes: int = 10,
+) -> bool:
+    """Return whether an activity starts within ``window_minutes`` of a target."""
+    try:
+        target = parse_iso(target_start)
+    except (AttributeError, ValueError, TypeError):
+        return False
+
+    target_naive = target.replace(tzinfo=None) if target.tzinfo else target
+    act_start_str = activity.get("startTimeGMT") or activity.get("startTimeLocal", "")
+    try:
+        act_start = parse_iso(act_start_str)
+        act_naive = act_start.replace(tzinfo=None) if act_start.tzinfo else act_start
+    except (AttributeError, ValueError, TypeError):
+        return False
+    return abs((act_naive - target_naive).total_seconds()) < window_minutes * 60
 
 
 def find_activity_by_start_time(
@@ -167,11 +188,11 @@ def find_activity_by_start_time(
     Searches by date range so old uploaded workouts are found regardless of
     how many newer activities exist on the account.
     """
-    from datetime import datetime, timedelta
+    from datetime import timedelta
 
     try:
         target = parse_iso(target_start)
-    except (ValueError, TypeError):
+    except (AttributeError, ValueError, TypeError):
         return None
 
     # Search the workout's date ±1 day to handle timezone edge cases
@@ -190,17 +211,8 @@ def find_activity_by_start_time(
         if act_type and act_type not in ("strength_training", "other"):
             continue
 
-        # Prefer startTimeGMT (UTC) over startTimeLocal to avoid timezone mismatch
-        act_start_str = act.get("startTimeGMT") or act.get("startTimeLocal", "")
-        try:
-            if "T" not in act_start_str:
-                act_start_str = act_start_str.replace(" ", "T")
-            act_start = parse_iso(act_start_str)
-            act_naive = act_start.replace(tzinfo=None) if act_start.tzinfo else act_start
-            if abs((act_naive - target_naive).total_seconds()) < window_minutes * 60:
-                return act.get("activityId")
-        except (ValueError, TypeError):
-            continue
+        if activity_matches_start_time(act, target_start, window_minutes):
+            return act.get("activityId")
     return None
 
 

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -419,7 +419,9 @@ async def logout():
 @app.get("/", response_class=HTMLResponse)
 async def dashboard(request: Request):
     config = load_config()
-    synced_count = db.get_synced_count()
+    terminal_counts = db.get_terminal_counts()
+    synced_count = terminal_counts["uploaded"]
+    terminal_count = terminal_counts["terminal"]
     recent = db.get_recent_synced(5)
 
     # Check garmin_connected FIRST (DB/file check only, no HTTP to Garmin)
@@ -475,6 +477,9 @@ async def dashboard(request: Request):
         "dashboard.html",
         synced_count=synced_count,
         matched_count=matched_count,
+        terminal_count=terminal_count,
+        manual_count=terminal_counts["manual"],
+        skipped_count=terminal_counts["skipped"],
         hevy_total=hevy_total,
         recent=recent,
         auto_sync=_get_autosync_status(),
@@ -734,9 +739,7 @@ async def workouts_page(request: Request):
 
         # Batch check sync status (1 query instead of N)
         hevy_ids = [w.get("id", "") for w in workouts_raw]
-        synced_map = _db.get_synced_ids(hevy_ids) if hasattr(_db, 'get_synced_ids') else {
-            wid: db.get_garmin_id(wid) for wid in hevy_ids if db.is_synced(wid)
-        }
+        states = _db.get_workout_states(hevy_ids)
         # Check for workouts edited on Hevy since last sync
         stale_ids = set(_db.get_stale_synced(workouts_raw))
 
@@ -749,13 +752,22 @@ async def workouts_page(request: Request):
         for w in workouts_raw:
             w["start_time"] = w.get("start_time") or w.get("startTime", "")
             w["end_time"] = w.get("end_time") or w.get("endTime", "")
-            if w["id"] in synced_map:
-                w["status"] = "uploaded"
-                gid = synced_map[w["id"]]
+            state = states.get(w["id"])
+            if state and state["kind"] == "terminal":
+                terminal_status = state.get("status") or "success"
+                w["status"] = {"success": "uploaded", "manual": "manual", "skipped": "skipped"}.get(terminal_status, "uploaded")
+                w["state_detail"] = state
+                gid = state.get("garmin_activity_id")
                 if gid:
                     w["garmin_match"] = {"garmin_id": gid, "garmin_name": w.get("title", "")}
                 if w["id"] in stale_ids:
                     w["edited_since_sync"] = True
+            elif state and state["kind"] == "pending":
+                phase = state.get("status")
+                w["status"] = "processing" if phase in {"preparing", "processing", "finalizing"} else phase
+                w["state_detail"] = state
+                if state.get("garmin_activity_id"):
+                    w["garmin_match"] = {"garmin_id": state["garmin_activity_id"], "garmin_name": w.get("title", "")}
             else:
                 w["status"] = "pending"
 
@@ -1350,6 +1362,107 @@ async def api_unsync(request: Request, hevy_id: str):
     return JSONResponse({"ok": True, "garmin_deleted": garmin_deleted})
 
 
+def _valid_hevy_id(hevy_id: str) -> bool:
+    return bool(hevy_id and len(hevy_id) <= 200 and re.fullmatch(r"[A-Za-z0-9._:-]+", hevy_id))
+
+
+def _clear_workout_cache(store) -> None:
+    for page in range(1, 11):
+        store.set_app_config(f"hevy_workouts_page_{page}", {})
+
+
+@app.post("/api/pending/{hevy_id}/reconcile")
+async def api_reconcile_pending(request: Request, hevy_id: str):
+    from fastapi.responses import JSONResponse
+    if not _valid_hevy_id(hevy_id):
+        return JSONResponse({"ok": False, "error": "Invalid workout ID"}, status_code=400)
+    store = db.get_db()
+    if not store.get_pending(hevy_id):
+        return JSONResponse({"ok": False, "error": "No pending operation"}, status_code=404)
+    try:
+        from hevy2garmin.garmin import get_client
+        from hevy2garmin.sync import reconcile_pending
+        config = load_config()
+        result = reconcile_pending(store, get_client(config.get("garmin_email")), hevy_id)
+        return JSONResponse({"ok": True, "status": result.status})
+    except Exception as exc:
+        return JSONResponse({"ok": False, "error": str(exc)[:1000]}, status_code=502)
+
+
+@app.post("/api/pending/{hevy_id}/retry")
+async def api_retry_pending(request: Request, hevy_id: str):
+    from fastapi.responses import JSONResponse
+    if not _valid_hevy_id(hevy_id):
+        return JSONResponse({"ok": False, "error": "Invalid workout ID"}, status_code=400)
+    form = await request.form()
+    if form.get("confirm") != hevy_id:
+        return JSONResponse({"ok": False, "error": "Explicit confirmation required"}, status_code=400)
+    store = db.get_db()
+    pending = store.get_pending(hevy_id)
+    if not pending or pending.get("phase") != "failed":
+        return JSONResponse({"ok": False, "error": "Only definitively rejected uploads can be retried"}, status_code=409)
+    try:
+        from hevy2garmin.garmin import get_client
+        from hevy2garmin.sync import reconcile_pending, sync_one_workout
+        config = load_config(); client = get_client(config.get("garmin_email"))
+        reconcile_pending(store, client, hevy_id)
+        pending = store.get_pending(hevy_id)
+        if not pending or pending.get("phase") != "failed":
+            return JSONResponse({"ok": False, "error": "Operation is no longer retryable"}, status_code=409)
+        workout = (pending.get("payload") or {}).get("workout")
+        if not workout:
+            return JSONResponse({"ok": False, "error": "Stored workout payload is unavailable"}, status_code=409)
+        store.delete_pending(hevy_id)
+        result = sync_one_workout(workout, cfg=config, garmin_client=client, force_upload=True, respect_grace=False, database=store)
+        return JSONResponse({"ok": True, "status": result.status})
+    except Exception as exc:
+        return JSONResponse({"ok": False, "error": str(exc)[:1000]}, status_code=502)
+
+
+@app.post("/api/pending/{hevy_id}/abandon")
+async def api_abandon_pending(request: Request, hevy_id: str):
+    from fastapi.responses import JSONResponse
+    if not _valid_hevy_id(hevy_id):
+        return JSONResponse({"ok": False, "error": "Invalid workout ID"}, status_code=400)
+    form = await request.form()
+    if form.get("confirm") != hevy_id:
+        return JSONResponse({"ok": False, "error": "Explicit confirmation required"}, status_code=400)
+    if not db.delete_pending(hevy_id):
+        return JSONResponse({"ok": False, "error": "No pending operation"}, status_code=404)
+    logger.warning("ABANDONED pending Garmin upload for %s from web UI; an orphan may still appear", hevy_id)
+    return JSONResponse({"ok": True})
+
+
+async def _manual_terminal(request: Request, hevy_id: str, status: str):
+    from fastapi.responses import JSONResponse
+    if not _valid_hevy_id(hevy_id):
+        return JSONResponse({"ok": False, "error": "Invalid workout ID"}, status_code=400)
+    form = await request.form(); store = db.get_db()
+    pending = store.get_pending(hevy_id)
+    if pending and form.get("confirm") != hevy_id:
+        return JSONResponse({"ok": False, "error": "Pending upload confirmation required"}, status_code=409)
+    reason = str(form.get("reason") or "")[:1000]
+    garmin_id = None
+    if status == "manual" and form.get("garmin_id"):
+        raw_id = str(form.get("garmin_id"))
+        if not raw_id.isdigit() or int(raw_id) <= 0:
+            return JSONResponse({"ok": False, "error": "Garmin ID must be a positive integer"}, status_code=400)
+        garmin_id = raw_id
+    store.resolve_terminal(hevy_id, status=status, garmin_activity_id=garmin_id, reason=reason, source="web")
+    _clear_workout_cache(store)
+    return JSONResponse({"ok": True, "status": status})
+
+
+@app.post("/api/workout/{hevy_id}/mark-synced")
+async def api_mark_synced(request: Request, hevy_id: str):
+    return await _manual_terminal(request, hevy_id, "manual")
+
+
+@app.post("/api/workout/{hevy_id}/skip")
+async def api_skip_workout(request: Request, hevy_id: str):
+    return await _manual_terminal(request, hevy_id, "skipped")
+
+
 @app.post("/api/unsync-all")
 async def api_unsync_all(request: Request):
     """Remove ALL sync records. Does not delete from Garmin."""
@@ -1753,7 +1866,9 @@ async def _do_sync_one(request: Request, *, respect_grace: bool = False):
 
     # Skip ids that are already failed this session, or deferred by grace this
     # invocation (cron continues to the next older unsynced workout).
-    skip_ids = set(_failed_ids)
+    pending_rows = _db.list_pending()
+    pending_ids = {row["hevy_id"] for row in pending_rows}
+    skip_ids = set(_failed_ids) | pending_ids
     deferred_count = 0
     unsynced = None
     unmapped_found: dict[str, int] = {}
@@ -1776,7 +1891,11 @@ async def _do_sync_one(request: Request, *, respect_grace: bool = False):
                     "remaining": remaining,
                     "done": remaining <= 0,
                 })
-            return JSONResponse({"synced": 0, "remaining": 0, "done": True})
+            remaining = max(0, total_count - db.get_synced_count())
+            return JSONResponse({
+                "synced": 0, "processing": len(pending_ids),
+                "remaining": remaining, "done": remaining <= len(pending_ids),
+            })
 
         # Defer before Garmin auth when possible (cron cold starts).
         grace_minutes = config.get("sync", {}).get("grace_period_minutes", 120)
@@ -1806,6 +1925,15 @@ async def _do_sync_one(request: Request, *, respect_grace: bool = False):
                 respect_grace=False,  # already checked above
                 database=db.get_db(),
             )
+
+            if one.status != "synced":
+                return JSONResponse({
+                    "synced": 0,
+                    one.status: 1,
+                    "title": unsynced["title"],
+                    "remaining": max(0, hevy.get_workout_count() - db.get_synced_count()),
+                    "done": False,
+                })
 
             remaining = hevy.get_workout_count() - db.get_synced_count()
             payload = {

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -15,6 +15,7 @@ from hevy2garmin.config import load_config
 from hevy2garmin.fit import generate_fit, _parse_timestamp
 from hevy2garmin.garmin import (
     GarminUploadRejected,
+    activity_matches_start_time,
     activities_for_workout,
     delete_activity,
     find_activity_by_start_time,
@@ -60,6 +61,12 @@ def _activity_id(activity: dict) -> int | None:
         return None
 
 
+def _pending_status(pending: dict | None) -> str:
+    """Normalize durable phases to the public sync result statuses."""
+    phase = (pending or {}).get("phase")
+    return phase if phase in {"failed", "needs_review"} else "processing"
+
+
 def _terminal_payload(payload: dict, activity_id: int) -> dict:
     return {
         "garmin_activity_id": str(activity_id),
@@ -96,18 +103,22 @@ def finalize_pending(store, client, pending: dict) -> SyncOneResult:
             step = "delete" if watch_id else "commit"
             store.update_pending(wid, next_step=step, last_error=None)
         if step == "delete":
-            if int(watch_id) == activity_id:
+            if not watch_id:
+                step = "commit"
+                store.update_pending(wid, next_step=step, last_error=None)
+            elif int(watch_id) == activity_id:
                 store.update_pending(wid, phase="needs_review", last_error="replacement equals watch activity; deletion blocked")
                 return SyncOneResult(status="needs_review", activity_id=activity_id)
-            try:
-                delete_activity(client, int(watch_id))
-            except Exception as exc:
-                attempts = int(pending.get("delete_attempt_count") or 0) + 1
-                phase = "needs_review" if attempts >= 3 else "finalizing"
-                store.update_pending(wid, phase=phase, next_step="delete", delete_attempt_count=attempts, last_error=str(exc)[:1000])
-                return SyncOneResult(status="needs_review" if phase == "needs_review" else "processing", activity_id=activity_id)
-            step = "commit"
-            store.update_pending(wid, next_step=step, last_error=None)
+            else:
+                try:
+                    delete_activity(client, int(watch_id))
+                except Exception as exc:
+                    attempts = int(pending.get("delete_attempt_count") or 0) + 1
+                    phase = "needs_review" if attempts >= 3 else "finalizing"
+                    store.update_pending(wid, phase=phase, next_step="delete", delete_attempt_count=attempts, last_error=str(exc)[:1000])
+                    return SyncOneResult(status="needs_review" if phase == "needs_review" else "processing", activity_id=activity_id)
+                step = "commit"
+                store.update_pending(wid, next_step=step, last_error=None)
         _complete(store, wid, payload, activity_id)
         return SyncOneResult(status="synced", activity_id=activity_id, sync_method=payload.get("sync_method", "upload"), merge_fallback=payload.get("merge_fallback", False), calories=payload.get("calories"), avg_hr=payload.get("avg_hr"))
     except Exception as exc:
@@ -139,6 +150,20 @@ def reconcile_pending(store, client, hevy_id: str) -> SyncOneResult:
             if resolved and str(resolved) not in {str(pending.get("watch_activity_id")), *map(str, pending.get("pre_upload_ids", []))}:
                 store.update_pending(hevy_id, phase="finalizing", next_step="rename", garmin_activity_id=str(resolved), resolution_source="upload_id", last_error=None)
                 return finalize_pending(store, client, store.get_pending(hevy_id))
+    phase = pending.get("phase")
+    attempt_count = int(pending.get("attempt_count") or 0)
+    has_recovery_evidence = bool(
+        upload_id
+        or pending.get("pre_upload_ids")
+        or (phase in {"processing", "finalizing", "needs_review"} and attempt_count > 0)
+    )
+    if not has_recovery_evidence:
+        store.update_pending(
+            hevy_id,
+            phase="needs_review",
+            last_error="no upload attempt checkpoint; refusing snapshot adoption",
+        )
+        return SyncOneResult(status="needs_review")
     workout = (pending.get("payload") or {}).get("workout") or {}
     try:
         activities = activities_for_workout(client, workout)
@@ -149,8 +174,15 @@ def reconcile_pending(store, client, hevy_id: str) -> SyncOneResult:
     if pending.get("watch_activity_id"):
         excluded.add(str(pending["watch_activity_id"]))
     candidates = [a for a in activities if _activity_id(a) and str(_activity_id(a)) not in excluded]
-    # Snapshot-only recovery is deliberately strict: exactly one DEVELOPMENT strength activity.
-    safe = [a for a in candidates if str(a.get("manufacturer", "")).upper() == "DEVELOPMENT" and a.get("activityType", {}).get("typeKey", "strength_training") in {"strength_training", "other"}]
+    start_time = workout.get("start_time") or workout.get("startTime", "")
+    # Snapshot-only recovery is deliberately strict: exactly one matching
+    # DEVELOPMENT strength activity at the workout's start time.
+    safe = [
+        a for a in candidates
+        if str(a.get("manufacturer", "")).upper() == "DEVELOPMENT"
+        and (a.get("activityType") or {}).get("typeKey") in {"strength_training", "other"}
+        and activity_matches_start_time(a, start_time)
+    ]
     if len(safe) != 1:
         if candidates:
             store.update_pending(hevy_id, phase="needs_review", last_error=f"{len(candidates)} unverified snapshot candidate(s)")
@@ -244,6 +276,13 @@ def sync_one_workout(
     wid = workout.get("id", "unknown")
     title = workout.get("title", "Workout")
     start_time = workout.get("start_time") or workout.get("startTime", "")
+
+    if not dry_run:
+        pending = merge_store.get_pending(wid)
+        if isinstance(pending, dict) and pending:
+            status = _pending_status(pending)
+            logger.debug("Skipping %s (%s) — pending upload is %s", wid, title, pending.get("phase"))
+            return SyncOneResult(status=status)
 
     grace_minutes = cfg.get("sync", {}).get("grace_period_minutes", 120)
     if respect_grace and _workout_within_grace(workout, grace_minutes):
@@ -367,7 +406,7 @@ def sync_one_workout(
             claimed = merge_store.claim_pending(wid, pending_payload)
             if claimed is False:
                 pending = merge_store.get_pending(wid)
-                return SyncOneResult(status=(pending or {}).get("phase", "processing"))
+                return SyncOneResult(status=_pending_status(pending))
             try:
                 snapshot = activities_for_workout(garmin_client, workout)
                 snapshot_ids = [str(x) for a in snapshot if (x := _activity_id(a))]
@@ -514,6 +553,10 @@ def sync(
         reset_circuit_breaker()
         logger.info("Merge mode enabled — will try to enhance watch activities")
 
+    pending_by_id = {}
+    if not dry_run:
+        pending_by_id = {row["hevy_id"]: row for row in store.list_pending()}
+
     for workout in workouts:
         wid = workout.get("id", "unknown")
         title = workout.get("title", "Workout")
@@ -521,6 +564,14 @@ def sync(
         if skip_existing and store.is_synced(wid):
             logger.debug("Skipping %s (%s) — already synced", wid, title)
             stats["skipped"] += 1
+            continue
+
+        pending = pending_by_id.get(wid)
+        if pending:
+            phase = pending.get("phase")
+            bucket = _pending_status(pending)
+            logger.debug("Skipping %s (%s) — pending upload is %s", wid, title, phase)
+            stats[bucket] += 1
             continue
 
         for ex in workout.get("exercises", []):

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -14,6 +14,8 @@ from hevy2garmin import db
 from hevy2garmin.config import load_config
 from hevy2garmin.fit import generate_fit, _parse_timestamp
 from hevy2garmin.garmin import (
+    GarminUploadRejected,
+    activities_for_workout,
     delete_activity,
     find_activity_by_start_time,
     generate_description,
@@ -25,6 +27,7 @@ from hevy2garmin.garmin import (
 from hevy2garmin.hevy import HevyClient
 from hevy2garmin.mapper import lookup_exercise
 from hevy2garmin.merge import attempt_merge, reset_circuit_breaker
+from hevy2garmin.db_interface import Database
 
 try:  # rate-limit HR fetches like other Garmin data calls
     from garmin_auth import RateLimiter
@@ -39,7 +42,7 @@ logger = logging.getLogger("hevy2garmin")
 class SyncOneResult:
     """Outcome of syncing a single Hevy workout."""
 
-    status: str  # "synced" | "dry_run" | "deferred"
+    status: str  # "synced" | "dry_run" | "deferred" | "processing" | "needs_review" | "failed"
     activity_id: int | None = None
     sync_method: str = "upload"
     merged: bool = False
@@ -47,6 +50,115 @@ class SyncOneResult:
     calories: int | None = None
     avg_hr: int | None = None
     no_hr: bool = False
+
+
+def _activity_id(activity: dict) -> int | None:
+    try:
+        value = int(str(activity.get("activityId", "")).strip("'\""))
+        return value if value > 0 else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _terminal_payload(payload: dict, activity_id: int) -> dict:
+    return {
+        "garmin_activity_id": str(activity_id),
+        "title": payload.get("title", ""),
+        "calories": payload.get("calories"),
+        "avg_hr": payload.get("avg_hr"),
+        "hevy_updated_at": payload.get("hevy_updated_at"),
+        "sync_method": payload.get("sync_method", "upload"),
+    }
+
+
+def _complete(store, hevy_id: str, payload: dict, activity_id: int) -> None:
+    terminal = _terminal_payload(payload, activity_id)
+    if isinstance(store, Database):
+        store.complete_pending(hevy_id, terminal)
+    else:  # preserves compatibility with the module facade and test doubles
+        store.mark_synced(hevy_id=hevy_id, **terminal)
+
+
+def finalize_pending(store, client, pending: dict) -> SyncOneResult:
+    """Resume remote finalization from a durable checkpoint; never uploads."""
+    wid = pending["hevy_id"]
+    payload = pending.get("payload") or {}
+    activity_id = int(pending["garmin_activity_id"])
+    watch_id = pending.get("watch_activity_id")
+    step = pending.get("next_step") or "rename"
+    try:
+        if step == "rename":
+            rename_activity(client, activity_id, payload.get("title", "Workout"))
+            step = "description" if payload.get("description_enabled") else ("delete" if watch_id else "commit")
+            store.update_pending(wid, phase="finalizing", next_step=step, last_error=None)
+        if step == "description":
+            set_description(client, activity_id, payload.get("description", ""))
+            step = "delete" if watch_id else "commit"
+            store.update_pending(wid, next_step=step, last_error=None)
+        if step == "delete":
+            if int(watch_id) == activity_id:
+                store.update_pending(wid, phase="needs_review", last_error="replacement equals watch activity; deletion blocked")
+                return SyncOneResult(status="needs_review", activity_id=activity_id)
+            try:
+                delete_activity(client, int(watch_id))
+            except Exception as exc:
+                attempts = int(pending.get("delete_attempt_count") or 0) + 1
+                phase = "needs_review" if attempts >= 3 else "finalizing"
+                store.update_pending(wid, phase=phase, next_step="delete", delete_attempt_count=attempts, last_error=str(exc)[:1000])
+                return SyncOneResult(status="needs_review" if phase == "needs_review" else "processing", activity_id=activity_id)
+            step = "commit"
+            store.update_pending(wid, next_step=step, last_error=None)
+        _complete(store, wid, payload, activity_id)
+        return SyncOneResult(status="synced", activity_id=activity_id, sync_method=payload.get("sync_method", "upload"), merge_fallback=payload.get("merge_fallback", False), calories=payload.get("calories"), avg_hr=payload.get("avg_hr"))
+    except Exception as exc:
+        store.update_pending(wid, phase="finalizing", next_step=step, last_error=str(exc)[:1000])
+        return SyncOneResult(status="processing", activity_id=activity_id)
+
+
+def reconcile_pending(store, client, hevy_id: str) -> SyncOneResult:
+    """Discover an accepted activity or resume finalization without uploading."""
+    pending = store.get_pending(hevy_id)
+    if not pending:
+        raise ValueError(f"no pending operation for {hevy_id}")
+    if pending.get("phase") == "failed":
+        return SyncOneResult(status="failed")
+    if pending.get("garmin_activity_id"):
+        return finalize_pending(store, client, pending)
+    upload_id = pending.get("upload_id")
+    if upload_id:
+        for method_name in ("get_upload_status", "get_activity_from_upload"):
+            method = getattr(client, method_name, None)
+            if not callable(method):
+                continue
+            try:
+                response = method(upload_id)
+                raw_id = response.get("activityId") or response.get("activity_id") or response.get("internalId") if isinstance(response, dict) else None
+                resolved = int(str(raw_id).strip("'\"")) if raw_id else None
+            except Exception:
+                continue
+            if resolved and str(resolved) not in {str(pending.get("watch_activity_id")), *map(str, pending.get("pre_upload_ids", []))}:
+                store.update_pending(hevy_id, phase="finalizing", next_step="rename", garmin_activity_id=str(resolved), resolution_source="upload_id", last_error=None)
+                return finalize_pending(store, client, store.get_pending(hevy_id))
+    workout = (pending.get("payload") or {}).get("workout") or {}
+    try:
+        activities = activities_for_workout(client, workout)
+    except Exception as exc:
+        store.update_pending(hevy_id, last_error=str(exc)[:1000])
+        return SyncOneResult(status="processing")
+    excluded = {str(x) for x in pending.get("pre_upload_ids", [])}
+    if pending.get("watch_activity_id"):
+        excluded.add(str(pending["watch_activity_id"]))
+    candidates = [a for a in activities if _activity_id(a) and str(_activity_id(a)) not in excluded]
+    # Snapshot-only recovery is deliberately strict: exactly one DEVELOPMENT strength activity.
+    safe = [a for a in candidates if str(a.get("manufacturer", "")).upper() == "DEVELOPMENT" and a.get("activityType", {}).get("typeKey", "strength_training") in {"strength_training", "other"}]
+    if len(safe) != 1:
+        if candidates:
+            store.update_pending(hevy_id, phase="needs_review", last_error=f"{len(candidates)} unverified snapshot candidate(s)")
+            return SyncOneResult(status="needs_review")
+        return SyncOneResult(status="processing")
+    activity_id = _activity_id(safe[0])
+    store.update_pending(hevy_id, phase="finalizing", next_step="rename", garmin_activity_id=str(activity_id), resolution_source="snapshot", last_error=None)
+    return finalize_pending(store, client, store.get_pending(hevy_id))
 
 
 def _workout_within_grace(workout: dict, grace_minutes: int) -> bool:
@@ -174,7 +286,7 @@ def sync_one_workout(
         )
         if merge_result.merged:
             fit_stats = _estimate_fit_stats(workout)
-            db.mark_synced(
+            merge_store.mark_synced(
                 hevy_id=wid,
                 garmin_activity_id=str(merge_result.activity_id),
                 title=title,
@@ -205,11 +317,11 @@ def sync_one_workout(
     if not dry_run and hr_fusion_on:
         from hevy2garmin.hr import hr_for_sync
 
-        hr_samples = hr_for_sync(db, garmin_client, workout, cfg, _hr_limiter)
+        hr_samples = hr_for_sync(merge_store, garmin_client, workout, cfg, _hr_limiter)
         if not hr_samples:
             # One retry — the watch's daily HR for this window may not
             # have settled on the first try.
-            hr_samples = hr_for_sync(db, garmin_client, workout, cfg, _hr_limiter)
+            hr_samples = hr_for_sync(merge_store, garmin_client, workout, cfg, _hr_limiter)
 
     with tempfile.TemporaryDirectory() as tmp:
         fit_path = str(Path(tmp) / f"{wid}.fit")
@@ -239,23 +351,58 @@ def sync_one_workout(
             logger.info("  Activity already on Garmin (%s), skipping upload", existing_id)
             activity_id = existing_id
         else:
-            upload_result = upload_fit(garmin_client, fit_path, workout_start=start_time)
-            activity_id = upload_result.get("activity_id")
-            uploaded = bool(activity_id)
-            if activity_id and merge_delete_id:
-                try:
-                    delete_activity(garmin_client, merge_delete_id)
-                    logger.info(
-                        "  Removed watch copy %s (replaced by %s)",
-                        merge_delete_id,
-                        activity_id,
-                    )
-                except Exception as e:
-                    logger.warning(
-                        "Could not delete watch activity %s: %s",
-                        merge_delete_id,
-                        e,
-                    )
+            sync_method = "upload_fallback" if merge_mode else "upload"
+            desc = generate_description(workout, calories=result.get("calories"), avg_hr=result.get("avg_hr")) if description_enabled else ""
+            pending_payload = {
+                "workout": workout,
+                "title": title,
+                "description": desc,
+                "description_enabled": description_enabled,
+                "calories": result.get("calories"),
+                "avg_hr": result.get("avg_hr"),
+                "hevy_updated_at": workout.get("updated_at"),
+                "sync_method": sync_method,
+                "merge_fallback": merge_fallback,
+            }
+            claimed = merge_store.claim_pending(wid, pending_payload)
+            if claimed is False:
+                pending = merge_store.get_pending(wid)
+                return SyncOneResult(status=(pending or {}).get("phase", "processing"))
+            try:
+                snapshot = activities_for_workout(garmin_client, workout)
+                snapshot_ids = [str(x) for a in snapshot if (x := _activity_id(a))]
+            except Exception:
+                merge_store.delete_pending(wid)
+                raise
+            merge_store.update_pending(wid, pre_upload_ids=snapshot_ids, watch_activity_id=str(merge_delete_id) if merge_delete_id else None, phase="processing", attempt_count=1)
+            try:
+                upload_result = upload_fit(garmin_client, fit_path, workout_start=start_time)
+            except GarminUploadRejected as exc:
+                merge_store.update_pending(wid, phase="failed", last_error=str(exc)[:1000])
+                return SyncOneResult(status="failed", merge_fallback=merge_fallback)
+            except Exception as exc:
+                # The request may have reached Garmin. Park it; never resubmit automatically.
+                merge_store.update_pending(wid, phase="processing", last_error=str(exc)[:1000])
+                return SyncOneResult(status="processing", merge_fallback=merge_fallback)
+            raw_id = upload_result.get("activity_id")
+            activity_id = int(raw_id) if raw_id and str(raw_id).isdigit() else None
+            upload_id = upload_result.get("upload_id")
+            merge_store.update_pending(wid, upload_id=str(upload_id) if upload_id else None, last_error=None)
+            if activity_id and str(activity_id) not in set(snapshot_ids) and (not merge_delete_id or activity_id != int(merge_delete_id)):
+                merge_store.update_pending(wid, phase="finalizing", next_step="rename", garmin_activity_id=str(activity_id), resolution_source="response")
+                if isinstance(merge_store, Database):
+                    pending_after = merge_store.get_pending(wid)
+                else:
+                    pending_after = {
+                        "hevy_id": wid, "phase": "finalizing", "next_step": "rename",
+                        "garmin_activity_id": str(activity_id),
+                        "watch_activity_id": str(merge_delete_id) if merge_delete_id else None,
+                        "payload": pending_payload, "delete_attempt_count": 0,
+                    }
+                finalized = finalize_pending(merge_store, garmin_client, pending_after)
+                finalized.no_hr = bool(hr_fusion_on and not hr_samples)
+                return finalized
+            return SyncOneResult(status="processing", merge_fallback=merge_fallback)
 
         if activity_id:
             rename_activity(garmin_client, activity_id, title)
@@ -268,7 +415,7 @@ def sync_one_workout(
                 set_description(garmin_client, activity_id, desc)
 
         sync_method = "upload_fallback" if merge_mode else "upload"
-        db.mark_synced(
+        merge_store.mark_synced(
             hevy_id=wid,
             garmin_activity_id=str(activity_id) if activity_id else None,
             title=title,
@@ -323,6 +470,8 @@ def sync(
         Dict with sync stats: synced, skipped, failed, total, unmapped.
     """
     cfg = config or load_config()
+    candidate_store = db.get_db() if callable(getattr(db, "get_db", None)) else None
+    store = candidate_store if isinstance(candidate_store, Database) else db
     hevy_api_key = overrides.get("hevy_api_key") or cfg.get("hevy_api_key")
     garmin_email = overrides.get("garmin_email") or cfg.get("garmin_email")
     garmin_password = overrides.get("garmin_password") or cfg.get("garmin_password", "")
@@ -357,6 +506,8 @@ def sync(
         "deferred": 0,
         "no_hr": 0,
         "duplicates": 0,
+        "processing": 0,
+        "needs_review": 0,
     }
 
     if merge_mode:
@@ -367,7 +518,7 @@ def sync(
         wid = workout.get("id", "unknown")
         title = workout.get("title", "Workout")
 
-        if skip_existing and db.is_synced(wid):
+        if skip_existing and store.is_synced(wid):
             logger.debug("Skipping %s (%s) — already synced", wid, title)
             stats["skipped"] += 1
             continue
@@ -385,9 +536,19 @@ def sync(
                 garmin_client=garmin_client,
                 dry_run=dry_run,
                 respect_grace=respect_grace,
+                database=store,
             )
             if one.status == "deferred":
                 stats["deferred"] += 1
+                continue
+            if one.status == "processing":
+                stats["processing"] += 1
+                continue
+            if one.status == "needs_review":
+                stats["needs_review"] += 1
+                continue
+            if one.status == "failed":
+                stats["failed"] += 1
                 continue
 
             if one.status == "dry_run":
@@ -431,7 +592,7 @@ def sync(
             trigger = "cli"
             if os.environ.get("GITHUB_ACTIONS"):
                 trigger = "github-actions"
-        db.record_sync_log(
+        store.record_sync_log(
             synced=stats["synced"],
             skipped=stats["skipped"],
             failed=stats["failed"],

--- a/src/hevy2garmin/templates/dashboard.html
+++ b/src/hevy2garmin/templates/dashboard.html
@@ -77,7 +77,7 @@
 </div>
 {% endif %}
 
-{% if synced_count == 0 and hevy_total > 0 %}
+{% if terminal_count == 0 and hevy_total > 0 %}
 <div class="card" style="margin-bottom: 20px; text-align: center; padding: 32px 20px; border-color: rgba(16, 185, 129, 0.3);">
     <div style="font-size: 18px; font-weight: 600; margin-bottom: 8px;">{{ hevy_total }} workouts ready to sync</div>
     <p style="font-size: 14px; color: var(--text-secondary); margin-bottom: 16px;">Your Hevy workouts are not on Garmin yet. Click Sync Now below to start.</p>
@@ -92,11 +92,15 @@
         <div class="stat-label">On Garmin</div>
     </div>
     <div class="stat-card">
-        <div class="stat-value blue">{{ hevy_total }}</div>
-        <div class="stat-label">In Hevy</div>
+        <div class="stat-value blue">{{ manual_count }}</div>
+        <div class="stat-label">Marked synced</div>
     </div>
     <div class="stat-card">
-        {% set pending = hevy_total - on_garmin %}
+        <div class="stat-value blue">{{ skipped_count }}</div>
+        <div class="stat-label">Skipped</div>
+    </div>
+    <div class="stat-card">
+        {% set pending = hevy_total - terminal_count %}
         <div class="stat-value {% if pending > 0 %}amber{% endif %}" id="stat-pending">{{ pending }}</div>
         <div class="stat-label">Pending</div>
     </div>
@@ -113,7 +117,7 @@
     <div style="display: flex; align-items: center; gap: 10px; margin-bottom: 6px;">
         <button id="sync-now-btn" class="btn btn-primary btn-sm" onclick="syncNow()" style="flex-shrink: 0;">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4M17 8l-5-5-5 5M12 3v12"/></svg>
-            {% set pending = hevy_total - [synced_count, matched_count]|max %}{% if pending > 1 %}Sync {{ pending }} Workouts{% elif pending == 1 %}Sync 1 Workout{% else %}Sync Now{% endif %}
+            {% set pending = hevy_total - terminal_count %}{% if pending > 1 %}Sync {{ pending }} Workouts{% elif pending == 1 %}Sync 1 Workout{% else %}Sync Now{% endif %}
         </button>
         <button id="sync-stop-btn" class="btn btn-secondary btn-sm" onclick="stopSync()" style="display: none; flex-shrink: 0;">Stop</button>
         <div id="sync-progress" style="flex: 1; display: none;">
@@ -126,7 +130,7 @@
             </div>
         </div>
     </div>
-    {% set pending = hevy_total - [synced_count, matched_count]|max %}
+    {% set pending = hevy_total - terminal_count %}
     {% if pending > 1 %}
     <p style="font-size: 12px; color: var(--text-muted); margin-bottom: 10px; line-height: 1.6;">
         Uploads one workout at a time (~{{ ((pending * 8) / 60) | round(0) | int }} min for {{ pending }}).

--- a/src/hevy2garmin/templates/history.html
+++ b/src/hevy2garmin/templates/history.html
@@ -4,7 +4,7 @@
 {% block content %}
 <div class="page-header">
     <h1>Sync History</h1>
-    <p>{{ total }} workouts synced</p>
+    <p>{{ total }} workouts resolved</p>
 </div>
 
 {% if history %}
@@ -28,9 +28,9 @@
                 <td style="text-align: right; font-variant-numeric: tabular-nums; color: var(--text-secondary);">{{ h.calories or '—' }}</td>
                 <td style="text-align: right; font-variant-numeric: tabular-nums; color: var(--text-secondary);">{{ h.avg_hr or '—' }}</td>
                 <td style="font-variant-numeric: tabular-nums; color: var(--text-muted); font-size: 13px;">{{ h.garmin_activity_id or '—' }}</td>
-                <td><span class="badge badge-success">
+                <td><span class="badge {% if (h.status or 'success') == 'success' %}badge-success{% endif %}">
                     <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>
-                    {{ h.status }}
+                    {% if (h.status or 'success') == 'manual' %}Marked as synced{% elif h.status == 'skipped' %}Skipped{% else %}Uploaded{% endif %}
                 </span></td>
             </tr>
             {% endfor %}

--- a/src/hevy2garmin/templates/workouts.html
+++ b/src/hevy2garmin/templates/workouts.html
@@ -151,6 +151,16 @@
                     <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>
                     On Garmin{% if w.garmin_match and w.garmin_match.garmin_name %} as "{{ w.garmin_match.garmin_name }}"{% endif %}
                 </span>
+                {% elif w.status == 'manual' %}
+                <span class="badge badge-success">Marked as synced</span>
+                {% elif w.status == 'skipped' %}
+                <span class="badge" style="background: rgba(100,116,139,.15); color: #94a3b8;">Skipped</span>
+                {% elif w.status == 'processing' %}
+                <span class="badge" style="background: rgba(59,130,246,.15); color: #60a5fa;">Processing</span>
+                {% elif w.status == 'needs_review' %}
+                <span class="badge" style="background: rgba(251,191,36,.15); color: #fbbf24;">Needs review</span>
+                {% elif w.status == 'failed' %}
+                <span class="badge" style="background: rgba(239,68,68,.15); color: #f87171;">Sync failed</span>
                 {% else %}
                 <span class="badge badge-pending">Not on Garmin</span>
                 {% endif %}
@@ -159,6 +169,11 @@
                 {{ w.start_time[:10] }} at {{ w.start_time[11:16] }}
                 &middot; {{ w.exercises|length }} exercises
             </div>
+            {% if w.state_detail and (w.state_detail.reason or w.state_detail.last_error) %}
+            <div style="font-size: 12px; color: var(--text-muted); margin: -4px 0 10px; max-width: 760px;">
+                {{ w.state_detail.reason or w.state_detail.last_error }}
+            </div>
+            {% endif %}
             <!-- Source links -->
             <div style="display: flex; gap: 8px; margin-bottom: 10px;">
                 <a href="https://hevy.com/workout/{{ w.id }}" target="_blank" rel="noopener"
@@ -182,14 +197,25 @@
                     Re-sync
                 </button>
                 {% endif %}
-                {% if w.status == 'uploaded' %}
+                {% if w.status in ('uploaded', 'manual', 'skipped') %}
                 <button type="button"
                     onclick="unsyncWorkout('{{ w.id }}', this)"
                     style="display: inline-flex; align-items: center; gap: 4px; padding: 3px 10px; border-radius: 6px; font-size: 12px; font-weight: 600; background: rgba(239,68,68,0.12); color: #f87171; border: none; cursor: pointer;"
                     title="Remove sync record so this workout can be re-synced">
                     <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M3 6h18M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
-                    Unsync
+                    Reset
                 </button>
+                {% endif %}
+                {% if w.status in ('processing', 'needs_review') %}
+                <button type="button" onclick="pendingAction('{{ w.id }}', 'reconcile', this)" class="btn btn-secondary btn-sm">Reconcile</button>
+                <button type="button" onclick="pendingAction('{{ w.id }}', 'abandon', this)" class="btn btn-secondary btn-sm" style="color:#f87171;">Abandon</button>
+                {% elif w.status == 'failed' %}
+                <button type="button" onclick="pendingAction('{{ w.id }}', 'retry', this)" class="btn btn-secondary btn-sm">Retry</button>
+                <button type="button" onclick="pendingAction('{{ w.id }}', 'abandon', this)" class="btn btn-secondary btn-sm" style="color:#f87171;">Abandon</button>
+                {% endif %}
+                {% if w.status in ('pending', 'processing', 'needs_review', 'failed') %}
+                <button type="button" onclick="manualAction('{{ w.id }}', 'mark-synced', this)" class="btn btn-secondary btn-sm">Mark synced</button>
+                <button type="button" onclick="manualAction('{{ w.id }}', 'skip', this)" class="btn btn-secondary btn-sm">Skip</button>
                 {% endif %}
             </div>
             <!-- Exercise details -->
@@ -507,6 +533,48 @@ async function resyncWorkout(hevyId, btn) {
         alert('Network error: ' + e.message);
         btn.disabled = false;
         btn.textContent = 'Re-sync';
+    }
+}
+
+async function pendingAction(hevyId, action, btn) {
+    const warnings = {
+        retry: 'Retry this definitively rejected upload?',
+        abandon: 'Abandon this pending operation? A delayed Garmin upload may still appear later.',
+        reconcile: 'Check Garmin and resume this operation without uploading again?'
+    };
+    if (!confirm(warnings[action])) return;
+    btn.disabled = true;
+    const form = new FormData();
+    if (action === 'retry' || action === 'abandon') form.append('confirm', hevyId);
+    try {
+        const resp = await fetch('/api/pending/' + encodeURIComponent(hevyId) + '/' + action, {method: 'POST', body: form});
+        const data = await resp.json();
+        if (!resp.ok || !data.ok) throw new Error(data.error || 'Operation failed');
+        window.location.reload();
+    } catch (e) {
+        alert(e.message); btn.disabled = false;
+    }
+}
+
+async function manualAction(hevyId, action, btn) {
+    const label = action === 'skip' ? 'skip' : 'mark as synced';
+    if (!confirm('Manually ' + label + ' this workout? If an upload is pending, a delayed Garmin activity may still appear.')) return;
+    const reason = prompt('Optional reason:', '') || '';
+    const form = new FormData();
+    form.append('reason', reason.slice(0, 1000));
+    form.append('confirm', hevyId);
+    if (action === 'mark-synced') {
+        const garminId = prompt('Optional Garmin activity ID:', '') || '';
+        if (garminId) form.append('garmin_id', garminId);
+    }
+    btn.disabled = true;
+    try {
+        const resp = await fetch('/api/workout/' + encodeURIComponent(hevyId) + '/' + action, {method: 'POST', body: form});
+        const data = await resp.json();
+        if (!resp.ok || !data.ok) throw new Error(data.error || 'Operation failed');
+        window.location.reload();
+    } catch (e) {
+        alert(e.message); btn.disabled = false;
     }
 }
 

--- a/src/hevy2garmin/templates/workouts.html
+++ b/src/hevy2garmin/templates/workouts.html
@@ -559,12 +559,14 @@ async function pendingAction(hevyId, action, btn) {
 async function manualAction(hevyId, action, btn) {
     const label = action === 'skip' ? 'skip' : 'mark as synced';
     if (!confirm('Manually ' + label + ' this workout? If an upload is pending, a delayed Garmin activity may still appear.')) return;
-    const reason = prompt('Optional reason:', '') || '';
+    const reason = prompt('Optional reason:', '');
+    if (reason === null) return;
     const form = new FormData();
     form.append('reason', reason.slice(0, 1000));
     form.append('confirm', hevyId);
     if (action === 'mark-synced') {
-        const garminId = prompt('Optional Garmin activity ID:', '') || '';
+        const garminId = prompt('Optional Garmin activity ID:', '');
+        if (garminId === null) return;
         if (garminId) form.append('garmin_id', garminId);
     }
     btn.disabled = true;

--- a/tests/test_resolution_ui.py
+++ b/tests/test_resolution_ui.py
@@ -1,0 +1,75 @@
+"""Web recovery and manual-resolution behavior."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from hevy2garmin.db_sqlite import SQLiteDatabase
+import hevy2garmin.server as srv
+
+
+def _client(store: SQLiteDatabase):
+    srv._is_configured_cache = True
+    return patch.object(srv.db, "get_db", return_value=store), TestClient(srv.app)
+
+
+def test_batch_state_terminal_precedence(tmp_path: Path) -> None:
+    store = SQLiteDatabase(tmp_path / "sync.db")
+    store.resolve_terminal("w1", status="manual", reason="verified", source="web")
+    conn = store._get_conn()
+    conn.execute("INSERT INTO pending_uploads (hevy_id, phase) VALUES ('w1', 'processing')")
+    conn.commit(); conn.close()
+    state = store.get_workout_states(["w1"])["w1"]
+    assert state["kind"] == "terminal"
+    assert state["status"] == "manual"
+
+
+def test_skip_pending_requires_confirmation(tmp_path: Path) -> None:
+    store = SQLiteDatabase(tmp_path / "sync.db")
+    store.claim_pending("w1", {})
+    db_patch, client = _client(store)
+    with db_patch, client:
+        response = client.post("/api/workout/w1/skip", data={"reason": "duplicate"})
+        assert response.status_code == 409
+        response = client.post("/api/workout/w1/skip", data={"reason": "duplicate", "confirm": "w1"})
+    assert response.json() == {"ok": True, "status": "skipped"}
+    assert store.get_workout_states(["w1"])["w1"]["status"] == "skipped"
+    assert store.get_pending("w1") is None
+
+
+def test_mark_synced_validates_garmin_id(tmp_path: Path) -> None:
+    store = SQLiteDatabase(tmp_path / "sync.db")
+    db_patch, client = _client(store)
+    with db_patch, client:
+        bad = client.post("/api/workout/w1/mark-synced", data={"garmin_id": "-4"})
+        good = client.post("/api/workout/w1/mark-synced", data={"garmin_id": "123", "reason": "verified"})
+    assert bad.status_code == 400
+    assert good.json()["status"] == "manual"
+    state = store.get_workout_states(["w1"])["w1"]
+    assert state["garmin_activity_id"] == "123"
+
+
+def test_abandon_requires_exact_confirmation(tmp_path: Path) -> None:
+    store = SQLiteDatabase(tmp_path / "sync.db")
+    store.claim_pending("w1", {})
+    db_patch, client = _client(store)
+    with db_patch, client:
+        denied = client.post("/api/pending/w1/abandon", data={"confirm": "wrong"})
+        allowed = client.post("/api/pending/w1/abandon", data={"confirm": "w1"})
+    assert denied.status_code == 400
+    assert allowed.json()["ok"] is True
+    assert store.get_pending("w1") is None
+
+
+def test_workout_template_shows_resolution_states() -> None:
+    workouts = [
+        {"id": "a", "title": "A", "status": "manual", "start_time": "2026-01-01T10:00", "exercises": []},
+        {"id": "b", "title": "B", "status": "skipped", "start_time": "2026-01-01T10:00", "exercises": []},
+        {"id": "c", "title": "C", "status": "needs_review", "start_time": "2026-01-01T10:00", "exercises": [], "state_detail": {"last_error": "verify candidate"}},
+    ]
+    html = srv._render("workouts.html", workouts=workouts, hr_fusion_enabled=False, page=1, page_count=1, fetch_error=None).body.decode()
+    assert "Marked as synced" in html
+    assert "Skipped" in html
+    assert "Needs review" in html
+    assert "verify candidate" in html

--- a/tests/test_resolution_ui.py
+++ b/tests/test_resolution_ui.py
@@ -73,3 +73,5 @@ def test_workout_template_shows_resolution_states() -> None:
     assert "Skipped" in html
     assert "Needs review" in html
     assert "verify candidate" in html
+    assert "if (reason === null) return;" in html
+    assert "if (garminId === null) return;" in html

--- a/tests/test_safe_pending.py
+++ b/tests/test_safe_pending.py
@@ -48,6 +48,21 @@ def test_same_id_never_deletes_replacement(tmp_path: Path) -> None:
     assert store.get_pending("w1")["phase"] == "needs_review"
 
 
+def test_finalize_null_watch_id_skips_delete(tmp_path: Path) -> None:
+    store = SQLiteDatabase(tmp_path / "sync.db")
+    store.claim_pending("w1", {"title": "Push", "description_enabled": False})
+    store.update_pending(
+        "w1", phase="finalizing", next_step="delete",
+        garmin_activity_id="42", watch_activity_id=None,
+    )
+    with patch("hevy2garmin.sync.delete_activity") as delete:
+        result = finalize_pending(store, MagicMock(), store.get_pending("w1"))
+    assert result.status == "synced"
+    delete.assert_not_called()
+    assert store.get_pending("w1") is None
+    assert store.is_synced("w1") is True
+
+
 def test_reconcile_without_candidate_never_uploads(tmp_path: Path) -> None:
     store = SQLiteDatabase(tmp_path / "sync.db")
     workout = {"start_time": "2026-01-01T10:00:00Z", "end_time": "2026-01-01T11:00:00Z"}
@@ -57,3 +72,100 @@ def test_reconcile_without_candidate_never_uploads(tmp_path: Path) -> None:
         result = reconcile_pending(store, MagicMock(), "w1")
     assert result.status == "processing"
     upload.assert_not_called()
+
+
+def test_reconcile_refuses_snapshot_without_recovery_evidence(tmp_path: Path) -> None:
+    store = SQLiteDatabase(tmp_path / "sync.db")
+    workout = {"start_time": "2026-01-01T10:00:00Z", "end_time": "2026-01-01T11:00:00Z"}
+    store.claim_pending("w1", {"workout": workout})
+    candidate = {
+        "activityId": 20,
+        "manufacturer": "DEVELOPMENT",
+        "activityType": {"typeKey": "strength_training"},
+        "startTimeGMT": "2026-01-01 10:00:00",
+    }
+    with (
+        patch("hevy2garmin.sync.activities_for_workout", return_value=[candidate]) as activities,
+        patch("hevy2garmin.sync.rename_activity") as rename,
+        patch("hevy2garmin.sync.upload_fit") as upload,
+    ):
+        first = reconcile_pending(store, MagicMock(), "w1")
+        second = reconcile_pending(store, MagicMock(), "w1")
+    assert first.status == "needs_review"
+    assert second.status == "needs_review"
+    activities.assert_not_called()
+    rename.assert_not_called()
+    upload.assert_not_called()
+    pending = store.get_pending("w1")
+    assert pending["phase"] == "needs_review"
+    assert "refusing snapshot adoption" in pending["last_error"]
+
+
+def test_reconcile_recovers_empty_snapshot_with_matching_candidate(tmp_path: Path) -> None:
+    store = SQLiteDatabase(tmp_path / "sync.db")
+    workout = {"start_time": "2026-01-01T10:00:00Z", "end_time": "2026-01-01T11:00:00Z"}
+    store.claim_pending("w1", {"workout": workout, "title": "Push", "description_enabled": False})
+    store.update_pending("w1", phase="processing", pre_upload_ids=[], attempt_count=1)
+    candidate = {
+        "activityId": 20,
+        "manufacturer": "DEVELOPMENT",
+        "activityType": {"typeKey": "strength_training"},
+        "startTimeGMT": "2026-01-01 10:05:00",
+    }
+    with (
+        patch("hevy2garmin.sync.activities_for_workout", return_value=[candidate]),
+        patch("hevy2garmin.sync.rename_activity") as rename,
+        patch("hevy2garmin.sync.upload_fit") as upload,
+    ):
+        result = reconcile_pending(store, MagicMock(), "w1")
+    assert result.status == "synced"
+    rename.assert_called_once()
+    upload.assert_not_called()
+    assert store.get_pending("w1") is None
+    assert store.get_garmin_id("w1") == "20"
+
+
+def test_reconcile_rejects_foreign_candidate_outside_start_window(tmp_path: Path) -> None:
+    store = SQLiteDatabase(tmp_path / "sync.db")
+    workout = {"start_time": "2026-01-01T10:00:00Z", "end_time": "2026-01-01T11:00:00Z"}
+    store.claim_pending("w1", {"workout": workout, "title": "Push", "description_enabled": False})
+    store.update_pending("w1", phase="processing", pre_upload_ids=["10"], attempt_count=1)
+    candidate = {
+        "activityId": 20,
+        "manufacturer": "DEVELOPMENT",
+        "activityType": {"typeKey": "strength_training"},
+        "startTimeGMT": "2026-01-01 12:00:00",
+    }
+    with (
+        patch("hevy2garmin.sync.activities_for_workout", return_value=[candidate]),
+        patch("hevy2garmin.sync.rename_activity") as rename,
+        patch("hevy2garmin.sync.upload_fit") as upload,
+    ):
+        result = reconcile_pending(store, MagicMock(), "w1")
+    assert result.status == "needs_review"
+    rename.assert_not_called()
+    upload.assert_not_called()
+    assert store.get_pending("w1")["garmin_activity_id"] is None
+
+
+def test_reconcile_rejects_candidate_with_null_activity_type(tmp_path: Path) -> None:
+    store = SQLiteDatabase(tmp_path / "sync.db")
+    workout = {"start_time": "2026-01-01T10:00:00Z", "end_time": "2026-01-01T11:00:00Z"}
+    store.claim_pending("w1", {"workout": workout, "title": "Push", "description_enabled": False})
+    store.update_pending("w1", phase="processing", pre_upload_ids=["10"], attempt_count=1)
+    candidate = {
+        "activityId": 20,
+        "manufacturer": "DEVELOPMENT",
+        "activityType": None,
+        "startTimeGMT": "2026-01-01 10:00:00",
+    }
+    with (
+        patch("hevy2garmin.sync.activities_for_workout", return_value=[candidate]),
+        patch("hevy2garmin.sync.rename_activity") as rename,
+        patch("hevy2garmin.sync.upload_fit") as upload,
+    ):
+        result = reconcile_pending(store, MagicMock(), "w1")
+    assert result.status == "needs_review"
+    rename.assert_not_called()
+    upload.assert_not_called()
+    assert store.get_pending("w1")["garmin_activity_id"] is None

--- a/tests/test_safe_pending.py
+++ b/tests/test_safe_pending.py
@@ -1,0 +1,59 @@
+"""Safety invariants for parked Garmin upload operations."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from hevy2garmin.db_sqlite import SQLiteDatabase
+from hevy2garmin.sync import finalize_pending, reconcile_pending
+
+
+def test_unique_pending_claim(tmp_path: Path) -> None:
+    store = SQLiteDatabase(tmp_path / "sync.db")
+    assert store.claim_pending("w1", {"title": "Push"}) is True
+    assert store.claim_pending("w1", {"title": "Other"}) is False
+    assert store.get_pending("w1")["payload"]["title"] == "Push"
+
+
+def test_complete_is_terminal_and_removes_pending(tmp_path: Path) -> None:
+    store = SQLiteDatabase(tmp_path / "sync.db")
+    store.claim_pending("w1", {})
+    store.complete_pending("w1", {"garmin_activity_id": "123", "title": "Push"})
+    assert store.get_pending("w1") is None
+    assert store.is_synced("w1") is True
+    assert store.get_recent_synced(1)[0]["status"] == "success"
+
+
+def test_manual_resolution_removes_pending(tmp_path: Path) -> None:
+    store = SQLiteDatabase(tmp_path / "sync.db")
+    store.claim_pending("w1", {})
+    store.resolve_terminal("w1", status="manual", garmin_activity_id="123", reason="verified", source="manual")
+    assert store.get_pending("w1") is None
+    row = store.get_recent_synced(1)[0]
+    assert row["status"] == "manual"
+    assert row["resolution_reason"] == "verified"
+
+
+def test_same_id_never_deletes_replacement(tmp_path: Path) -> None:
+    store = SQLiteDatabase(tmp_path / "sync.db")
+    store.claim_pending("w1", {"title": "Push", "description_enabled": False})
+    store.update_pending(
+        "w1", phase="finalizing", next_step="delete",
+        garmin_activity_id="42", watch_activity_id="42",
+    )
+    client = MagicMock()
+    with patch("hevy2garmin.sync.delete_activity") as delete:
+        result = finalize_pending(store, client, store.get_pending("w1"))
+    assert result.status == "needs_review"
+    delete.assert_not_called()
+    assert store.get_pending("w1")["phase"] == "needs_review"
+
+
+def test_reconcile_without_candidate_never_uploads(tmp_path: Path) -> None:
+    store = SQLiteDatabase(tmp_path / "sync.db")
+    workout = {"start_time": "2026-01-01T10:00:00Z", "end_time": "2026-01-01T11:00:00Z"}
+    store.claim_pending("w1", {"workout": workout})
+    store.update_pending("w1", phase="processing", pre_upload_ids=["10"])
+    with patch("hevy2garmin.sync.activities_for_workout", return_value=[]), patch("hevy2garmin.sync.upload_fit") as upload:
+        result = reconcile_pending(store, MagicMock(), "w1")
+    assert result.status == "processing"
+    upload.assert_not_called()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from datetime import datetime, timezone, timedelta
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from hevy2garmin.merge import MergeResult
 from hevy2garmin.sync import fetch_workouts, sync, sync_one_workout
 
@@ -136,6 +138,7 @@ class TestSync:
             result = sync(dry_run=True, limit=1, hevy_api_key="test", respect_grace=False)
 
             mock_garmin.assert_not_called()
+            mock_db.list_pending.assert_not_called()
             assert result["synced"] == 1
 
     def test_skips_already_synced(self, sample_workout: dict) -> None:
@@ -150,6 +153,64 @@ class TestSync:
             result = sync(dry_run=True, limit=1, hevy_api_key="test", respect_grace=False)
             assert result["skipped"] == 1
             assert result["synced"] == 0
+
+    @pytest.mark.parametrize(
+        ("phase", "bucket"),
+        [
+            ("processing", "processing"),
+            ("needs_review", "needs_review"),
+            ("failed", "failed"),
+        ],
+    )
+    def test_preskips_parked_workout_with_phase_stats(
+        self, sample_workout: dict, phase: str, bucket: str,
+    ) -> None:
+        with patch("hevy2garmin.sync.HevyClient") as MockHevy, \
+             patch("hevy2garmin.sync.db") as mock_db, \
+             patch("hevy2garmin.sync.get_client"), \
+             patch("hevy2garmin.sync.sync_one_workout") as mock_one, \
+             patch("hevy2garmin.reconcile.detect_duplicates", return_value=[]):
+            mock_hevy = MockHevy.return_value
+            mock_hevy.get_workout_count.return_value = 1
+            mock_hevy.get_workouts.return_value = {"workouts": [sample_workout], "page_count": 1}
+            mock_db.is_synced.return_value = False
+            mock_db.list_pending.return_value = [{"hevy_id": sample_workout["id"], "phase": phase}]
+
+            result = sync(
+                config={"hevy_api_key": "test", "merge_mode": False},
+                limit=1,
+                respect_grace=False,
+                record_log=False,
+            )
+
+            mock_one.assert_not_called()
+            assert result[bucket] == 1
+            assert result["synced"] == 0
+
+    def test_terminal_state_precedes_parked_state(self, sample_workout: dict) -> None:
+        with patch("hevy2garmin.sync.HevyClient") as MockHevy, \
+             patch("hevy2garmin.sync.db") as mock_db, \
+             patch("hevy2garmin.sync.get_client"), \
+             patch("hevy2garmin.sync.sync_one_workout") as mock_one, \
+             patch("hevy2garmin.reconcile.detect_duplicates", return_value=[]):
+            mock_hevy = MockHevy.return_value
+            mock_hevy.get_workout_count.return_value = 1
+            mock_hevy.get_workouts.return_value = {"workouts": [sample_workout], "page_count": 1}
+            mock_db.is_synced.return_value = True
+            mock_db.list_pending.return_value = [
+                {"hevy_id": sample_workout["id"], "phase": "processing"}
+            ]
+
+            result = sync(
+                config={"hevy_api_key": "test", "merge_mode": False},
+                limit=1,
+                respect_grace=False,
+                record_log=False,
+            )
+
+            mock_one.assert_not_called()
+            assert result["skipped"] == 1
+            assert result["processing"] == 0
 
     def test_reports_unmapped_exercises(self, sample_workout_unmapped: dict) -> None:
         with patch("hevy2garmin.sync.HevyClient") as MockHevy, \
@@ -242,6 +303,27 @@ class TestSync:
 
 
 class TestSyncOneWorkout:
+    def test_parked_workout_blocks_all_remote_and_terminal_work(self, sample_workout: dict) -> None:
+        store = MagicMock()
+        store.get_pending.return_value = {"hevy_id": sample_workout["id"], "phase": "finalizing"}
+        with patch("hevy2garmin.sync.attempt_merge") as merge, \
+             patch("hevy2garmin.sync.generate_fit") as generate, \
+             patch("hevy2garmin.sync.find_activity_by_start_time") as find_existing, \
+             patch("hevy2garmin.sync.rename_activity") as rename:
+            result = sync_one_workout(
+                sample_workout,
+                cfg={"merge_mode": True},
+                garmin_client=MagicMock(),
+                database=store,
+            )
+
+        assert result.status == "processing"
+        merge.assert_not_called()
+        generate.assert_not_called()
+        find_existing.assert_not_called()
+        rename.assert_not_called()
+        store.mark_synced.assert_not_called()
+
     def test_merge_success_stores_calories(self, sample_workout: dict) -> None:
         with patch("hevy2garmin.sync.db") as mock_db, \
              patch("hevy2garmin.sync.attempt_merge") as mock_merge, \


### PR DESCRIPTION
## Summary
- Park uncertain Garmin uploads in a new `pending_uploads` table so crashes/timeouts never auto-resubmit and create duplicates.
- Resume rename/description/watch-delete from durable checkpoints; block same-ID deletion and cap delete retries.
- Add CLI + web controls: reconcile (never uploads), retry failed only, abandon, mark-synced, and skip — with separate uploaded/manual/skipped counts.

## Motivation
Garmin uploads are not transactional. Mid-request failures previously caused duplicate uploads or unsafe Replace finalization (including the same-ID / 404 data-loss class). Once an upload might have reached Garmin, the next sync must not blindly upload again.

## Compatibility
- Additive `pending_uploads` schema (SQLite + Postgres).
- Existing `synced_workouts` readers remain valid; new terminal statuses `manual` / `skipped` are optional.
- Downgrading while a pending row exists is unsupported (older clients may duplicate).

## Test plan
- [x] `pytest tests/test_safe_pending.py tests/test_resolution_ui.py`
- [x] Manual: force a parked processing state → Reconcile does not upload
- [x] Manual: failed pending → Retry with confirm resubmits once
- [x] Manual: Abandon / Mark synced / Skip clear the block as documented

Made with [Cursor](https://cursor.com)