### PR TITLE
chore(ts): widen garmin-auth peer to any 0.x

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,24 +1,24 @@
 {
   "name": "hevy2garmin",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hevy2garmin",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@garmin/fitsdk": "^21.0.0"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
-        "garmin-auth": "^0.2.0",
+        "garmin-auth": "^0.3.0",
         "typescript": "^5.6.0",
         "vitest": "^2.0.0"
       },
       "peerDependencies": {
-        "garmin-auth": "^0.1.0 || ^0.2.0",
+        "garmin-auth": ">=0.1.0 <1.0.0",
         "pg": "^8.0.0"
       },
       "peerDependenciesMeta": {
@@ -1110,9 +1110,9 @@
       }
     },
     "node_modules/garmin-auth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/garmin-auth/-/garmin-auth-0.2.0.tgz",
-      "integrity": "sha512-/9ttpLoyBDEje/UthtbDhipIhrfoen7FgEISL5n67KlgzoiaLLdMtkN7PnVSgyA7xFAqjixXa0KyZi0aKfB3XA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/garmin-auth/-/garmin-auth-0.3.0.tgz",
+      "integrity": "sha512-Ijdb4/gkw9wPUSHLZUPD7/lcHqs3uQ455fTz9nAZSLAyC/A2JJBP0CQdVcRd8yDFslGxY+gcV4mfDjbej5yumg==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hevy2garmin",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Sync Hevy workouts to Garmin Connect (TypeScript). FIT generation, exercise mapping, and upload. The TS twin of the Python hevy2garmin.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -10,7 +10,7 @@
   "license": "MIT",
   "repository": { "type": "git", "url": "github:drkostas/hevy2garmin", "directory": "typescript" },
   "dependencies": { "@garmin/fitsdk": "^21.0.0" },
-  "peerDependencies": { "garmin-auth": "^0.1.0 || ^0.2.0", "pg": "^8.0.0" },
+  "peerDependencies": { "garmin-auth": ">=0.1.0 <1.0.0", "pg": "^8.0.0" },
   "peerDependenciesMeta": { "garmin-auth": { "optional": true }, "pg": { "optional": true } },
-  "devDependencies": { "typescript": "^5.6.0", "vitest": "^2.0.0", "@types/node": "^20.0.0", "garmin-auth": "^0.2.0" }
+  "devDependencies": { "typescript": "^5.6.0", "vitest": "^2.0.0", "@types/node": "^20.0.0", "garmin-auth": "^0.3.0" }
 }


### PR DESCRIPTION
garmin-auth is pre-1.0 and adds methods in minor bumps (0.2 `post`, 0.3 `put`/`postForm`) without breaking consumers. Widen the optional peer to `>=0.1.0 <1.0.0` so future garmin-auth minors don't force another peer republish. Build + tests green. Bumps 0.1.3.