### PR TITLE
feat(sync): preserve watch hi-res HR in replacements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- The watch-activity **Replace** strategy now extracts high-resolution heart-rate samples from the original Garmin FIT and embeds them in the named Hevy replacement before deleting the watch copy. If the source cannot be extracted or restored from backup, replacement stops and preserves the original activity.
+
 ## [0.5.19] - 2026-07-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -380,12 +380,12 @@ This is visible in the activity details on Garmin Connect and any connected apps
 
 ## Enhance Watch Activities (opt-in)
 
-By default, hevy2garmin creates a new Garmin activity from your Hevy workout using your watch's continuous HR monitoring (~2 min sampling). This works without any behavior change.
+By default, hevy2garmin creates a new Garmin activity from your Hevy workout using your watch's daily HR monitoring (~2 min sampling). This works without any behavior change. When a matching watch-recorded workout is found and the **Replace** strategy is selected, hevy2garmin instead downloads that activity's high-resolution HR, saves a durable backup, embeds it in the named Hevy FIT, uploads the replacement, and only then deletes the watch copy. If neither the original FIT nor an existing backup is available, replacement stops and preserves the watch activity.
 
-If you start a **Strength Training** activity on your Garmin watch when you hit the gym, you can enable **Enhance Watch Activities** in the config (`"merge_mode": true`). hevy2garmin will detect the matching watch activity and push your Hevy exercise data directly into it instead of creating a new activity. Benefits:
+If you start a **Strength Training** activity on your Garmin watch when you hit the gym, you can enable **Enhance Watch Activities** in the config (`"merge_mode": true`). hevy2garmin detects the matching watch activity and combines it with your Hevy data using the configured watch strategy. The in-place strategies keep the original watch activity; Replace creates one named composite activity. Depending on the selected strategy, benefits include:
 
 - **1-second HR sampling** (vs ~2 min in continuous monitoring)
-- **Training effect, EPOC, recovery time, and VO2max impact** all count (Garmin ignores these for manually uploaded activities)
+- **Training effect, EPOC, recovery time, and VO2max impact** remain when an in-place strategy keeps the original activity (Garmin does not transfer these to an uploaded replacement)
 - **Correct Strava timestamps** (watch-synced activities use the real time, not upload time)
 - **Single activity** on Garmin (no duplicate)
 

--- a/src/hevy2garmin/garmin.py
+++ b/src/hevy2garmin/garmin.py
@@ -71,13 +71,20 @@ def _sanitize_activity_id(raw: object) -> int | None:
         return None
 
 
-def upload_fit(client: Garmin, fit_path: str | Path, workout_start: str | None = None) -> dict:
+def upload_fit(
+    client: Garmin,
+    fit_path: str | Path,
+    workout_start: str | None = None,
+    exclude_activity_ids: list[int | str] | set[int | str] | None = None,
+) -> dict:
     """Upload a FIT file to Garmin Connect.
 
     Args:
         client: Authenticated Garmin client.
         fit_path: Path to the .fit file.
         workout_start: ISO-8601 start time for matching the uploaded activity.
+        exclude_activity_ids: Activities that existed before the upload. These
+            must not be mistaken for the newly imported activity.
 
     Returns dict with upload_id and activity_id (if found).
     """
