### PR TITLE
fix: Python 3.10 ISO timestamp parsing via parse_iso (0.5.18, #229)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.18] - 2026-07-14
+
+### Fixed
+- Python 3.10 compatibility: timestamps with a single fractional-second digit (e.g. `2026-03-15T18:02:00.0`) or a space date/time separator no longer raise `ValueError` on Python 3.10, which the project supports. All ISO-8601 parsing now goes through a shared `parse_iso()` helper that normalizes the fraction width and the `Z`/space separators (previously 15 `datetime.fromisoformat` call sites could fail on 3.10 for such timestamps). (#229)
+
 ## [0.5.17] - 2026-07-13
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hevy2garmin"
-version = "0.5.17"
+version = "0.5.18"
 description = "Sync Hevy gym workouts to Garmin Connect — exercise mapping, FIT file generation, and automatic upload"
 readme = "README.md"
 license = "MIT"

--- a/src/hevy2garmin/_isotime.py
+++ b/src/hevy2garmin/_isotime.py
@@ -1,0 +1,23 @@
+"""ISO-8601 timestamp parsing that behaves the same on Python 3.10 and 3.11+.
+
+``datetime.fromisoformat`` on Python 3.10 only accepts 0, 3, or 6 fractional-second
+digits and requires a ``T`` separator. Garmin/Surfr timestamps can carry a single
+fractional digit (e.g. ``2026-03-15T18:02:00.0+00:00``) or a space separator, which
+parses fine on 3.11+ but raises ``ValueError`` on 3.10. The repo supports 3.10
+(``requires-python >=3.10``), so all timestamp parsing goes through ``parse_iso``.
+"""
+from __future__ import annotations
+
+import re
+from datetime import datetime
+
+_FRAC = re.compile(r"\.(\d+)")
+
+
+def parse_iso(value: str) -> datetime:
+    """Parse an ISO-8601 timestamp, tolerant of a space date/time separator, a
+    trailing ``Z``, and any fractional-second width (padded to 6 digits so 3.10
+    parses it too)."""
+    s = value.replace(" ", "T").replace("Z", "+00:00")
+    s = _FRAC.sub(lambda m: "." + (m.group(1) + "000000")[:6], s)
+    return datetime.fromisoformat(s)

--- a/src/hevy2garmin/db_postgres.py
+++ b/src/hevy2garmin/db_postgres.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime
+from hevy2garmin._isotime import parse_iso
 
 from hevy2garmin.db_interface import Database
 
@@ -11,8 +12,8 @@ from hevy2garmin.db_interface import Database
 def _ts_newer(new_ts: str, old_ts: str) -> bool:
     """Compare ISO timestamps safely (handles Z vs +00:00 differences)."""
     try:
-        new_dt = datetime.fromisoformat(new_ts.replace("Z", "+00:00"))
-        old_dt = datetime.fromisoformat(old_ts.replace("Z", "+00:00"))
+        new_dt = parse_iso(new_ts)
+        old_dt = parse_iso(old_ts)
         return new_dt > old_dt
     except (ValueError, TypeError):
         return new_ts > old_ts  # fallback to string comparison

--- a/src/hevy2garmin/db_sqlite.py
+++ b/src/hevy2garmin/db_sqlite.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from datetime import datetime
+from hevy2garmin._isotime import parse_iso
 from pathlib import Path
 
 from hevy2garmin.db_interface import Database, NoWritableDatabaseError
@@ -13,8 +14,8 @@ from hevy2garmin.db_interface import Database, NoWritableDatabaseError
 def _ts_newer(new_ts: str, old_ts: str) -> bool:
     """Compare ISO timestamps safely (handles Z vs +00:00 differences)."""
     try:
-        new_dt = datetime.fromisoformat(new_ts.replace("Z", "+00:00"))
-        old_dt = datetime.fromisoformat(old_ts.replace("Z", "+00:00"))
+        new_dt = parse_iso(new_ts)
+        old_dt = parse_iso(old_ts)
         return new_dt > old_dt
     except (ValueError, TypeError):
         return new_ts > old_ts

--- a/src/hevy2garmin/fit.py
+++ b/src/hevy2garmin/fit.py
@@ -8,6 +8,7 @@ uploaded to Garmin Connect.
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from hevy2garmin._isotime import parse_iso
 from pathlib import Path
 
 from fit_tool.fit_file_builder import FitFileBuilder
@@ -91,7 +92,7 @@ def _parse_timestamp(raw: str | None) -> datetime | None:
         return None
     try:
         if "T" in cleaned:
-            return datetime.fromisoformat(cleaned.replace("Z", "+00:00"))
+            return parse_iso(cleaned)
         return datetime.strptime(cleaned, "%Y-%m-%d %H:%M:%S").replace(
             tzinfo=timezone.utc
         )

--- a/src/hevy2garmin/garmin.py
+++ b/src/hevy2garmin/garmin.py
@@ -9,6 +9,7 @@ import io
 import logging
 import time
 from pathlib import Path
+from hevy2garmin._isotime import parse_iso
 
 from garminconnect import Garmin
 from garmin_auth import GarminAuth, RateLimiter
@@ -146,7 +147,7 @@ def find_activity_by_start_time(
     from datetime import datetime, timedelta
 
     try:
-        target = datetime.fromisoformat(target_start.replace("Z", "+00:00"))
+        target = parse_iso(target_start)
     except (ValueError, TypeError):
         return None
 
@@ -171,7 +172,7 @@ def find_activity_by_start_time(
         try:
             if "T" not in act_start_str:
                 act_start_str = act_start_str.replace(" ", "T")
-            act_start = datetime.fromisoformat(act_start_str)
+            act_start = parse_iso(act_start_str)
             act_naive = act_start.replace(tzinfo=None) if act_start.tzinfo else act_start
             if abs((act_naive - target_naive).total_seconds()) < window_minutes * 60:
                 return act.get("activityId")
@@ -245,8 +246,8 @@ def find_matching_garmin_activity(
         return None
 
     try:
-        hevy_start = datetime.fromisoformat(start_raw.replace("Z", "+00:00"))
-        hevy_end = datetime.fromisoformat(end_raw.replace("Z", "+00:00"))
+        hevy_start = parse_iso(start_raw)
+        hevy_end = parse_iso(end_raw)
     except (ValueError, TypeError):
         return None
 
@@ -282,7 +283,7 @@ def find_matching_garmin_activity(
         try:
             if "T" not in act_start_str:
                 act_start_str = act_start_str.replace(" ", "T")
-            act_start = datetime.fromisoformat(act_start_str)
+            act_start = parse_iso(act_start_str)
             if act_start.tzinfo is None:
                 act_start = act_start.replace(tzinfo=timezone.utc)
         except (ValueError, TypeError):
@@ -358,8 +359,8 @@ def generate_description(workout: dict, calories: int | None = None, avg_hr: int
         from datetime import datetime
         try:
             fmt = "%Y-%m-%dT%H:%M:%S%z" if "T" in start else "%Y-%m-%d %H:%M:%S"
-            t0 = datetime.fromisoformat(start.replace("Z", "+00:00"))
-            t1 = datetime.fromisoformat(end.replace("Z", "+00:00"))
+            t0 = parse_iso(start)
+            t1 = parse_iso(end)
             duration_s = int((t1 - t0).total_seconds())
         except Exception:
             pass

--- a/src/hevy2garmin/matcher.py
+++ b/src/hevy2garmin/matcher.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 import time as _time
 from datetime import datetime, timedelta
+from hevy2garmin._isotime import parse_iso
 
 from garminconnect import Garmin
 
@@ -92,7 +93,7 @@ def _parse_time(raw: str) -> datetime | None:
         cleaned = raw.replace("Z", "+00:00")
         if "T" not in cleaned:
             cleaned = cleaned.replace(" ", "T")
-        return datetime.fromisoformat(cleaned)
+        return parse_iso(cleaned)
     except (ValueError, TypeError):
         return None
 

--- a/src/hevy2garmin/merge.py
+++ b/src/hevy2garmin/merge.py
@@ -15,6 +15,7 @@ import logging
 import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from hevy2garmin._isotime import parse_iso
 
 from hevy2garmin.garmin import (
     find_matching_garmin_activity,
@@ -263,7 +264,7 @@ def build_exercise_sets_payload(
     start_str = activity_start_time.replace(" ", "T")
     if "+" not in start_str and not start_str.endswith("Z"):
         start_str += "+00:00"
-    act_start = datetime.fromisoformat(start_str.replace("Z", "+00:00"))
+    act_start = parse_iso(start_str)
 
     exercises = hevy_workout.get("exercises", [])
     if not exercises:

--- a/src/hevy2garmin/ratelimit.py
+++ b/src/hevy2garmin/ratelimit.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta, timezone
+from hevy2garmin._isotime import parse_iso
 
 logger = logging.getLogger("hevy2garmin")
 
@@ -53,7 +54,7 @@ def cooldown_remaining(db) -> int:
     if not state or not state.get("until"):
         return 0
     try:
-        until = datetime.fromisoformat(state["until"])
+        until = parse_iso(state["until"])
     except Exception:
         return 0
     remaining = (until - _now()).total_seconds()

--- a/tests/test_isotime.py
+++ b/tests/test_isotime.py
@@ -1,0 +1,39 @@
+"""parse_iso must behave identically on Python 3.10 and 3.11+ (#229).
+
+Python 3.10's datetime.fromisoformat only accepts 0/3/6 fractional-second digits
+and a 'T' separator; Garmin/Surfr timestamps can have a single fractional digit or
+a space separator. parse_iso normalizes both.
+"""
+from datetime import datetime, timezone
+
+from hevy2garmin._isotime import parse_iso
+
+
+def test_single_digit_fraction():
+    # The exact case that raised ValueError on 3.10 (surfaced by PR #228).
+    dt = parse_iso("2026-03-15T18:02:00.0+00:00")
+    assert dt == datetime(2026, 3, 15, 18, 2, 0, tzinfo=timezone.utc)
+
+
+def test_various_fractional_widths():
+    assert parse_iso("2026-03-15T18:02:00.5+00:00").microsecond == 500000
+    assert parse_iso("2026-03-15T18:02:00.123+00:00").microsecond == 123000
+    assert parse_iso("2026-03-15T18:02:00.123456+00:00").microsecond == 123456
+    # more than 6 digits is truncated to 6, not rejected
+    assert parse_iso("2026-03-15T18:02:00.1234567+00:00").microsecond == 123456
+
+
+def test_no_fraction():
+    assert parse_iso("2026-03-15T18:02:00+00:00") == datetime(2026, 3, 15, 18, 2, tzinfo=timezone.utc)
+
+
+def test_space_separator_and_z():
+    # Garmin often uses a space separator and a Z suffix.
+    dt = parse_iso("2026-03-15 18:02:00Z")
+    assert dt == datetime(2026, 3, 15, 18, 2, tzinfo=timezone.utc)
+
+
+def test_naive_when_no_offset():
+    # No offset -> naive datetime (unchanged behavior).
+    dt = parse_iso("2026-03-15T18:02:00")
+    assert dt.tzinfo is None


### PR DESCRIPTION
Closes #229.

`datetime.fromisoformat` on **Python 3.10** (repo supports `>=3.10`) only accepts 0/3/6 fractional-second digits and a `T` separator. Garmin/Surfr timestamps can carry a single fractional digit (`2026-03-15T18:02:00.0`) or a space separator, which raises `ValueError` on 3.10 but parses fine on 3.11+.

Pre-existing bug at **15 call sites** (merge, garmin, fit, matcher, ratelimit, db_postgres, db_sqlite). Surfaced by a new test in #228 that hits `merge.py` and failed only on the 3.10 CI matrix.

Fix: shared `_isotime.parse_iso()` (normalizes fraction width + `Z`/space), used at all 15 sites. This unblocks #228's 3.10 CI after rebase.

Tests: new `test_isotime.py` (5) + full suite **294 passed** on Python 3.10 (the previously-broken version). Ships as 0.5.18.