@@ -127,7 +134,11 @@ def upload_fit(client: Garmin, fit_path: str | Path, workout_start: str | None =
     if not activity_id and workout_start:
         for attempt, wait in enumerate([3, 5, 10], 1):
             time.sleep(wait)
-            activity_id = find_activity_by_start_time(client, workout_start)
+            activity_id = find_activity_by_start_time(
+                client,
+                workout_start,
+                exclude_activity_ids=exclude_activity_ids,
+            )
             if activity_id:
                 break
             logger.info("  Activity not found yet (attempt %d/%d), retrying...", attempt, 3)
@@ -182,6 +193,7 @@ def find_activity_by_start_time(
     client: Garmin,
     target_start: str,
     window_minutes: int = 10,
+    exclude_activity_ids: list[int | str] | set[int | str] | None = None,
 ) -> int | None:
     """Find a Garmin activity matching a start time within a window.
 
@@ -205,14 +217,18 @@ def find_activity_by_start_time(
     except Exception:
         return None
 
+    excluded = {str(activity_id) for activity_id in (exclude_activity_ids or [])}
     for act in activities:
+        activity_id = act.get("activityId")
+        if str(activity_id) in excluded:
+            continue
         # Only match strength training activities — skip runs, bikes, yoga, etc.
         act_type = act.get("activityType", {}).get("typeKey", "")
         if act_type and act_type not in ("strength_training", "other"):
             continue
 
         if activity_matches_start_time(act, target_start, window_minutes):
-            return act.get("activityId")
+            return activity_id
     return None
 
 

--- a/src/hevy2garmin/hr.py
+++ b/src/hevy2garmin/hr.py
@@ -7,8 +7,11 @@ source, in priority order:
    captures via Apple HealthKit). This is the most consistent during a lift, but
    only present when the user wore a recording device for that session — and
    only when Hevy actually exposes it (see ``extract_hevy_hr``).
-2. **Garmin daily passive HR** (wrist monitoring, ~every couple of minutes).
-   Always available if the user wears the watch, but coarser.
+2. **Matched Garmin activity HR** from the watch-recorded FIT file. This is the
+   preferred source for replacement uploads and is typically sampled every
+   second.
+3. **Garmin daily passive HR** (wrist monitoring, ~every couple of minutes).
+   Usually available if the user wears the watch, but coarser.
 
 ``merge_hr_sources`` combines them: the higher-priority source wins wherever it
 has a sample, and the lower-priority source fills the gaps. The result is a
@@ -18,9 +21,18 @@ timestamped ``[{"time": secs_from_start, "hr": bpm}]`` series that
 
 from __future__ import annotations
 
+import io
 import logging
+import zipfile
+from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
+
+_HR_BACKUP_PREFIX = "hr_backup_"
+
+
+class HRBackupError(RuntimeError):
+    """A high-resolution HR series could not be durably backed up."""
 
 
 def extract_hevy_hr(workout: dict) -> list[dict]:
@@ -84,6 +96,239 @@ def fetch_watch_hr(garmin_client, workout: dict, limiter=None) -> list[dict]:
     return samples
 
 
+def fetch_activity_hr(
+    garmin_client,
+    activity_id: int | str,
+    workout: dict,
+    limiter=None,
+) -> list[dict]:
+    """Extract high-resolution HR from a Garmin-recorded activity.
+
+    Garmin's ``ORIGINAL`` activity download is normally a zip containing the
+    device-recorded FIT file.  Record timestamps are converted to offsets from
+    the Hevy workout start so the samples can be embedded in the replacement
+    FIT. Samples outside the Hevy workout window are discarded.
+
+    Returns an empty list on any download or parse failure so callers can fall
+    back to Garmin's coarser daily HR feed.
+    """
+    from garminconnect import Garmin
+    from fit_tool.fit_file import FitFile
+    from fit_tool.profile.messages.record_message import RecordMessage
+    from hevy2garmin.fit import _parse_timestamp
+
+    start_raw = workout.get("start_time") or workout.get("startTime", "")
+    end_raw = workout.get("end_time") or workout.get("endTime", "")
+    start_dt = _parse_timestamp(start_raw)
+    end_dt = _parse_timestamp(end_raw)
+    if not start_dt or not end_dt:
+        return []
+    start_ms = int(start_dt.timestamp() * 1000)
+    end_ms = int(end_dt.timestamp() * 1000)
+
+    try:
+        call = (limiter.call if limiter is not None else (lambda f, *a: f(*a)))
+        downloaded = call(
+            garmin_client.download_activity,
+            str(activity_id),
+            Garmin.ActivityDownloadFormat.ORIGINAL,
+        )
+        if not isinstance(downloaded, bytes) or not downloaded:
+            return []
+
+        fit_bytes = downloaded
+        stream = io.BytesIO(downloaded)
+        if zipfile.is_zipfile(stream):
+            with zipfile.ZipFile(stream) as archive:
+                fit_member = next(
+                    (member for member in archive.infolist() if member.filename.lower().endswith(".fit")),
+                    None,
+                )
+                if fit_member is None:
+                    return []
+                fit_bytes = archive.read(fit_member)
+
+        # Device FIT files can contain fields newer than fit-tool's bundled
+        # profile. They are safely skipped, but fit-tool otherwise emits one
+        # warning per record and floods normal sync output.
+        fit_logger = logging.getLogger("fit_tool")
+        previous_level = fit_logger.level
+        fit_logger.setLevel(logging.ERROR)
+        try:
+            fit_file = FitFile.from_bytes(fit_bytes, check_crc=False)
+        finally:
+            fit_logger.setLevel(previous_level)
+    except Exception as exc:
+        logger.debug("activity HR fetch failed for %s: %s", activity_id, exc)
+        return []
+
+    samples: list[dict] = []
+    for record in fit_file.records:
+        message = record.message
+        if not isinstance(message, RecordMessage):
+            continue
+        timestamp = getattr(message, "timestamp", None)
+        bpm = getattr(message, "heart_rate", None)
+        if timestamp is None or bpm is None:
+            continue
+        try:
+            timestamp_ms = float(timestamp)
+            # Be defensive if a FIT implementation returns Unix seconds rather
+            # than the millisecond representation used by fit-tool.
+            if timestamp_ms < 100_000_000_000:
+                timestamp_ms *= 1000
+            bpm_int = int(bpm)
+        except (TypeError, ValueError):
+            continue
+        if start_ms <= timestamp_ms <= end_ms and 0 < bpm_int < 256:
+            samples.append({
+                "time": max(0.0, (timestamp_ms - start_ms) / 1000.0),
+                "hr": bpm_int,
+            })
+
+    samples.sort(key=lambda sample: sample["time"])
+    return samples
+
+
+def save_hr_backup(
+    database,
+    workout: dict,
+    samples: list[dict],
+    source_activity_id: int | str,
+) -> dict | None:
+    """Persist the best-known activity HR series for later replacements.
+
+    Backups live in the generic durable app-config store rather than the
+    dashboard HR cache. A later coarse import must never overwrite a denser
+    activity recording.
+    """
+    workout_id = workout.get("id")
+    if not workout_id or not samples:
+        return None
+    key = f"{_HR_BACKUP_PREFIX}{workout_id}"
+    existing = database.get_app_config(key)
+    try:
+        existing_count = int((existing or {}).get("sample_count") or 0)
+    except (TypeError, ValueError):
+        existing_count = 0
+    if existing_count >= len(samples):
+        return existing
+
+    payload = {
+        "version": 1,
+        "source": "garmin_activity_fit",
+        "source_activity_id": str(source_activity_id),
+        "workout_start": workout.get("start_time") or workout.get("startTime", ""),
+        "workout_end": workout.get("end_time") or workout.get("endTime", ""),
+        "sample_count": len(samples),
+        "hr_samples": [
+            {"time": float(sample["time"]), "hr": int(sample["hr"])}
+            for sample in samples
+            if sample.get("time") is not None and sample.get("hr") is not None
+        ],
+        "backed_up_at": datetime.now(timezone.utc).isoformat(),
+    }
+    database.set_app_config(key, payload)
+    logger.info(
+        "  HR backup: saved %d samples from Garmin activity %s",
+        len(samples),
+        source_activity_id,
+    )
+    return payload
+
+
+def load_hr_backup(database, workout: dict) -> list[dict]:
+    """Load, rebase, and clip a durable HR backup to the current Hevy window."""
+    from hevy2garmin.fit import _parse_timestamp
+
+    workout_id = workout.get("id")
+    if not workout_id:
+        return []
+    backup = database.get_app_config(f"{_HR_BACKUP_PREFIX}{workout_id}")
+    if not isinstance(backup, dict):
+        return []
+    raw_samples = backup.get("hr_samples")
+    if not isinstance(raw_samples, list):
+        return []
+
+    stored_start = _parse_timestamp(backup.get("workout_start", ""))
+    current_start = _parse_timestamp(
+        workout.get("start_time") or workout.get("startTime", "")
+    )
+    current_end = _parse_timestamp(
+        workout.get("end_time") or workout.get("endTime", "")
+    )
+    shift_s = (
+        (stored_start - current_start).total_seconds()
+        if stored_start is not None and current_start is not None
+        else 0.0
+    )
+    duration_s = (
+        (current_end - current_start).total_seconds()
+        if current_start is not None and current_end is not None
+        else None
+    )
+
+    samples: list[dict] = []
+    for sample in raw_samples:
+        if not isinstance(sample, dict):
+            continue
+        try:
+            rebased_time = float(sample["time"]) + shift_s
+            bpm = int(sample["hr"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        if rebased_time < 0 or (duration_s is not None and rebased_time > duration_s):
+            continue
+        if 0 < bpm < 256:
+            samples.append({"time": rebased_time, "hr": bpm})
+    samples.sort(key=lambda sample: sample["time"])
+    return samples
+
+
+def backup_activity_hr(
+    database,
+    garmin_client,
+    workout: dict,
+    source_activity_id: int | str,
+    limiter=None,
+) -> list[dict]:
+    """Extract and durably save activity HR before any destructive action."""
+    samples = fetch_activity_hr(
+        garmin_client, source_activity_id, workout, limiter
+    )
+    if not samples:
+        return []
+    try:
+        save_hr_backup(database, workout, samples, source_activity_id)
+    except Exception as exc:
+        raise HRBackupError(
+            f"could not back up HR from Garmin activity {source_activity_id}: {exc}"
+        ) from exc
+    protected = load_hr_backup(database, workout)
+    return protected if len(protected) >= len(samples) else samples
+
+
+def require_activity_hr_backup(
+    database,
+    garmin_client,
+    workout: dict,
+    source_activity_id: int | str,
+    limiter=None,
+) -> list[dict]:
+    """Return protected activity HR or stop before the source can be deleted."""
+    protected = backup_activity_hr(
+        database, garmin_client, workout, source_activity_id, limiter
+    )
+    if not protected:
+        protected = load_hr_backup(database, workout)
+    if not protected:
+        raise HRBackupError(
+            f"Garmin activity {source_activity_id} HR could not be extracted and no durable backup exists; source activity preserved"
+        )
+    return protected
+
+
 def merge_hr_sources(
     primary: list[dict] | None,
     secondary: list[dict] | None,
@@ -114,14 +359,42 @@ def merge_hr_sources(
     return [chosen[k] for k in sorted(chosen)]
 
 
-def build_workout_hr(garmin_client, workout: dict, limiter=None) -> list[dict]:
-    """Top-level helper: merged HR for a workout (AirPods-preferred, watch fill)."""
+def build_workout_hr(
+    garmin_client,
+    workout: dict,
+    limiter=None,
+    source_activity_id: int | str | None = None,
+) -> list[dict]:
+    """Top-level helper: merged HR for a workout (Hevy-preferred, watch fill).
+
+    When replacing a matched watch activity, prefer its high-resolution FIT HR.
+    Daily passive HR remains the best-effort fallback for ordinary uploads or
+    when Garmin does not make the original activity downloadable.
+    """
     hevy_hr = extract_hevy_hr(workout)        # AirPods / in-workout (empty today)
-    watch_hr = fetch_watch_hr(garmin_client, workout, limiter)
+    activity_hr = (
+        fetch_activity_hr(garmin_client, source_activity_id, workout, limiter)
+        if source_activity_id is not None
+        else []
+    )
+    if activity_hr:
+        logger.info(
+            "  HR: using %d samples from Garmin activity %s",
+            len(activity_hr),
+            source_activity_id,
+        )
+    watch_hr = activity_hr or fetch_watch_hr(garmin_client, workout, limiter)
     return merge_hr_sources(hevy_hr, watch_hr)
 
 
-def hr_for_sync(db, garmin_client, workout: dict, config: dict, limiter=None) -> list[dict] | None:
+def hr_for_sync(
+    db,
+    garmin_client,
+    workout: dict,
+    config: dict,
+    limiter=None,
+    source_activity_id: int | str | None = None,
+) -> list[dict] | None:
     """Merged HR samples for embedding in a sync's FIT — or None.
 
     Honors the ``hr_fusion.enabled`` toggle, reuses the dashboard's cached HR
@@ -131,11 +404,38 @@ def hr_for_sync(db, garmin_client, workout: dict, config: dict, limiter=None) ->
     if not garmin_client or not config.get("hr_fusion", {}).get("enabled", True):
         return None
     try:
+        # A matched watch recording has much denser, activity-specific HR than
+        # either the dashboard cache or daily monitoring, so always try it first.
+        if source_activity_id is not None:
+            activity_hr = backup_activity_hr(
+                db, garmin_client, workout, source_activity_id, limiter
+            )
+            if activity_hr:
+                logger.info(
+                    "  HR: using %d protected samples for Garmin activity %s",
+                    len(activity_hr),
+                    source_activity_id,
+                )
+                return merge_hr_sources(extract_hevy_hr(workout), activity_hr) or None
+
+        backup_hr = load_hr_backup(db, workout)
+        if backup_hr:
+            logger.info("  HR: restored %d samples from durable backup", len(backup_hr))
+            return merge_hr_sources(extract_hevy_hr(workout), backup_hr) or None
+        if source_activity_id is not None:
+            raise HRBackupError(
+                f"Garmin activity {source_activity_id} HR could not be extracted and no durable backup exists; source activity preserved"
+            )
+
         wid = workout.get("id")
         cached = db.get_cached_hr(wid) if wid else None
         if isinstance(cached, dict) and cached.get("hr_samples"):
             return merge_hr_sources(extract_hevy_hr(workout), cached["hr_samples"]) or None
         return build_workout_hr(garmin_client, workout, limiter) or None
+    except HRBackupError:
+        # A replacement must not proceed to deletion if the only high-resolution
+        # source could not be saved durably.
+        raise
     except Exception:
         logger.debug("HR enrichment skipped for sync", exc_info=True)
         return None

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -309,9 +309,11 @@ def sync_one_workout(
     merge_activity_types = set(cfg.get("merge_activity_types", ["strength_training"]))
     merge_watch_strategy = cfg.get("merge_watch_strategy", "replace")
     description_enabled = cfg.get("description_enabled", True)
+    hr_fusion_on = cfg.get("hr_fusion", {}).get("enabled", True)
 
     merge_forced_fresh = False
     merge_delete_id = None
+    protected_source_hr = None
 
     if merge_mode and garmin_client and not dry_run:
         merge_result = attempt_merge(
@@ -351,16 +353,38 @@ def sync_one_workout(
     else:
         merge_fallback = False
 
-    hr_samples = None
-    hr_fusion_on = cfg.get("hr_fusion", {}).get("enabled", True)
-    if not dry_run and hr_fusion_on:
-        from hevy2garmin.hr import hr_for_sync
+    if merge_delete_id is not None and not dry_run:
+        # Deletion is allowed only after the best-known source HR is durable.
+        # This runs even when HR embedding is disabled: disabling fusion should
+        # not discard the only recoverable high-resolution recording.
+        from hevy2garmin.hr import require_activity_hr_backup
 
-        hr_samples = hr_for_sync(merge_store, garmin_client, workout, cfg, _hr_limiter)
+        protected_source_hr = require_activity_hr_backup(
+            merge_store,
+            garmin_client,
+            workout,
+            merge_delete_id,
+            _hr_limiter,
+        )
+
+    hr_samples = None
+    if not dry_run and hr_fusion_on:
+        from hevy2garmin.hr import extract_hevy_hr, hr_for_sync, merge_hr_sources
+
+        if protected_source_hr:
+            hr_samples = merge_hr_sources(
+                extract_hevy_hr(workout), protected_source_hr
+            ) or None
+        else:
+            hr_samples = hr_for_sync(
+                merge_store, garmin_client, workout, cfg, _hr_limiter
+            )
         if not hr_samples:
             # One retry — the watch's daily HR for this window may not
             # have settled on the first try.
-            hr_samples = hr_for_sync(merge_store, garmin_client, workout, cfg, _hr_limiter)
+            hr_samples = hr_for_sync(
+                merge_store, garmin_client, workout, cfg, _hr_limiter
+            )
 
     with tempfile.TemporaryDirectory() as tmp:
         fit_path = str(Path(tmp) / f"{wid}.fit")
@@ -383,8 +407,13 @@ def sync_one_workout(
 
         existing_id = None
         uploaded = False
+        exclude_ids = [merge_delete_id] if merge_delete_id else None
         if start_time and not force_upload and not merge_forced_fresh:
-            existing_id = find_activity_by_start_time(garmin_client, start_time)
+            existing_id = find_activity_by_start_time(
+                garmin_client,
+                start_time,
+                exclude_activity_ids=exclude_ids,
+            )
 
         if existing_id:
             logger.info("  Activity already on Garmin (%s), skipping upload", existing_id)
@@ -415,7 +444,12 @@ def sync_one_workout(
                 raise
             merge_store.update_pending(wid, pre_upload_ids=snapshot_ids, watch_activity_id=str(merge_delete_id) if merge_delete_id else None, phase="processing", attempt_count=1)
             try:
-                upload_result = upload_fit(garmin_client, fit_path, workout_start=start_time)
+                upload_result = upload_fit(
+                    garmin_client,
+                    fit_path,
+                    workout_start=start_time,
+                    exclude_activity_ids=exclude_ids,
+                )
             except GarminUploadRejected as exc:
                 merge_store.update_pending(wid, phase="failed", last_error=str(exc)[:1000])
                 return SyncOneResult(status="failed", merge_fallback=merge_fallback)

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,6 +11,7 @@ from hevy2garmin.garmin import (
     _sanitize_activity_id,
     find_activity_by_start_time,
     generate_description,
+    upload_fit,
 )
 
 
@@ -95,6 +97,45 @@ class TestFindActivityByStartTime:
             mock_limiter.call.side_effect = Exception("API error")
             result = find_activity_by_start_time(client, "2026-04-01T20:00:00+00:00")
             assert result is None
+
+    def test_excludes_pre_upload_activity(self) -> None:
+        client = MagicMock()
+        acts = self._make_activities(
+            "2026-04-01 20:00:00",
+            "2026-04-01 20:00:02",
+        )
+        with patch("hevy2garmin.garmin._limiter") as mock_limiter:
+            mock_limiter.call.return_value = acts
+            result = find_activity_by_start_time(
+                client,
+                "2026-04-01T20:00:00+00:00",
+                exclude_activity_ids=["1"],
+            )
+            assert result == 2
+
+
+class TestUploadFit:
+    def test_post_upload_lookup_excludes_snapshot_ids(self, tmp_path: Path) -> None:
+        fit_path = tmp_path / "workout.fit"
+        fit_path.write_bytes(b"fit")
+        client = MagicMock()
+        client.upload_activity.return_value = {"detailedImportResult": {"uploadId": "u1"}}
+
+        with patch("hevy2garmin.garmin._limiter") as limiter, patch(
+            "hevy2garmin.garmin.time.sleep"
+        ), patch(
+            "hevy2garmin.garmin.find_activity_by_start_time", return_value=2
+        ) as finder:
+            limiter.call.side_effect = lambda func, *args: func(*args)
+            result = upload_fit(
+                client,
+                fit_path,
+                workout_start="2026-04-01T20:00:00+00:00",
+                exclude_activity_ids=["1"],
+            )
+
+        assert result == {"upload_id": "u1", "activity_id": 2}
+        assert finder.call_args.kwargs["exclude_activity_ids"] == ["1"]
 
 
 class TestGenerateDescription:

--- a/tests/test_hr.py
+++ b/tests/test_hr.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import io
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+import zipfile
 
 import pytest
 
@@ -11,10 +13,16 @@ from fit_tool.fit_file import FitFile
 from fit_tool.profile.messages.record_message import RecordMessage
 
 from hevy2garmin.hr import (
+    HRBackupError,
+    backup_activity_hr,
     build_workout_hr,
     extract_hevy_hr,
+    fetch_activity_hr,
     fetch_watch_hr,
+    hr_for_sync,
+    load_hr_backup,
     merge_hr_sources,
+    save_hr_backup,
 )
 from hevy2garmin.fit import generate_fit
 
@@ -98,6 +106,212 @@ class TestFetchWatchHR:
     def test_missing_timestamps_returns_empty(self):
         client = MagicMock()
         assert fetch_watch_hr(client, {"start_time": "", "end_time": ""}) == []
+
+
+# --- fetch_activity_hr ------------------------------------------------------
+
+class TestFetchActivityHR:
+    WORKOUT = {
+        "title": "Push",
+        "start_time": "2026-03-15T18:00:00+00:00",
+        "end_time": "2026-03-15T18:10:00+00:00",
+        "exercises": [
+            {"title": "Bench Press (Barbell)", "sets": [{"type": "normal", "weight_kg": 60, "reps": 10}]},
+        ],
+    }
+
+    def _zipped_activity(self, tmp_path: Path) -> bytes:
+        fit_path = tmp_path / "activity.fit"
+        generate_fit(
+            self.WORKOUT,
+            hr_samples=[
+                {"time": 0, "hr": 110},
+                {"time": 120, "hr": 130},
+                {"time": 480, "hr": 150},
+            ],
+            output_path=str(fit_path),
+        )
+        output = io.BytesIO()
+        with zipfile.ZipFile(output, "w") as archive:
+            archive.writestr("123_ACTIVITY.fit", fit_path.read_bytes())
+        return output.getvalue()
+
+    def test_extracts_timestamped_hr_from_original_zip(self, tmp_path: Path):
+        client = MagicMock()
+        client.download_activity.return_value = self._zipped_activity(tmp_path)
+
+        samples = fetch_activity_hr(client, 123, self.WORKOUT)
+
+        assert samples == [
+            {"time": 0.0, "hr": 110},
+            {"time": 120.0, "hr": 130},
+            {"time": 480.0, "hr": 150},
+        ]
+
+    def test_falls_back_to_daily_hr_when_original_download_fails(self):
+        client = MagicMock()
+        client.download_activity.side_effect = RuntimeError("not downloadable")
+        import datetime as dt
+        start_ms = int(dt.datetime.fromisoformat(self.WORKOUT["start_time"]).timestamp() * 1000)
+        client.get_heart_rates.return_value = {
+            "heartRateValues": [[start_ms + 60_000, 120]]
+        }
+
+        samples = build_workout_hr(client, self.WORKOUT, source_activity_id=123)
+
+        assert samples == [{"time": 60.0, "hr": 120}]
+
+
+# --- durable HR backup ------------------------------------------------------
+
+class TestHRBackup:
+    WORKOUT = {
+        "id": "w1",
+        "start_time": "2026-03-15T18:00:00+00:00",
+        "end_time": "2026-03-15T18:10:00+00:00",
+    }
+
+    def test_saves_activity_samples_with_source_metadata(self):
+        database = MagicMock()
+        database.get_app_config.return_value = None
+        samples = [{"time": 0.0, "hr": 100}, {"time": 1.0, "hr": 101}]
+
+        payload = save_hr_backup(database, self.WORKOUT, samples, 123)
+
+        assert payload["sample_count"] == 2
+        assert payload["source_activity_id"] == "123"
+        database.set_app_config.assert_called_once()
+        assert database.set_app_config.call_args.args[0] == "hr_backup_w1"
+
+    def test_denser_backup_is_not_overwritten(self):
+        database = MagicMock()
+        existing = {"sample_count": 100, "hr_samples": [{"time": 0, "hr": 90}]}
+        database.get_app_config.return_value = existing
+
+        result = save_hr_backup(
+            database,
+            self.WORKOUT,
+            [{"time": 0, "hr": 100}],
+            456,
+        )
+
+        assert result is existing
+        database.set_app_config.assert_not_called()
+
+    def test_load_rebases_samples_after_hevy_start_edit(self):
+        database = MagicMock()
+        database.get_app_config.return_value = {
+            "workout_start": "2026-03-15T18:00:00+00:00",
+            "sample_count": 2,
+            "hr_samples": [
+                {"time": 30, "hr": 100},
+                {"time": 120, "hr": 110},
+            ],
+        }
+        edited = {
+            **self.WORKOUT,
+            "start_time": "2026-03-15T18:01:00+00:00",
+        }
+
+        samples = load_hr_backup(database, edited)
+
+        # The 18:00:30 sample is before the edited start and is clipped. The
+        # 18:02:00 sample moves from offset 120s to offset 60s.
+        assert samples == [{"time": 60.0, "hr": 110}]
+
+    @patch("hevy2garmin.hr.fetch_activity_hr")
+    def test_hr_for_sync_persists_activity_hr(self, fetch_activity):
+        fetch_activity.return_value = [{"time": 0, "hr": 100}]
+        database = MagicMock()
+        database.get_app_config.return_value = None
+
+        result = hr_for_sync(
+            database,
+            MagicMock(),
+            self.WORKOUT,
+            {"hr_fusion": {"enabled": True}},
+            source_activity_id=123,
+        )
+
+        assert result == [{"time": 0, "hr": 100}]
+        database.set_app_config.assert_called_once()
+
+    @patch("hevy2garmin.hr.fetch_activity_hr", return_value=[])
+    def test_hr_for_sync_restores_backup_when_source_is_gone(self, _fetch):
+        database = MagicMock()
+        database.get_app_config.return_value = {
+            "workout_start": self.WORKOUT["start_time"],
+            "sample_count": 1,
+            "hr_samples": [{"time": 5, "hr": 105}],
+        }
+
+        result = hr_for_sync(
+            database,
+            MagicMock(),
+            self.WORKOUT,
+            {"hr_fusion": {"enabled": True}},
+            source_activity_id=123,
+        )
+
+        assert result == [{"time": 5.0, "hr": 105}]
+
+    @patch("hevy2garmin.hr.fetch_activity_hr", return_value=[])
+    def test_replacement_stops_without_source_hr_or_backup(self, _fetch):
+        database = MagicMock()
+        database.get_app_config.return_value = None
+        database.get_cached_hr.return_value = {
+            "hr_samples": [{"time": 0, "hr": 90}]
+        }
+
+        with pytest.raises(HRBackupError, match="source activity preserved"):
+            hr_for_sync(
+                database,
+                MagicMock(),
+                self.WORKOUT,
+                {"hr_fusion": {"enabled": True}},
+                source_activity_id=123,
+            )
+
+    @patch("hevy2garmin.hr.fetch_activity_hr")
+    def test_hr_for_sync_prefers_denser_backup_over_coarse_download(self, fetch_activity):
+        fetch_activity.return_value = [{"time": 0, "hr": 90}]
+        database = MagicMock()
+        database.get_app_config.return_value = {
+            "workout_start": self.WORKOUT["start_time"],
+            "sample_count": 2,
+            "hr_samples": [
+                {"time": 0, "hr": 100},
+                {"time": 1, "hr": 101},
+            ],
+        }
+
+        result = hr_for_sync(
+            database,
+            MagicMock(),
+            self.WORKOUT,
+            {"hr_fusion": {"enabled": True}},
+            source_activity_id=123,
+        )
+
+        assert result == [
+            {"time": 0.0, "hr": 100},
+            {"time": 1.0, "hr": 101},
+        ]
+
+    @patch("hevy2garmin.hr.fetch_activity_hr")
+    def test_backup_write_failure_is_not_silenced(self, fetch_activity):
+        fetch_activity.return_value = [{"time": 0, "hr": 100}]
+        database = MagicMock()
+        database.get_app_config.return_value = None
+        database.set_app_config.side_effect = RuntimeError("database readonly")
+
+        with pytest.raises(HRBackupError, match="could not back up HR"):
+            backup_activity_hr(
+                database,
+                MagicMock(),
+                self.WORKOUT,
+                source_activity_id=123,
+            )
 
 
 # --- end-to-end: HR actually lands in the FIT -------------------------------

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -349,6 +349,37 @@ class TestSyncOneWorkout:
                 sync_method="merge",
             )
 
+    def test_watch_replacement_requires_backup_even_with_hr_fusion_off(
+        self, sample_workout: dict
+    ) -> None:
+        from hevy2garmin.hr import HRBackupError
+
+        with patch("hevy2garmin.sync.attempt_merge") as mock_merge, patch(
+            "hevy2garmin.hr.require_activity_hr_backup",
+            side_effect=HRBackupError("source activity preserved"),
+        ) as require_backup, patch("hevy2garmin.sync.generate_fit") as generate_fit:
+            mock_merge.return_value = MergeResult(
+                merged=False,
+                force_fresh_upload=True,
+                delete_after_upload=444,
+                fallback_reason="watch replacement",
+            )
+
+            with pytest.raises(HRBackupError, match="source activity preserved"):
+                sync_one_workout(
+                    sample_workout,
+                    cfg={
+                        "merge_mode": True,
+                        "merge_watch_strategy": "replace",
+                        "hr_fusion": {"enabled": False},
+                    },
+                    garmin_client=MagicMock(),
+                    database=MagicMock(),
+                )
+
+        require_backup.assert_called_once()
+        generate_fit.assert_not_called()
+
     def test_description_disabled_skips_set_description(self, sample_workout: dict) -> None:
         with patch("hevy2garmin.sync.db") as mock_db, \
              patch("hevy2garmin.sync.attempt_merge", return_value=MergeResult(merged=False, fallback_reason="No match")), \
@@ -445,7 +476,11 @@ def test_hr_empty_retries_once_then_counts_no_hr(mock_hr, *rest):
     h.get_workouts.return_value = {"workouts": [w], "page_count": 1}
     mock_hevy_cls.return_value = h; mock_gclient.return_value = MagicMock()
     mock_db.is_synced.return_value = False
-    mock_merge.return_value = MergeResult(merged=False, force_fresh_upload=True, fallback_reason="no match")
+    mock_merge.return_value = MergeResult(
+        merged=False,
+        force_fresh_upload=True,
+        fallback_reason="fresh upload",
+    )
     stats = sync(config={"hevy_api_key": "t", "merge_mode": True,
                          "sync": {"grace_period_minutes": 120},
                          "hr_fusion": {"enabled": True}}, limit=1)


### PR DESCRIPTION
still trying to isolated the change from another PR, I had these on one branch locally but it's kinda messy now

## Summary
- Before Replace deletes a watch activity, extract ~1s HR from its ORIGINAL FIT and store a durable backup.
- Embed that hi-res HR into the replacement FIT (preferred over ~2min daily passive HR).
- Abort replacement (keep the watch activity) if HR cannot be backed up; preserve HR across re-sync of tool-created activities.

## Motivation
Replace previously uploaded a named Hevy activity then deleted the watch recording, discarding high-resolution FIT HR in favor of coarse daily HR.

## Notes
Independent of #227 — this PR only contains the hi-res HR / re-sync preservation work against `main`.

## Test plan
- [ ] `pytest tests/test_hr.py tests/test_sync.py tests/test_merge.py tests/test_resync_ui.py`
- [ ] Manual Replace with a watch activity that has FIT HR → replacement shows dense HR
- [ ] Manual: FIT download failure → replacement stops, watch activity retained