### PR TITLE
feat(routines): sync Hevy routines to Garmin as planned workouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ venv/
 .env.*
 !.env.example
 
+# Local Garmin workout dumps from scripts/dump_garmin_workout.py (personal data)
+manual.json
+sync.json
+*.workout.json
+
 # IDE
 .idea/
 .vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 - The watch-activity **Replace** strategy now extracts high-resolution heart-rate samples from the original Garmin FIT and embeds them in the named Hevy replacement before deleting the watch copy. If the source cannot be extracted or restored from backup, replacement stops and preserves the original activity.
+- Sync Hevy routines to Garmin as planned workouts. Maps routine exercises to Garmin workout-service exercise IDs (validated against a real Garmin export), adds timed rest steps between sets, and supports per-routine scheduling (one-off and recurring weekly). Re-sync is checksum-based with a `--force` override, the sync summary reports created vs updated separately, and the dashboard gains a routines page plus a home-screen summary.
 
 ## [0.5.19] - 2026-07-14
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hevy2garmin"
-version = "0.5.19"
+version = "0.5.20"
 description = "Sync Hevy gym workouts to Garmin Connect — exercise mapping, FIT file generation, and automatic upload"
 readme = "README.md"
 license = "MIT"

--- a/scripts/dump_garmin_workout.py
+++ b/scripts/dump_garmin_workout.py
@@ -1,0 +1,122 @@
+"""Dump a Garmin planned-workout as JSON to reverse-engineer /workout-service.
+
+The Hevy→Garmin *routine* sync (``hevy2garmin.routine``) builds the workout
+payload from IDs discovered by reverse engineering — sportType, stepType,
+endCondition, weightUnit, and whether ``weightValue`` is kg or grams. This
+read-only script fetches a REAL workout from your Garmin account so those
+constants can be confirmed against ground truth.
+
+Recommended: create one strength workout by hand in Garmin Connect (a warmup set
+plus two working sets with reps and weight), then dump it and compare its steps
+to the constants in ``src/hevy2garmin/routine.py``.
+
+Credentials come from a ``.env`` file (GARMIN_EMAIL / GARMIN_PASSWORD, and
+optionally DATABASE_URL to reuse the same Postgres token store as your
+deployment). See ``.env.example``. Real environment variables take precedence
+over the file.
+
+Usage:
+
+    PYTHONPATH=src python scripts/dump_garmin_workout.py --list
+    PYTHONPATH=src python scripts/dump_garmin_workout.py --id 123456789
+    PYTHONPATH=src python scripts/dump_garmin_workout.py --id 123456789 -o out.json
+    PYTHONPATH=src python scripts/dump_garmin_workout.py --env path/to/.env --list
+
+Nothing is created, scheduled, or deleted — only GET requests are made.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+from hevy2garmin.config import load_config
+from hevy2garmin.garmin import get_client
+
+# Repo root = parent of this script's directory, so `.env` resolves whether the
+# script is run from the repo root or elsewhere.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_dotenv(path: str | None) -> None:
+    """Load KEY=VALUE pairs from a .env file into os.environ.
+
+    A tiny parser so the script needs no python-dotenv dependency. Skips blank
+    lines and comments, strips optional surrounding quotes, and never overrides
+    a variable already set in the real environment.
+    """
+    candidates = [Path(path)] if path else [Path.cwd() / ".env", _REPO_ROOT / ".env"]
+    env_file = next((p for p in candidates if p.is_file()), None)
+    if env_file is None:
+        if path:
+            sys.exit(f"env file not found: {path}")
+        return
+    print(f"Loading env from {env_file}", file=sys.stderr)
+    for raw in env_file.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key and key not in os.environ:
+            os.environ[key] = value
+
+
+def _client():
+    cfg = load_config()
+    return get_client(
+        cfg.get("garmin_email"),
+        cfg.get("garmin_password", ""),
+        cfg.get("garmin_token_dir", "~/.garminconnect"),
+    )
+
+
+def cmd_list(client) -> None:
+    workouts = client.get_workouts() or []
+    if not workouts:
+        print("No saved workouts found in this Garmin account.")
+        return
+    print(f"{'workoutId':>14}  name")
+    print("-" * 40)
+    for w in workouts:
+        sport = (w.get("sportType") or {}).get("sportTypeKey", "?")
+        print(f"{str(w.get('workoutId', '?')):>14}  {w.get('workoutName', '?')}  [{sport}]")
+
+
+def cmd_dump(client, workout_id: str, out_path: str | None) -> None:
+    data = client.get_workout_by_id(workout_id)
+    text = json.dumps(data, indent=2, ensure_ascii=False)
+    if out_path:
+        with open(out_path, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        print(f"Wrote {len(text)} bytes to {out_path}")
+    print(text)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--list", action="store_true", help="List saved workouts (id + name)")
+    parser.add_argument("--id", help="workoutId to dump as JSON")
+    parser.add_argument("-o", "--out", help="Also write the JSON to this file")
+    parser.add_argument("--env", help="Path to a .env file (default: ./.env or repo root)")
+    args = parser.parse_args()
+
+    if not args.list and not args.id:
+        parser.error("pass --list or --id <workoutId>")
+
+    _load_dotenv(args.env)
+    print("Authenticating with Garmin Connect...", file=sys.stderr)
+    client = _client()
+
+    if args.list:
+        cmd_list(client)
+    if args.id:
+        cmd_dump(client, args.id, args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/hevy2garmin/cli.py
+++ b/src/hevy2garmin/cli.py
@@ -11,7 +11,7 @@ import sys
 from hevy2garmin import db
 from hevy2garmin.config import is_configured, load_config, save_config
 from hevy2garmin.mapper import save_custom_mapping
-from hevy2garmin.sync import sync
+from hevy2garmin.sync import sync, sync_routines
 
 
 def _not_configured_message() -> str:
@@ -129,6 +129,43 @@ def cmd_sync(args: argparse.Namespace) -> None:
     print(f"\n✓ Sync complete: {result['synced']} synced, {result['skipped']} skipped, {result['failed']} failed")
     if result.get("unmapped"):
         print(f"  ⚠ {len(result['unmapped'])} unmapped exercises — run: hevy2garmin unmapped")
+    if result["failed"] > 0:
+        sys.exit(1)
+
+
+def cmd_sync_routines(args: argparse.Namespace) -> None:
+    """Sync Hevy routines to Garmin as planned workouts."""
+    _require_config(args)
+
+    if args.list:
+        cfg = load_config()
+        from hevy2garmin.hevy import HevyClient
+        hevy = HevyClient(api_key=args.hevy_api_key or cfg.get("hevy_api_key"))
+        for r in hevy.get_routines(page=1, page_size=args.limit or 10).get("routines", []):
+            synced = "✓" if db.get_synced_routine(r["id"]) else " "
+            n = len(r.get("exercises", []))
+            print(f"  [{synced}] {r.get('title', '?')} ({n} exercises)")
+        return
+
+    overrides = {}
+    if args.hevy_api_key:
+        overrides["hevy_api_key"] = args.hevy_api_key
+    if args.garmin_email:
+        overrides["garmin_email"] = args.garmin_email
+    if args.garmin_password:
+        overrides["garmin_password"] = args.garmin_password
+
+    result = sync_routines(
+        dry_run=args.dry_run,
+        schedule_date=args.date,
+        **overrides,
+    )
+
+    print(
+        f"\n✓ Routine sync complete: {result['created']} created, "
+        f"{result['skipped']} skipped, {result['failed']} failed"
+        + (f", {result['scheduled']} scheduled" if result.get("scheduled") else "")
+    )
     if result["failed"] > 0:
         sys.exit(1)
 
@@ -331,6 +368,15 @@ def main() -> None:
     sync_parser.add_argument("--all", action="store_true", help="Sync entire history")
     sync_parser.add_argument("--dry-run", action="store_true", help="Generate FIT files without uploading")
 
+    # sync-routines
+    routines_parser = subparsers.add_parser(
+        "sync-routines", help="Sync Hevy routines to Garmin as planned workouts"
+    )
+    routines_parser.add_argument("--dry-run", action="store_true", help="Build payloads without calling Garmin")
+    routines_parser.add_argument("--date", help="Also schedule workouts on this date (YYYY-MM-DD)")
+    routines_parser.add_argument("--list", action="store_true", help="List Hevy routines and their sync status")
+    routines_parser.add_argument("-n", "--limit", type=int, help="Number of routines to list with --list")
+
     # status
     subparsers.add_parser("status", help="Show sync status")
 
@@ -390,6 +436,7 @@ def main() -> None:
         commands = {
             "init": cmd_init,
             "sync": cmd_sync,
+            "sync-routines": cmd_sync_routines,
             "status": cmd_status,
             "list": cmd_list,
             "unmapped": cmd_unmapped,

--- a/src/hevy2garmin/cli.py
+++ b/src/hevy2garmin/cli.py
@@ -166,7 +166,7 @@ def cmd_sync_routines(args: argparse.Namespace) -> None:
 
     print(
         f"\n✓ Routine sync complete: {result['created']} created, "
-        f"{result['skipped']} skipped, {result['failed']} failed"
+        f"{result['updated']} updated, {result['skipped']} skipped, {result['failed']} failed"
         + (f", {result['scheduled']} scheduled" if result.get("scheduled") else "")
     )
     if result["failed"] > 0:

--- a/src/hevy2garmin/cli.py
+++ b/src/hevy2garmin/cli.py
@@ -160,6 +160,7 @@ def cmd_sync_routines(args: argparse.Namespace) -> None:
     result = sync_routines(
         dry_run=args.dry_run,
         schedule_date=args.date,
+        force=args.force,
         **overrides,
     )
 
@@ -375,6 +376,7 @@ def main() -> None:
         "sync-routines", help="Sync Hevy routines to Garmin as planned workouts"
     )
     routines_parser.add_argument("--dry-run", action="store_true", help="Build payloads without calling Garmin")
+    routines_parser.add_argument("--force", action="store_true", help="Re-create even routines already synced (deletes & recreates)")
     routines_parser.add_argument("--date", help="Also schedule workouts on this date (YYYY-MM-DD)")
     routines_parser.add_argument("--list", action="store_true", help="List Hevy routines and their sync status")
     routines_parser.add_argument("-n", "--limit", type=int, help="Number of routines to list with --list")

--- a/src/hevy2garmin/cli.py
+++ b/src/hevy2garmin/cli.py
@@ -141,7 +141,9 @@ def cmd_sync_routines(args: argparse.Namespace) -> None:
         cfg = load_config()
         from hevy2garmin.hevy import HevyClient
         hevy = HevyClient(api_key=args.hevy_api_key or cfg.get("hevy_api_key"))
-        for r in hevy.get_routines(page=1, page_size=args.limit or 10).get("routines", []):
+        # Hevy caps /v1/routines at pageSize 10 — larger values return HTTP 400.
+        page_size = min(args.limit or 10, 10)
+        for r in hevy.get_routines(page=1, page_size=page_size).get("routines", []):
             synced = "✓" if db.get_synced_routine(r["id"]) else " "
             n = len(r.get("exercises", []))
             print(f"  [{synced}] {r.get('title', '?')} ({n} exercises)")

--- a/src/hevy2garmin/db.py
+++ b/src/hevy2garmin/db.py
@@ -118,6 +118,11 @@ def get_recent_synced_routines(limit: int = 5, **kw) -> list[dict]:
     return get_db().get_recent_synced_routines(limit)
 
 
+def get_synced_routine(hevy_routine_id: str, **kw) -> dict | None:
+    """Get a single synced-routine record (used by `sync-routines --list`)."""
+    return get_db().get_synced_routine(hevy_routine_id)
+
+
 def record_sync_log(
     synced: int = 0,
     skipped: int = 0,

--- a/src/hevy2garmin/db.py
+++ b/src/hevy2garmin/db.py
@@ -108,6 +108,16 @@ def get_recent_synced(limit: int = 10, **kw) -> list[dict]:
     return get_db().get_recent_synced(limit)
 
 
+def get_routine_stats(**kw) -> dict:
+    """Get routine sync counts: {"synced": int, "scheduled": int}."""
+    return get_db().get_routine_stats()
+
+
+def get_recent_synced_routines(limit: int = 5, **kw) -> list[dict]:
+    """Get recently synced routines, newest first."""
+    return get_db().get_recent_synced_routines(limit)
+
+
 def record_sync_log(
     synced: int = 0,
     skipped: int = 0,

--- a/src/hevy2garmin/db_interface.py
+++ b/src/hevy2garmin/db_interface.py
@@ -132,3 +132,27 @@ class Database(ABC):
     @abstractmethod
     def get_terminal_counts(self) -> dict[str, int]:
         """Return uploaded, manual, skipped, and total terminal counts."""
+
+    # ── Routine → Garmin planned-workout tracking ───────────────────────────
+    @abstractmethod
+    def get_synced_routine(self, hevy_routine_id: str) -> dict | None:
+        """Return the sync record for a Hevy routine, or None if never synced."""
+
+    @abstractmethod
+    def is_routine_synced(self, hevy_routine_id: str, hevy_updated_at: str | None = None) -> bool:
+        """True if the routine was synced and (if given) not edited on Hevy since."""
+
+    @abstractmethod
+    def mark_routine_synced(
+        self,
+        hevy_routine_id: str,
+        garmin_workout_id: str | None = None,
+        title: str = "",
+        hevy_updated_at: str | None = None,
+        scheduled_date: str | None = None,
+    ) -> None:
+        """Record a routine synced to a Garmin planned workout."""
+
+    @abstractmethod
+    def delete_synced_routine(self, hevy_routine_id: str) -> bool:
+        """Remove a routine sync record. Returns True if a record was deleted."""

--- a/src/hevy2garmin/db_interface.py
+++ b/src/hevy2garmin/db_interface.py
@@ -150,6 +150,7 @@ class Database(ABC):
         title: str = "",
         hevy_updated_at: str | None = None,
         scheduled_date: str | None = None,
+        content_hash: str | None = None,
     ) -> None:
         """Record a routine synced to a Garmin planned workout."""
 

--- a/src/hevy2garmin/db_interface.py
+++ b/src/hevy2garmin/db_interface.py
@@ -157,3 +157,11 @@ class Database(ABC):
     @abstractmethod
     def delete_synced_routine(self, hevy_routine_id: str) -> bool:
         """Remove a routine sync record. Returns True if a record was deleted."""
+
+    @abstractmethod
+    def get_routine_stats(self) -> dict:
+        """Return routine sync counts: ``{"synced": int, "scheduled": int}``."""
+
+    @abstractmethod
+    def get_recent_synced_routines(self, limit: int = 5) -> list[dict]:
+        """Return recently synced routines, newest first."""

--- a/src/hevy2garmin/db_postgres.py
+++ b/src/hevy2garmin/db_postgres.py
@@ -126,6 +126,17 @@ class PostgresDatabase(Database):
                         updated_at TIMESTAMPTZ DEFAULT NOW()
                     )
                 """)
+                cur.execute("""
+                    CREATE TABLE IF NOT EXISTS synced_routines (
+                        hevy_routine_id TEXT PRIMARY KEY,
+                        garmin_workout_id TEXT,
+                        title TEXT,
+                        hevy_updated_at TEXT,
+                        scheduled_date TEXT,
+                        synced_at TIMESTAMPTZ DEFAULT NOW(),
+                        status VARCHAR(20) DEFAULT 'success'
+                    )
+                """)
             conn.commit()
 
     def is_synced(self, hevy_id: str) -> bool:
@@ -155,6 +166,64 @@ class PostgresDatabase(Database):
                 )
                 row = cur.fetchone()
                 return row["garmin_activity_id"] if row else None
+
+    # ── Routine → Garmin planned-workout tracking ───────────────────────────
+    def get_synced_routine(self, hevy_routine_id: str) -> dict | None:
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT hevy_routine_id, garmin_workout_id, title, hevy_updated_at, "
+                    "scheduled_date, synced_at, status FROM synced_routines "
+                    "WHERE hevy_routine_id = %s",
+                    (hevy_routine_id,),
+                )
+                row = cur.fetchone()
+                return dict(row) if row else None
+
+    def is_routine_synced(self, hevy_routine_id: str, hevy_updated_at: str | None = None) -> bool:
+        record = self.get_synced_routine(hevy_routine_id)
+        if record is None:
+            return False
+        if hevy_updated_at and record.get("hevy_updated_at"):
+            return not _ts_newer(hevy_updated_at, record["hevy_updated_at"])
+        return True
+
+    def mark_routine_synced(
+        self,
+        hevy_routine_id: str,
+        garmin_workout_id: str | None = None,
+        title: str = "",
+        hevy_updated_at: str | None = None,
+        scheduled_date: str | None = None,
+    ) -> None:
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO synced_routines
+                        (hevy_routine_id, garmin_workout_id, title, hevy_updated_at, scheduled_date, status)
+                    VALUES (%s, %s, %s, %s, %s, 'success')
+                    ON CONFLICT (hevy_routine_id) DO UPDATE SET
+                        garmin_workout_id = EXCLUDED.garmin_workout_id,
+                        title = EXCLUDED.title,
+                        hevy_updated_at = EXCLUDED.hevy_updated_at,
+                        scheduled_date = EXCLUDED.scheduled_date,
+                        synced_at = NOW(),
+                        status = 'success'
+                    """,
+                    (hevy_routine_id, garmin_workout_id, title, hevy_updated_at, scheduled_date),
+                )
+            conn.commit()
+
+    def delete_synced_routine(self, hevy_routine_id: str) -> bool:
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM synced_routines WHERE hevy_routine_id = %s", (hevy_routine_id,)
+                )
+                deleted = cur.rowcount > 0
+            conn.commit()
+            return deleted
 
     def mark_synced(
         self,

--- a/src/hevy2garmin/db_postgres.py
+++ b/src/hevy2garmin/db_postgres.py
@@ -133,10 +133,12 @@ class PostgresDatabase(Database):
                         title TEXT,
                         hevy_updated_at TEXT,
                         scheduled_date TEXT,
+                        content_hash TEXT,
                         synced_at TIMESTAMPTZ DEFAULT NOW(),
                         status VARCHAR(20) DEFAULT 'success'
                     )
                 """)
+                cur.execute("ALTER TABLE synced_routines ADD COLUMN IF NOT EXISTS content_hash TEXT")
             conn.commit()
 
     def is_synced(self, hevy_id: str) -> bool:
@@ -173,7 +175,7 @@ class PostgresDatabase(Database):
             with conn.cursor() as cur:
                 cur.execute(
                     "SELECT hevy_routine_id, garmin_workout_id, title, hevy_updated_at, "
-                    "scheduled_date, synced_at, status FROM synced_routines "
+                    "scheduled_date, content_hash, synced_at, status FROM synced_routines "
                     "WHERE hevy_routine_id = %s",
                     (hevy_routine_id,),
                 )
@@ -195,23 +197,25 @@ class PostgresDatabase(Database):
         title: str = "",
         hevy_updated_at: str | None = None,
         scheduled_date: str | None = None,
+        content_hash: str | None = None,
     ) -> None:
         with self._get_conn() as conn:
             with conn.cursor() as cur:
                 cur.execute(
                     """
                     INSERT INTO synced_routines
-                        (hevy_routine_id, garmin_workout_id, title, hevy_updated_at, scheduled_date, status)
-                    VALUES (%s, %s, %s, %s, %s, 'success')
+                        (hevy_routine_id, garmin_workout_id, title, hevy_updated_at, scheduled_date, content_hash, status)
+                    VALUES (%s, %s, %s, %s, %s, %s, 'success')
                     ON CONFLICT (hevy_routine_id) DO UPDATE SET
                         garmin_workout_id = EXCLUDED.garmin_workout_id,
                         title = EXCLUDED.title,
                         hevy_updated_at = EXCLUDED.hevy_updated_at,
                         scheduled_date = EXCLUDED.scheduled_date,
+                        content_hash = EXCLUDED.content_hash,
                         synced_at = NOW(),
                         status = 'success'
                     """,
-                    (hevy_routine_id, garmin_workout_id, title, hevy_updated_at, scheduled_date),
+                    (hevy_routine_id, garmin_workout_id, title, hevy_updated_at, scheduled_date, content_hash),
                 )
             conn.commit()
 

--- a/src/hevy2garmin/db_postgres.py
+++ b/src/hevy2garmin/db_postgres.py
@@ -229,6 +229,25 @@ class PostgresDatabase(Database):
             conn.commit()
             return deleted
 
+    def get_routine_stats(self) -> dict:
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT COUNT(*) AS synced, COUNT(scheduled_date) AS scheduled FROM synced_routines"
+                )
+                row = cur.fetchone()
+                return {"synced": row["synced"] or 0, "scheduled": row["scheduled"] or 0}
+
+    def get_recent_synced_routines(self, limit: int = 5) -> list[dict]:
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT hevy_routine_id, title, scheduled_date, garmin_workout_id, synced_at "
+                    "FROM synced_routines ORDER BY synced_at DESC LIMIT %s",
+                    (limit,),
+                )
+                return [dict(r) for r in cur.fetchall()]
+
     def mark_synced(
         self,
         hevy_id: str,

--- a/src/hevy2garmin/db_sqlite.py
+++ b/src/hevy2garmin/db_sqlite.py
@@ -129,10 +129,16 @@ class SQLiteDatabase(Database):
                 title TEXT,
                 hevy_updated_at TEXT,
                 scheduled_date TEXT,
+                content_hash TEXT,
                 synced_at TEXT DEFAULT (datetime('now')),
                 status TEXT DEFAULT 'success'
             )
         """)
+        # Migration: add content_hash to routine tables created before it existed.
+        try:
+            conn.execute("ALTER TABLE synced_routines ADD COLUMN content_hash TEXT")
+        except Exception:
+            pass  # Column already exists
         conn.commit()
         return conn
 
@@ -158,7 +164,7 @@ class SQLiteDatabase(Database):
         conn = self._get_conn()
         row = conn.execute(
             "SELECT hevy_routine_id, garmin_workout_id, title, hevy_updated_at, "
-            "scheduled_date, synced_at, status FROM synced_routines "
+            "scheduled_date, content_hash, synced_at, status FROM synced_routines "
             "WHERE hevy_routine_id = ?",
             (hevy_routine_id,),
         ).fetchone()
@@ -166,7 +172,7 @@ class SQLiteDatabase(Database):
         if row is None:
             return None
         keys = ("hevy_routine_id", "garmin_workout_id", "title", "hevy_updated_at",
-                "scheduled_date", "synced_at", "status")
+                "scheduled_date", "content_hash", "synced_at", "status")
         return dict(zip(keys, row))
 
     def is_routine_synced(self, hevy_routine_id: str, hevy_updated_at: str | None = None) -> bool:
@@ -185,22 +191,24 @@ class SQLiteDatabase(Database):
         title: str = "",
         hevy_updated_at: str | None = None,
         scheduled_date: str | None = None,
+        content_hash: str | None = None,
     ) -> None:
         conn = self._get_conn()
         conn.execute(
             """
             INSERT INTO synced_routines
-                (hevy_routine_id, garmin_workout_id, title, hevy_updated_at, scheduled_date, status)
-            VALUES (?, ?, ?, ?, ?, 'success')
+                (hevy_routine_id, garmin_workout_id, title, hevy_updated_at, scheduled_date, content_hash, status)
+            VALUES (?, ?, ?, ?, ?, ?, 'success')
             ON CONFLICT(hevy_routine_id) DO UPDATE SET
                 garmin_workout_id = excluded.garmin_workout_id,
                 title = excluded.title,
                 hevy_updated_at = excluded.hevy_updated_at,
                 scheduled_date = excluded.scheduled_date,
+                content_hash = excluded.content_hash,
                 synced_at = datetime('now'),
                 status = 'success'
             """,
-            (hevy_routine_id, garmin_workout_id, title, hevy_updated_at, scheduled_date),
+            (hevy_routine_id, garmin_workout_id, title, hevy_updated_at, scheduled_date, content_hash),
         )
         conn.commit()
         conn.close()

--- a/src/hevy2garmin/db_sqlite.py
+++ b/src/hevy2garmin/db_sqlite.py
@@ -122,6 +122,17 @@ class SQLiteDatabase(Database):
                 updated_at TEXT DEFAULT (datetime('now'))
             )
         """)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS synced_routines (
+                hevy_routine_id TEXT PRIMARY KEY,
+                garmin_workout_id TEXT,
+                title TEXT,
+                hevy_updated_at TEXT,
+                scheduled_date TEXT,
+                synced_at TEXT DEFAULT (datetime('now')),
+                status TEXT DEFAULT 'success'
+            )
+        """)
         conn.commit()
         return conn
 
@@ -141,6 +152,68 @@ class SQLiteDatabase(Database):
         ).fetchone()
         conn.close()
         return row[0] if row else None
+
+    # ── Routine → Garmin planned-workout tracking ───────────────────────────
+    def get_synced_routine(self, hevy_routine_id: str) -> dict | None:
+        conn = self._get_conn()
+        row = conn.execute(
+            "SELECT hevy_routine_id, garmin_workout_id, title, hevy_updated_at, "
+            "scheduled_date, synced_at, status FROM synced_routines "
+            "WHERE hevy_routine_id = ?",
+            (hevy_routine_id,),
+        ).fetchone()
+        conn.close()
+        if row is None:
+            return None
+        keys = ("hevy_routine_id", "garmin_workout_id", "title", "hevy_updated_at",
+                "scheduled_date", "synced_at", "status")
+        return dict(zip(keys, row))
+
+    def is_routine_synced(self, hevy_routine_id: str, hevy_updated_at: str | None = None) -> bool:
+        record = self.get_synced_routine(hevy_routine_id)
+        if record is None:
+            return False
+        if hevy_updated_at and record.get("hevy_updated_at"):
+            # Edited on Hevy since last sync → treat as not synced (re-create).
+            return not _ts_newer(hevy_updated_at, record["hevy_updated_at"])
+        return True
+
+    def mark_routine_synced(
+        self,
+        hevy_routine_id: str,
+        garmin_workout_id: str | None = None,
+        title: str = "",
+        hevy_updated_at: str | None = None,
+        scheduled_date: str | None = None,
+    ) -> None:
+        conn = self._get_conn()
+        conn.execute(
+            """
+            INSERT INTO synced_routines
+                (hevy_routine_id, garmin_workout_id, title, hevy_updated_at, scheduled_date, status)
+            VALUES (?, ?, ?, ?, ?, 'success')
+            ON CONFLICT(hevy_routine_id) DO UPDATE SET
+                garmin_workout_id = excluded.garmin_workout_id,
+                title = excluded.title,
+                hevy_updated_at = excluded.hevy_updated_at,
+                scheduled_date = excluded.scheduled_date,
+                synced_at = datetime('now'),
+                status = 'success'
+            """,
+            (hevy_routine_id, garmin_workout_id, title, hevy_updated_at, scheduled_date),
+        )
+        conn.commit()
+        conn.close()
+
+    def delete_synced_routine(self, hevy_routine_id: str) -> bool:
+        conn = self._get_conn()
+        cur = conn.execute(
+            "DELETE FROM synced_routines WHERE hevy_routine_id = ?", (hevy_routine_id,)
+        )
+        deleted = cur.rowcount > 0
+        conn.commit()
+        conn.close()
+        return deleted
 
     def mark_synced(
         self,

--- a/src/hevy2garmin/db_sqlite.py
+++ b/src/hevy2garmin/db_sqlite.py
@@ -223,6 +223,25 @@ class SQLiteDatabase(Database):
         conn.close()
         return deleted
 
+    def get_routine_stats(self) -> dict:
+        conn = self._get_conn()
+        row = conn.execute(
+            "SELECT COUNT(*), COUNT(scheduled_date) FROM synced_routines"
+        ).fetchone()
+        conn.close()
+        return {"synced": row[0] or 0, "scheduled": row[1] or 0}
+
+    def get_recent_synced_routines(self, limit: int = 5) -> list[dict]:
+        conn = self._get_conn()
+        rows = conn.execute(
+            "SELECT hevy_routine_id, title, scheduled_date, garmin_workout_id, synced_at "
+            "FROM synced_routines ORDER BY synced_at DESC LIMIT ?",
+            (limit,),
+        ).fetchall()
+        conn.close()
+        keys = ("hevy_routine_id", "title", "scheduled_date", "garmin_workout_id", "synced_at")
+        return [dict(zip(keys, r)) for r in rows]
+
     def mark_synced(
         self,
         hevy_id: str,

--- a/src/hevy2garmin/garmin.py
+++ b/src/hevy2garmin/garmin.py
@@ -398,6 +398,61 @@ def push_exercise_sets(client: Garmin, activity_id: int, payload: dict) -> None:
     logger.info("  Pushed %d exercise sets to activity %s", len(payload.get("exerciseSets", [])), activity_id)
 
 
+def create_workout(client: Garmin, payload: dict) -> int | None:
+    """Create a planned workout in the Garmin Connect Workouts library.
+
+    POSTs to the undocumented /workout-service/workout endpoint — the same one
+    the Garmin Connect web UI uses to save a workout. Unlike upload_fit(), this
+    creates a *plan* (a reusable template shown under Training > Workouts), not a
+    completed activity. Returns the new workoutId, or None if absent.
+
+    Called directly (not through _limiter) so the JSON response body — which
+    carries the workoutId — is returned verbatim; the limiter is tuned for the
+    activity endpoints' 204s.
+    """
+    time.sleep(1.0)  # manual rate limit
+    resp = client.client.request(
+        "POST", "connectapi", "/workout-service/workout", json=payload
+    )
+    data = resp.json() if hasattr(resp, "json") else resp
+    workout_id = data.get("workoutId") if isinstance(data, dict) else None
+    logger.info("  Created Garmin workout %s ('%s')", workout_id, payload.get("workoutName"))
+    return workout_id
+
+
+def list_workouts(client: Garmin, limit: int = 100) -> list[dict]:
+    """List the user's saved Garmin workouts (for idempotency / reconciliation)."""
+    time.sleep(1.0)  # manual rate limit
+    resp = client.client.request(
+        "GET",
+        "connectapi",
+        f"/workout-service/workouts?start=1&limit={limit}&myWorkoutsOnly=true",
+    )
+    data = resp.json() if hasattr(resp, "json") else resp
+    return data if isinstance(data, list) else []
+
+
+def delete_workout(client: Garmin, workout_id: int | str) -> None:
+    """Delete a saved Garmin workout (used to recreate one after a routine edit)."""
+    time.sleep(1.0)  # manual rate limit
+    client.client.request(
+        "DELETE", "connectapi", f"/workout-service/workout/{workout_id}"
+    )
+    logger.info("  Deleted Garmin workout %s", workout_id)
+
+
+def schedule_workout(client: Garmin, workout_id: int | str, date: str) -> None:
+    """Schedule a saved Garmin workout onto the calendar for ``date`` (YYYY-MM-DD)."""
+    time.sleep(1.0)  # manual rate limit
+    client.client.request(
+        "POST",
+        "connectapi",
+        f"/workout-service/schedule/{workout_id}",
+        json={"date": date},
+    )
+    logger.info("  Scheduled Garmin workout %s for %s", workout_id, date)
+
+
 def generate_description(workout: dict, calories: int | None = None, avg_hr: int | None = None) -> str:
     """Generate a text description for a gym workout."""
     lines: list[str] = []

--- a/src/hevy2garmin/mapper.py
+++ b/src/hevy2garmin/mapper.py
@@ -729,3 +729,68 @@ def lookup_exercise(hevy_name: str, template_id: str | None = None) -> tuple[int
     if pair is not None:
         return (pair[0], pair[1], hevy_name)
     return (_UNKNOWN_CATEGORY, _UNKNOWN_SUBCATEGORY, hevy_name)
+
+
+# --------------------------------------------------------------------------- #
+# FIT numeric IDs  ->  Garmin Connect workout-API strings
+#
+# The Garmin /workout-service API identifies a strength step by string enums
+# (``category`` = "BENCH_PRESS", ``exerciseName`` = "BARBELL_BENCH_PRESS")
+# rather than the numeric (category, subcategory) pair used inside a FIT file.
+# Those strings are exactly the member names of the FIT SDK exercise enums that
+# fit-tool (already a dependency) ships, so we derive them instead of hand-
+# maintaining a second table.  ``ExerciseCategory`` maps the category int to its
+# name; a per-category ``*ExerciseName`` enum maps the subcategory int.
+# --------------------------------------------------------------------------- #
+
+# category int -> the fit-tool *ExerciseName enum class for its subcategories.
+# Built by turning each ExerciseCategory member name (e.g. "OLYMPIC_LIFT") into
+# the matching class name ("OlympicLiftExerciseName") — the same convention the
+# FIT SDK uses — so it stays correct if the SDK adds categories.
+def _build_category_exercise_enum() -> dict[int, type]:
+    from fit_tool.profile.profile_type import ExerciseCategory  # local import: heavy module
+    import fit_tool.profile.profile_type as _pt
+
+    mapping: dict[int, type] = {}
+    for member in ExerciseCategory:
+        if member.value in (_UNKNOWN_CATEGORY, 65535):
+            continue
+        class_name = member.name.title().replace("_", "") + "ExerciseName"
+        enum_cls = getattr(_pt, class_name, None)
+        if enum_cls is not None:
+            mapping[member.value] = enum_cls
+    return mapping
+
+
+_CATEGORY_EXERCISE_ENUM: dict[int, type] | None = None
+
+
+def fit_exercise_strings(category: int, subcategory: int) -> tuple[str | None, str | None]:
+    """Translate FIT numeric ``(category, subcategory)`` to Garmin API strings.
+
+    Returns ``(category_str, exercise_name_str)`` where each is the FIT SDK enum
+    member name (e.g. ``("BENCH_PRESS", "BARBELL_BENCH_PRESS")``). Either element
+    is ``None`` when it cannot be resolved — the sentinel ``UNKNOWN`` category, a
+    subcategory outside the enum, or an SDK gap — so callers can fall back to a
+    generic step with a custom name instead of sending an invalid enum.
+    """
+    global _CATEGORY_EXERCISE_ENUM
+    if category == _UNKNOWN_CATEGORY:
+        return (None, None)
+
+    try:
+        from fit_tool.profile.profile_type import ExerciseCategory
+        category_str = ExerciseCategory(category).name
+    except (ValueError, ImportError):
+        return (None, None)
+
+    if _CATEGORY_EXERCISE_ENUM is None:
+        _CATEGORY_EXERCISE_ENUM = _build_category_exercise_enum()
+
+    enum_cls = _CATEGORY_EXERCISE_ENUM.get(category)
+    if enum_cls is None:
+        return (category_str, None)
+    try:
+        return (category_str, enum_cls(subcategory).name)
+    except ValueError:
+        return (category_str, None)

--- a/src/hevy2garmin/routine.py
+++ b/src/hevy2garmin/routine.py
@@ -23,11 +23,26 @@ step per set instead, which is equally valid and preserves per-set weights.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 
 from hevy2garmin.mapper import fit_exercise_strings, lookup_exercise
 
 logger = logging.getLogger("hevy2garmin")
+
+
+def workout_content_hash(payload: dict) -> str:
+    """Stable SHA-256 of a Garmin workout payload, for change detection.
+
+    Hashing the *generated payload* (not the raw Hevy routine) means the hash
+    changes both when the routine's exercises/sets change AND when this builder
+    changes how it emits steps (e.g. adding rest steps). That lets ``sync_routines``
+    re-create a workout whenever its content would differ, without relying on
+    Hevy's ``updated_at`` or a manual ``--force``.
+    """
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 # --- Garmin workout-service enums (validated against a real export 2026-07-16) #
 SPORT_TYPE_STRENGTH = {"sportTypeId": 5, "sportTypeKey": "strength_training"}

--- a/src/hevy2garmin/routine.py
+++ b/src/hevy2garmin/routine.py
@@ -1,0 +1,131 @@
+"""Build a Garmin Connect planned-workout payload from a Hevy routine.
+
+A Hevy *routine* is a template (a plan of exercises/sets/reps), not a logged
+session, so it maps to a Garmin **planned workout** in the Training/Workouts
+library — not to an uploaded activity. This module converts a routine dict from
+``GET /v1/routines`` into the JSON body accepted by Garmin's
+``POST /workout-service/workout`` endpoint.
+
+The payload shape is reverse-engineered (Garmin does not publish this API). The
+numeric IDs below (``sportType``, ``stepType``, ``endCondition``, ``weightUnit``)
+should be confirmed against a real strength workout exported from Garmin Connect
+before relying on them in production — see the plan's "spike" step. The exercise
+``category``/``exerciseName`` strings come from :func:`mapper.fit_exercise_strings`,
+which derives them from the FIT SDK enums fit-tool ships.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from hevy2garmin.mapper import fit_exercise_strings, lookup_exercise
+
+logger = logging.getLogger("hevy2garmin")
+
+# --- Reverse-engineered Garmin workout-service enums (confirm via spike) ----- #
+SPORT_TYPE_STRENGTH = {"sportTypeId": 5, "sportTypeKey": "strength_training"}
+
+# stepType: warmup sets vs. working sets.
+_STEP_TYPE_WARMUP = {"stepTypeId": 1, "stepTypeKey": "warmup"}
+_STEP_TYPE_INTERVAL = {"stepTypeId": 3, "stepTypeKey": "interval"}
+
+# endCondition: how a step ends.
+_END_REPS = {"conditionTypeId": 10, "conditionTypeKey": "reps"}
+_END_TIME = {"conditionTypeId": 2, "conditionTypeKey": "time"}
+_END_LAP_BUTTON = {"conditionTypeId": 1, "conditionTypeKey": "lap.button"}
+
+_WEIGHT_UNIT_KG = {"unitId": 8, "unitKey": "kilogram"}
+_WEIGHT_UNIT_LB = {"unitId": 7, "unitKey": "pound"}
+_KG_TO_LB = 2.2046226218
+
+
+def _weight_fields(set_data: dict, weight_unit: str) -> dict:
+    """Weight fields for a step, or empty when the set has no weight."""
+    weight_kg = set_data.get("weight_kg")
+    if weight_kg is None:
+        return {}
+    if weight_unit == "pound":
+        return {"weightValue": round(weight_kg * _KG_TO_LB, 2), "weightUnit": _WEIGHT_UNIT_LB}
+    return {"weightValue": float(weight_kg), "weightUnit": _WEIGHT_UNIT_KG}
+
+
+def _build_step(
+    order: int,
+    set_data: dict,
+    exercise_title: str,
+    category_str: str | None,
+    exercise_name_str: str | None,
+    weight_unit: str,
+) -> dict:
+    """Build one ``ExecutableStepDTO`` for a single Hevy set."""
+    is_warmup = (set_data.get("type") or "").lower() == "warmup"
+    step: dict = {
+        "type": "ExecutableStepDTO",
+        "stepOrder": order,
+        "stepType": _STEP_TYPE_WARMUP if is_warmup else _STEP_TYPE_INTERVAL,
+    }
+
+    reps = set_data.get("reps")
+    duration = set_data.get("duration_seconds")
+    if reps is not None:
+        step["endCondition"] = _END_REPS
+        step["endConditionValue"] = float(reps)
+    elif duration is not None:
+        step["endCondition"] = _END_TIME
+        step["endConditionValue"] = float(duration)
+    else:
+        step["endCondition"] = _END_LAP_BUTTON
+
+    # Garmin identifies the strength exercise by string enums. When we can't map
+    # it, fall back to a named step so the user still sees the exercise.
+    if category_str is not None:
+        step["category"] = category_str
+    if exercise_name_str is not None:
+        step["exerciseName"] = exercise_name_str
+    if exercise_name_str is None:
+        step["stepName"] = exercise_title
+
+    step.update(_weight_fields(set_data, weight_unit))
+    return step
+
+
+def routine_to_garmin_workout(routine: dict, *, weight_unit: str = "kilogram") -> dict:
+    """Convert a Hevy routine into a Garmin ``/workout-service/workout`` body.
+
+    ``weight_unit`` is ``"kilogram"`` (default) or ``"pound"``; Hevy always
+    stores ``weight_kg`` so pounds are converted. Exercises that don't map to a
+    known FIT category become generic named steps (logged via ``UNKNOWN`` count).
+    """
+    exercises = routine.get("exercises") or []
+    steps: list[dict] = []
+    unknown = 0
+    order = 1
+    for exercise in exercises:
+        title = exercise.get("title") or exercise.get("name") or "Exercise"
+        template_id = exercise.get("exercise_template_id")
+        category, subcategory, _ = lookup_exercise(title, template_id)
+        category_str, exercise_name_str = fit_exercise_strings(category, subcategory)
+        if category_str is None:
+            unknown += 1
+        for set_data in exercise.get("sets") or []:
+            steps.append(
+                _build_step(order, set_data, title, category_str, exercise_name_str, weight_unit)
+            )
+            order += 1
+
+    name = routine.get("title") or routine.get("name") or "Hevy Routine"
+    if unknown:
+        logger.info("  Routine '%s': %d exercise(s) had no Garmin mapping", name, unknown)
+
+    return {
+        "workoutName": name,
+        "description": (routine.get("notes") or "Synced from Hevy").strip()[:1024],
+        "sportType": SPORT_TYPE_STRENGTH,
+        "workoutSegments": [
+            {
+                "segmentOrder": 1,
+                "sportType": SPORT_TYPE_STRENGTH,
+                "workoutSteps": steps,
+            }
+        ],
+    }

--- a/src/hevy2garmin/routine.py
+++ b/src/hevy2garmin/routine.py
@@ -8,10 +8,17 @@ library — not to an uploaded activity. This module converts a routine dict fro
 
 The payload shape is reverse-engineered (Garmin does not publish this API). The
 numeric IDs below (``sportType``, ``stepType``, ``endCondition``, ``weightUnit``)
-should be confirmed against a real strength workout exported from Garmin Connect
-before relying on them in production — see the plan's "spike" step. The exercise
+were **validated on 2026-07-16** by diffing a workout created by this builder
+against a strength workout hand-authored in Garmin Connect (via
+``client.get_workout_by_id``): Garmin accepted and stored every field verbatim,
+and ``weightValue`` is in **kilograms** (not grams). Garmin fills in
+``weightUnit.factor`` and ``targetType`` itself, so we omit them. The exercise
 ``category``/``exerciseName`` strings come from :func:`mapper.fit_exercise_strings`,
 which derives them from the FIT SDK enums fit-tool ships.
+
+Note: Garmin's own UI collapses identical consecutive sets into a
+``RepeatGroupDTO`` with a rest step; this builder emits one flat ``interval``
+step per set instead, which is equally valid and preserves per-set weights.
 """
 
 from __future__ import annotations
@@ -22,7 +29,7 @@ from hevy2garmin.mapper import fit_exercise_strings, lookup_exercise
 
 logger = logging.getLogger("hevy2garmin")
 
-# --- Reverse-engineered Garmin workout-service enums (confirm via spike) ----- #
+# --- Garmin workout-service enums (validated against a real export 2026-07-16) #
 SPORT_TYPE_STRENGTH = {"sportTypeId": 5, "sportTypeKey": "strength_training"}
 
 # stepType: warmup sets vs. working sets.

--- a/src/hevy2garmin/routine.py
+++ b/src/hevy2garmin/routine.py
@@ -32,9 +32,10 @@ logger = logging.getLogger("hevy2garmin")
 # --- Garmin workout-service enums (validated against a real export 2026-07-16) #
 SPORT_TYPE_STRENGTH = {"sportTypeId": 5, "sportTypeKey": "strength_training"}
 
-# stepType: warmup sets vs. working sets.
+# stepType: warmup sets vs. working sets vs. rest between sets.
 _STEP_TYPE_WARMUP = {"stepTypeId": 1, "stepTypeKey": "warmup"}
 _STEP_TYPE_INTERVAL = {"stepTypeId": 3, "stepTypeKey": "interval"}
+_STEP_TYPE_REST = {"stepTypeId": 5, "stepTypeKey": "rest"}
 
 # endCondition: how a step ends.
 _END_REPS = {"conditionTypeId": 10, "conditionTypeKey": "reps"}
@@ -96,12 +97,33 @@ def _build_step(
     return step
 
 
-def routine_to_garmin_workout(routine: dict, *, weight_unit: str = "kilogram") -> dict:
+def _rest_step(order: int, rest_seconds: int) -> dict:
+    """Build a timed rest step (stepType ``rest``, ends after ``rest_seconds``)."""
+    return {
+        "type": "ExecutableStepDTO",
+        "stepOrder": order,
+        "stepType": _STEP_TYPE_REST,
+        "endCondition": _END_TIME,
+        "endConditionValue": float(rest_seconds),
+    }
+
+
+def routine_to_garmin_workout(
+    routine: dict,
+    *,
+    weight_unit: str = "kilogram",
+    default_rest_seconds: int | None = None,
+) -> dict:
     """Convert a Hevy routine into a Garmin ``/workout-service/workout`` body.
 
     ``weight_unit`` is ``"kilogram"`` (default) or ``"pound"``; Hevy always
     stores ``weight_kg`` so pounds are converted. Exercises that don't map to a
     known FIT category become generic named steps (logged via ``UNKNOWN`` count).
+
+    A timed ``rest`` step is inserted *between* consecutive sets of an exercise
+    (never after its last set). The duration is the exercise's Hevy
+    ``rest_seconds``; when Hevy omits it, ``default_rest_seconds`` is used, and
+    if that is also falsy no rest steps are added.
     """
     exercises = routine.get("exercises") or []
     steps: list[dict] = []
@@ -114,11 +136,21 @@ def routine_to_garmin_workout(routine: dict, *, weight_unit: str = "kilogram") -
         category_str, exercise_name_str = fit_exercise_strings(category, subcategory)
         if category_str is None:
             unknown += 1
-        for set_data in exercise.get("sets") or []:
+
+        rest_seconds = exercise.get("rest_seconds")
+        if rest_seconds is None:
+            rest_seconds = default_rest_seconds
+
+        sets = exercise.get("sets") or []
+        for i, set_data in enumerate(sets):
             steps.append(
                 _build_step(order, set_data, title, category_str, exercise_name_str, weight_unit)
             )
             order += 1
+            # Rest goes between sets of the same exercise, not after the last one.
+            if rest_seconds and i < len(sets) - 1:
+                steps.append(_rest_step(order, rest_seconds))
+                order += 1
 
     name = routine.get("title") or routine.get("name") or "Hevy Routine"
     if unknown:

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -22,7 +22,7 @@ from hevy2garmin.auth import auth_enabled, verify_session, sign_session, check_p
 from hevy2garmin.config import is_configured, load_config, save_config
 from hevy2garmin.demo import is_demo_mode
 from hevy2garmin.ratelimit import record_rate_limit, cooldown_remaining, clear_rate_limit, format_cooldown
-from hevy2garmin.sync import sync
+from hevy2garmin.sync import sync, sync_routines
 
 logger = logging.getLogger("hevy2garmin")
 
@@ -1291,6 +1291,55 @@ async def api_sync(request: Request):
     _last_sync_time = datetime.now(timezone.utc)
     _record_sync_log(result, trigger=f"manual ({scope})")
     return _render("partials/sync_result.html", result=result)
+
+
+@app.get("/routines", response_class=HTMLResponse)
+async def routines_page(request: Request):
+    """List Hevy routines and their sync status."""
+    config = load_config()
+    routines: list[dict] = []
+    fetch_error = None
+    try:
+        from hevy2garmin.hevy import HevyClient
+
+        _db = db.get_db()
+        data = HevyClient(api_key=config.get("hevy_api_key")).get_routines(page=1, page_size=100)
+        for r in data.get("routines", []):
+            routines.append({
+                "title": r.get("title") or r.get("name") or "Routine",
+                "exercise_count": len(r.get("exercises", [])),
+                "synced": _db.get_synced_routine(r.get("id", "")) is not None,
+            })
+    except Exception as e:
+        fetch_error = str(e)
+    return _render("routines.html", request=request, routines=routines, fetch_error=fetch_error)
+
+
+@app.post("/api/routines/sync", response_class=HTMLResponse)
+async def api_routines_sync(request: Request):
+    """Create Garmin planned workouts from all Hevy routines."""
+    if is_demo_mode():
+        return HTMLResponse('<div class="toast toast-success">Sync disabled in demo mode.</div>')
+
+    form = await request.form()
+    schedule_date = (form.get("date") or "").strip() or None
+
+    if not _acquire_sync_lock():
+        return HTMLResponse('<div class="toast toast-error">Another sync is already running. Please wait.</div>')
+
+    try:
+        result = sync_routines(dry_run=False, schedule_date=schedule_date)
+    except Exception as e:
+        return HTMLResponse(f'<div class="toast toast-error">Routine sync failed: {e}</div>')
+    finally:
+        _sync_executing.release()
+
+    msg = (
+        f"{result['created']} created, {result['skipped']} skipped, {result['failed']} failed"
+        + (f", {result['scheduled']} scheduled" if result.get("scheduled") else "")
+    )
+    cls = "toast-error" if result["failed"] else "toast-success"
+    return HTMLResponse(f'<div class="toast {cls}">Routine sync complete: {msg}</div>')
 
 
 @app.post("/api/sync/{workout_id}", response_class=HTMLResponse)

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -485,7 +485,7 @@ async def dashboard(request: Request):
         if isinstance(cached_total, dict) and isinstance(cached_total.get("count"), int):
             routines_pending = max(0, cached_total["count"] - routine_stats["synced"])
     except Exception:
-        pass
+        logger.warning("Could not build routine summary for dashboard", exc_info=True)
 
     return _render(
         "dashboard.html",
@@ -1318,16 +1318,12 @@ async def routines_page(request: Request):
     fetch_error = None
     try:
         from hevy2garmin.hevy import HevyClient
-        from hevy2garmin.sync import fetch_all_routines
+        from hevy2garmin.sync import fetch_all_routines, _cache_routines_total
 
         _db = db.get_db()
         hevy = HevyClient(api_key=config.get("hevy_api_key"))
         all_routines = fetch_all_routines(hevy)
-        # Cache the total so the dashboard can show "pending" without a Hevy call.
-        try:
-            _db.set_app_config("routines_total", {"count": len(all_routines)})
-        except Exception:
-            pass
+        _cache_routines_total(_db, len(all_routines))
         for r in all_routines:
             record = _db.get_synced_routine(r.get("id", ""))
             routines.append({
@@ -1337,8 +1333,9 @@ async def routines_page(request: Request):
                 "synced": record is not None,
                 "scheduled_date": (record or {}).get("scheduled_date"),
             })
-    except Exception as e:
-        fetch_error = str(e)
+    except Exception:
+        logger.exception("Failed to load Hevy routines")
+        fetch_error = "Could not load routines from Hevy. Check your API key and try again."
     return _render("routines.html", request=request, routines=routines, fetch_error=fetch_error)
 
 
@@ -1356,8 +1353,9 @@ async def api_routines_sync(request: Request):
 
     try:
         result = sync_routines(dry_run=False, force=force)
-    except Exception as e:
-        return HTMLResponse(f'<div class="toast toast-error">Routine sync failed: {e}</div>')
+    except Exception:
+        logger.exception("Routine sync failed")
+        return HTMLResponse('<div class="toast toast-error">Routine sync failed. Check the logs for details.</div>')
     finally:
         _sync_executing.release()
 
@@ -1396,8 +1394,9 @@ async def api_routine_schedule(request: Request, hevy_routine_id: str):
         result = schedule_routine(hevy_routine_id, dates)
     except ValueError as e:
         return HTMLResponse(f'<div class="toast toast-error">{e}</div>')
-    except Exception as e:
-        return HTMLResponse(f'<div class="toast toast-error">Scheduling failed: {e}</div>')
+    except Exception:
+        logger.exception("Scheduling routine %s failed", hevy_routine_id)
+        return HTMLResponse('<div class="toast toast-error">Scheduling failed. Check the logs for details.</div>')
     finally:
         _sync_executing.release()
 

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -22,7 +22,7 @@ from hevy2garmin.auth import auth_enabled, verify_session, sign_session, check_p
 from hevy2garmin.config import is_configured, load_config, save_config
 from hevy2garmin.demo import is_demo_mode
 from hevy2garmin.ratelimit import record_rate_limit, cooldown_remaining, clear_rate_limit, format_cooldown
-from hevy2garmin.sync import sync, sync_routines
+from hevy2garmin.sync import sync, sync_routines, routine_schedule_dates, schedule_routine
 
 logger = logging.getLogger("hevy2garmin")
 
@@ -1306,10 +1306,13 @@ async def routines_page(request: Request):
         _db = db.get_db()
         hevy = HevyClient(api_key=config.get("hevy_api_key"))
         for r in fetch_all_routines(hevy):
+            record = _db.get_synced_routine(r.get("id", ""))
             routines.append({
+                "id": r.get("id", ""),
                 "title": r.get("title") or r.get("name") or "Routine",
                 "exercise_count": len(r.get("exercises", [])),
-                "synced": _db.get_synced_routine(r.get("id", "")) is not None,
+                "synced": record is not None,
+                "scheduled_date": (record or {}).get("scheduled_date"),
             })
     except Exception as e:
         fetch_error = str(e)
@@ -1343,6 +1346,44 @@ async def api_routines_sync(request: Request):
     )
     cls = "toast-error" if result["failed"] else "toast-success"
     return HTMLResponse(f'<div class="toast {cls}">Routine sync complete: {msg}</div>')
+
+
+@app.post("/api/routines/{hevy_routine_id}/schedule", response_class=HTMLResponse)
+async def api_routine_schedule(request: Request, hevy_routine_id: str):
+    """Schedule one synced routine on the Garmin calendar (once or recurring weekly)."""
+    if is_demo_mode():
+        return HTMLResponse('<div class="toast toast-success">Scheduling disabled in demo mode.</div>')
+
+    form = await request.form()
+    mode = form.get("mode", "once")
+    try:
+        dates = routine_schedule_dates(
+            mode,
+            date=form.get("date"),
+            weekday=form.get("weekday"),
+            start_date=form.get("start_date"),
+            weeks=form.get("weeks"),
+        )
+    except (ValueError, TypeError) as e:
+        return HTMLResponse(f'<div class="toast toast-error">Invalid schedule: {e}</div>')
+
+    if not _acquire_sync_lock():
+        return HTMLResponse('<div class="toast toast-error">Another sync is already running. Please wait.</div>')
+
+    try:
+        result = schedule_routine(hevy_routine_id, dates)
+    except ValueError as e:
+        return HTMLResponse(f'<div class="toast toast-error">{e}</div>')
+    except Exception as e:
+        return HTMLResponse(f'<div class="toast toast-error">Scheduling failed: {e}</div>')
+    finally:
+        _sync_executing.release()
+
+    n = result["scheduled"]
+    span = f" ({result['dates'][0]} → {result['dates'][-1]})" if n > 1 else f" on {result['dates'][0]}"
+    return HTMLResponse(
+        f'<div class="toast toast-success">Scheduled {n} session(s){span}.</div>'
+    )
 
 
 @app.post("/api/sync/{workout_id}", response_class=HTMLResponse)

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -473,8 +473,25 @@ async def dashboard(request: Request):
     except Exception:
         pass
 
+    # Routine summary — all DB-backed (no Hevy call). "pending" needs the total
+    # routine count, cached by the /routines page and by routine sync.
+    routine_stats = {"synced": 0, "scheduled": 0}
+    recent_routines: list = []
+    routines_pending = None
+    try:
+        routine_stats = db.get_routine_stats()
+        recent_routines = db.get_recent_synced_routines(5)
+        cached_total = db.get_app_config("routines_total")
+        if isinstance(cached_total, dict) and isinstance(cached_total.get("count"), int):
+            routines_pending = max(0, cached_total["count"] - routine_stats["synced"])
+    except Exception:
+        pass
+
     return _render(
         "dashboard.html",
+        routine_stats=routine_stats,
+        recent_routines=recent_routines,
+        routines_pending=routines_pending,
         synced_count=synced_count,
         matched_count=matched_count,
         terminal_count=terminal_count,
@@ -1305,7 +1322,13 @@ async def routines_page(request: Request):
 
         _db = db.get_db()
         hevy = HevyClient(api_key=config.get("hevy_api_key"))
-        for r in fetch_all_routines(hevy):
+        all_routines = fetch_all_routines(hevy)
+        # Cache the total so the dashboard can show "pending" without a Hevy call.
+        try:
+            _db.set_app_config("routines_total", {"count": len(all_routines)})
+        except Exception:
+            pass
+        for r in all_routines:
             record = _db.get_synced_routine(r.get("id", ""))
             routines.append({
                 "id": r.get("id", ""),

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -1337,7 +1337,8 @@ async def api_routines_sync(request: Request):
         _sync_executing.release()
 
     msg = (
-        f"{result['created']} created, {result['skipped']} skipped, {result['failed']} failed"
+        f"{result['created']} created, {result['updated']} updated, "
+        f"{result['skipped']} skipped, {result['failed']} failed"
         + (f", {result['scheduled']} scheduled" if result.get("scheduled") else "")
     )
     cls = "toast-error" if result["failed"] else "toast-success"

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -1324,12 +1324,13 @@ async def api_routines_sync(request: Request):
 
     form = await request.form()
     schedule_date = (form.get("date") or "").strip() or None
+    force = form.get("force") in ("1", "true", "on")
 
     if not _acquire_sync_lock():
         return HTMLResponse('<div class="toast toast-error">Another sync is already running. Please wait.</div>')
 
     try:
-        result = sync_routines(dry_run=False, schedule_date=schedule_date)
+        result = sync_routines(dry_run=False, schedule_date=schedule_date, force=force)
     except Exception as e:
         return HTMLResponse(f'<div class="toast toast-error">Routine sync failed: {e}</div>')
     finally:

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -1301,10 +1301,11 @@ async def routines_page(request: Request):
     fetch_error = None
     try:
         from hevy2garmin.hevy import HevyClient
+        from hevy2garmin.sync import fetch_all_routines
 
         _db = db.get_db()
-        data = HevyClient(api_key=config.get("hevy_api_key")).get_routines(page=1, page_size=100)
-        for r in data.get("routines", []):
+        hevy = HevyClient(api_key=config.get("hevy_api_key"))
+        for r in fetch_all_routines(hevy):
             routines.append({
                 "title": r.get("title") or r.get("name") or "Routine",
                 "exercise_count": len(r.get("exercises", [])),

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -1326,14 +1326,13 @@ async def api_routines_sync(request: Request):
         return HTMLResponse('<div class="toast toast-success">Sync disabled in demo mode.</div>')
 
     form = await request.form()
-    schedule_date = (form.get("date") or "").strip() or None
     force = form.get("force") in ("1", "true", "on")
 
     if not _acquire_sync_lock():
         return HTMLResponse('<div class="toast toast-error">Another sync is already running. Please wait.</div>')
 
     try:
-        result = sync_routines(dry_run=False, schedule_date=schedule_date, force=force)
+        result = sync_routines(dry_run=False, force=force)
     except Exception as e:
         return HTMLResponse(f'<div class="toast toast-error">Routine sync failed: {e}</div>')
     finally:

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -17,16 +17,20 @@ from hevy2garmin.garmin import (
     GarminUploadRejected,
     activity_matches_start_time,
     activities_for_workout,
+    create_workout,
     delete_activity,
+    delete_workout,
     find_activity_by_start_time,
     generate_description,
     get_client,
     rename_activity,
+    schedule_workout,
     set_description,
     upload_fit,
 )
 from hevy2garmin.hevy import HevyClient
 from hevy2garmin.mapper import lookup_exercise
+from hevy2garmin.routine import routine_to_garmin_workout
 from hevy2garmin.merge import attempt_merge, reset_circuit_breaker
 from hevy2garmin.db_interface import Database
 
@@ -684,4 +688,127 @@ def sync(
             trigger=trigger,
         )
 
+    return stats
+
+
+def fetch_all_routines(hevy: HevyClient, page_size: int = 10) -> list[dict]:
+    """Fetch every Hevy routine (paginated). Returns a list of routine dicts."""
+    routines: list[dict] = []
+    page = 1
+    while True:
+        data = hevy.get_routines(page, page_size)
+        batch = data.get("routines", [])
+        routines.extend(batch)
+        logger.info("  Routines page %d/%s — %d", page, data.get("page_count", "?"), len(batch))
+        if page >= data.get("page_count", page):
+            break
+        page += 1
+    return routines
+
+
+def sync_routines(
+    config: dict[str, Any] | None = None,
+    dry_run: bool = False,
+    schedule_date: str | None = None,
+    **overrides: Any,
+) -> dict:
+    """Sync Hevy routines (templates) to Garmin as planned workouts.
+
+    Each Hevy routine becomes a planned workout in the Garmin Workouts library
+    (not an uploaded activity). Already-synced routines are skipped unless edited
+    on Hevy since — those are deleted and recreated. When ``schedule_date`` (an
+    ISO ``YYYY-MM-DD``) is given, each created workout is also scheduled onto the
+    Garmin calendar for that date; otherwise only the library entry is created.
+
+    Args:
+        config: Config dict (loaded from file if None).
+        dry_run: Build payloads and log them, but don't call Garmin.
+        schedule_date: Optional ``YYYY-MM-DD`` to schedule the workouts.
+        **overrides: Override config values (hevy_api_key, garmin_email, garmin_password).
+
+    Returns:
+        Dict with stats: created, skipped, failed, scheduled, total.
+    """
+    cfg = config or load_config()
+    candidate_store = db.get_db() if callable(getattr(db, "get_db", None)) else None
+    store = candidate_store if isinstance(candidate_store, Database) else db
+    hevy_api_key = overrides.get("hevy_api_key") or cfg.get("hevy_api_key")
+    garmin_email = overrides.get("garmin_email") or cfg.get("garmin_email")
+    garmin_password = overrides.get("garmin_password") or cfg.get("garmin_password", "")
+    garmin_token_dir = cfg.get("garmin_token_dir", "~/.garminconnect")
+    weight_unit = cfg.get("sync", {}).get("weight_unit", "kilogram")
+
+    hevy = HevyClient(api_key=hevy_api_key)
+    routines = fetch_all_routines(hevy)
+    logger.info("Fetched %d routines to process", len(routines))
+
+    garmin_client = None
+    if not dry_run:
+        logger.info("Authenticating with Garmin Connect...")
+        garmin_client = get_client(garmin_email, garmin_password, garmin_token_dir)
+        logger.info("Authenticated successfully")
+
+    stats = {
+        "created": 0,
+        "skipped": 0,
+        "failed": 0,
+        "scheduled": 0,
+        "total": len(routines),
+    }
+
+    for routine in routines:
+        rid = routine.get("id", "unknown")
+        title = routine.get("title") or routine.get("name") or "Routine"
+        updated_at = routine.get("updated_at")
+
+        existing = store.get_synced_routine(rid)
+        if existing and store.is_routine_synced(rid, updated_at):
+            logger.debug("Skipping routine %s (%s) — already synced", rid, title)
+            stats["skipped"] += 1
+            continue
+
+        try:
+            payload = routine_to_garmin_workout(routine, weight_unit=weight_unit)
+            if dry_run:
+                logger.info(
+                    "[dry-run] Would create Garmin workout '%s' with %d step(s)",
+                    title,
+                    len(payload["workoutSegments"][0]["workoutSteps"]),
+                )
+                stats["created"] += 1
+                continue
+
+            # Routine was edited on Hevy — drop the stale Garmin workout first.
+            if existing and existing.get("garmin_workout_id"):
+                try:
+                    delete_workout(garmin_client, existing["garmin_workout_id"])
+                except Exception:
+                    logger.warning("  Could not delete stale workout %s", existing["garmin_workout_id"])
+
+            workout_id = create_workout(garmin_client, payload)
+            if workout_id is None:
+                logger.warning("  Garmin did not return a workoutId for '%s'", title)
+                stats["failed"] += 1
+                continue
+
+            if schedule_date:
+                schedule_workout(garmin_client, workout_id, schedule_date)
+                stats["scheduled"] += 1
+
+            store.mark_routine_synced(
+                rid,
+                garmin_workout_id=str(workout_id),
+                title=title,
+                hevy_updated_at=updated_at,
+                scheduled_date=schedule_date,
+            )
+            stats["created"] += 1
+        except Exception:
+            logger.exception("Failed to sync routine %s (%s)", rid, title)
+            stats["failed"] += 1
+
+    logger.info(
+        "Routine sync done — created=%d skipped=%d failed=%d scheduled=%d",
+        stats["created"], stats["skipped"], stats["failed"], stats["scheduled"],
+    )
     return stats

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -30,7 +30,7 @@ from hevy2garmin.garmin import (
 )
 from hevy2garmin.hevy import HevyClient
 from hevy2garmin.mapper import lookup_exercise
-from hevy2garmin.routine import routine_to_garmin_workout
+from hevy2garmin.routine import routine_to_garmin_workout, workout_content_hash
 from hevy2garmin.merge import attempt_merge, reset_circuit_breaker
 from hevy2garmin.db_interface import Database
 
@@ -716,18 +716,20 @@ def sync_routines(
     """Sync Hevy routines (templates) to Garmin as planned workouts.
 
     Each Hevy routine becomes a planned workout in the Garmin Workouts library
-    (not an uploaded activity). Already-synced routines are skipped unless edited
-    on Hevy since — those are deleted and recreated. When ``schedule_date`` (an
-    ISO ``YYYY-MM-DD``) is given, each created workout is also scheduled onto the
+    (not an uploaded activity). A routine is skipped when the workout payload it
+    now produces hashes identically to the last one synced; otherwise the old
+    Garmin workout is deleted and recreated. Because the hash covers the
+    *generated payload*, changes to this builder (e.g. new rest steps) re-sync
+    automatically without ``--force``. When ``schedule_date`` (an ISO
+    ``YYYY-MM-DD``) is given, each created workout is also scheduled onto the
     Garmin calendar for that date; otherwise only the library entry is created.
 
     Args:
         config: Config dict (loaded from file if None).
         dry_run: Build payloads and log them, but don't call Garmin.
         schedule_date: Optional ``YYYY-MM-DD`` to schedule the workouts.
-        force: Re-create every routine even if already synced and unchanged
-            (deletes the old Garmin workout first). Use after changing how the
-            payload is built — e.g. to pick up newly added rest steps.
+        force: Re-create every routine even when its payload hash is unchanged
+            (deletes the old Garmin workout first).
         **overrides: Override config values (hevy_api_key, garmin_email, garmin_password).
 
     Returns:
@@ -768,16 +770,21 @@ def sync_routines(
         title = routine.get("title") or routine.get("name") or "Routine"
         updated_at = routine.get("updated_at")
 
-        existing = store.get_synced_routine(rid)
-        if not force and existing and store.is_routine_synced(rid, updated_at):
-            logger.debug("Skipping routine %s (%s) — already synced", rid, title)
-            stats["skipped"] += 1
-            continue
-
         try:
             payload = routine_to_garmin_workout(
                 routine, weight_unit=weight_unit, default_rest_seconds=default_rest_seconds
             )
+            content_hash = workout_content_hash(payload)
+
+            # Skip when the generated payload is byte-for-byte what we last synced.
+            # Hashing the payload (not Hevy's updated_at) also re-syncs when this
+            # builder changes — e.g. after adding rest steps. --force overrides it.
+            existing = store.get_synced_routine(rid)
+            if not force and existing and existing.get("content_hash") == content_hash:
+                logger.debug("Skipping routine %s (%s) — unchanged", rid, title)
+                stats["skipped"] += 1
+                continue
+
             if dry_run:
                 logger.info(
                     "[dry-run] Would create Garmin workout '%s' with %d step(s)",
@@ -787,7 +794,7 @@ def sync_routines(
                 stats["created"] += 1
                 continue
 
-            # Routine was edited on Hevy — drop the stale Garmin workout first.
+            # Content changed (or forced) — drop the stale Garmin workout first.
             if existing and existing.get("garmin_workout_id"):
                 try:
                     delete_workout(garmin_client, existing["garmin_workout_id"])
@@ -810,6 +817,7 @@ def sync_routines(
                 title=title,
                 hevy_updated_at=updated_at,
                 scheduled_date=schedule_date,
+                content_hash=content_hash,
             )
             stats["created"] += 1
         except Exception:

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -43,6 +43,20 @@ except Exception:  # pragma: no cover
 logger = logging.getLogger("hevy2garmin")
 
 
+def _resolve_store() -> Any:
+    """Return the active ``Database`` singleton, or the ``db`` module facade as fallback."""
+    candidate = db.get_db() if callable(getattr(db, "get_db", None)) else None
+    return candidate if isinstance(candidate, Database) else db
+
+
+def _cache_routines_total(store: Any, count: int) -> None:
+    """Cache the routine count so the dashboard can show "pending" without a Hevy call."""
+    try:
+        store.set_app_config("routines_total", {"count": count})
+    except Exception:
+        logger.debug("Could not cache routines_total", exc_info=True)
+
+
 @dataclass
 class SyncOneResult:
     """Outcome of syncing a single Hevy workout."""
@@ -547,8 +561,7 @@ def sync(
         Dict with sync stats: synced, skipped, failed, total, unmapped.
     """
     cfg = config or load_config()
-    candidate_store = db.get_db() if callable(getattr(db, "get_db", None)) else None
-    store = candidate_store if isinstance(candidate_store, Database) else db
+    store = _resolve_store()
     hevy_api_key = overrides.get("hevy_api_key") or cfg.get("hevy_api_key")
     garmin_email = overrides.get("garmin_email") or cfg.get("garmin_email")
     garmin_password = overrides.get("garmin_password") or cfg.get("garmin_password", "")
@@ -736,25 +749,21 @@ def sync_routines(
         Dict with stats: created, skipped, failed, scheduled, total.
     """
     cfg = config or load_config()
-    candidate_store = db.get_db() if callable(getattr(db, "get_db", None)) else None
-    store = candidate_store if isinstance(candidate_store, Database) else db
+    store = _resolve_store()
     hevy_api_key = overrides.get("hevy_api_key") or cfg.get("hevy_api_key")
     garmin_email = overrides.get("garmin_email") or cfg.get("garmin_email")
     garmin_password = overrides.get("garmin_password") or cfg.get("garmin_password", "")
     garmin_token_dir = cfg.get("garmin_token_dir", "~/.garminconnect")
-    weight_unit = cfg.get("sync", {}).get("weight_unit", "kilogram")
+    # ``or {}`` guards against a config key present but explicitly null.
+    weight_unit = (cfg.get("sync") or {}).get("weight_unit", "kilogram")
     # Fallback rest between sets when a Hevy routine doesn't specify one, mirroring
     # the FIT timing default used for logged workouts.
-    default_rest_seconds = cfg.get("timing", {}).get("rest_between_sets_seconds", 75)
+    default_rest_seconds = (cfg.get("timing") or {}).get("rest_between_sets_seconds", 75)
 
     hevy = HevyClient(api_key=hevy_api_key)
     routines = fetch_all_routines(hevy)
     logger.info("Fetched %d routines to process", len(routines))
-    # Cache the total so the dashboard can show "pending" without a Hevy call.
-    try:
-        store.set_app_config("routines_total", {"count": len(routines)})
-    except Exception:
-        logger.debug("Could not cache routines_total", exc_info=True)
+    _cache_routines_total(store, len(routines))
 
     garmin_client = None
     if not dry_run:
@@ -819,16 +828,22 @@ def sync_routines(
                 stats["failed"] += 1
                 continue
 
-            if schedule_date:
-                schedule_workout(garmin_client, workout_id, schedule_date)
-                stats["scheduled"] += 1
+            # Recreating the workout drops any calendar entry the old one had, so
+            # re-apply a prior schedule when this run doesn't set a new one. Only an
+            # explicit schedule_date counts toward the "scheduled" stat; re-applying a
+            # stored date is a restore, not a new booking.
+            effective_schedule_date = schedule_date or (existing or {}).get("scheduled_date")
+            if effective_schedule_date:
+                schedule_workout(garmin_client, workout_id, effective_schedule_date)
+                if schedule_date:
+                    stats["scheduled"] += 1
 
             store.mark_routine_synced(
                 rid,
                 garmin_workout_id=str(workout_id),
                 title=title,
                 hevy_updated_at=updated_at,
-                scheduled_date=schedule_date,
+                scheduled_date=effective_schedule_date,
                 content_hash=content_hash,
             )
             stats[outcome] += 1
@@ -902,8 +917,7 @@ def schedule_routine(
         raise ValueError("no dates to schedule")
 
     cfg = config or load_config()
-    candidate_store = db.get_db() if callable(getattr(db, "get_db", None)) else None
-    store = candidate_store if isinstance(candidate_store, Database) else db
+    store = _resolve_store()
 
     record = store.get_synced_routine(hevy_routine_id)
     if not record or not record.get("garmin_workout_id"):

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -6,7 +6,7 @@ import logging
 import os
 import tempfile
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import date as _date, datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -836,3 +836,92 @@ def sync_routines(
         stats["created"], stats["updated"], stats["skipped"], stats["failed"], stats["scheduled"],
     )
     return stats
+
+
+# Cap on recurring occurrences, so a typo in "weeks" can't schedule years of entries.
+MAX_SCHEDULE_OCCURRENCES = 52
+
+
+def routine_schedule_dates(
+    mode: str,
+    *,
+    date: str | None = None,
+    weekday: int | str | None = None,
+    start_date: str | None = None,
+    weeks: int | str | None = None,
+) -> list[str]:
+    """Compute the calendar dates to schedule a routine on.
+
+    ``mode="once"`` returns ``[date]``. ``mode="recurring"`` returns one date per
+    week for ``weeks`` weeks, on the given ``weekday`` (0=Monday .. 6=Sunday),
+    starting at the first matching weekday on or after ``start_date``. All inputs
+    are ISO ``YYYY-MM-DD`` strings; raises ``ValueError`` on missing/invalid data.
+    """
+    if mode == "once":
+        if not date:
+            raise ValueError("a date is required for a one-off schedule")
+        return [_date.fromisoformat(date).isoformat()]
+
+    if mode == "recurring":
+        if weekday is None or start_date in (None, "") or weeks in (None, ""):
+            raise ValueError("weekday, start_date and weeks are required for a recurring schedule")
+        weekday = int(weekday)
+        weeks = int(weeks)
+        if not 0 <= weekday <= 6:
+            raise ValueError("weekday must be 0 (Monday) .. 6 (Sunday)")
+        if weeks < 1:
+            raise ValueError("weeks must be at least 1")
+        weeks = min(weeks, MAX_SCHEDULE_OCCURRENCES)
+        start = _date.fromisoformat(start_date)
+        first = start + timedelta(days=(weekday - start.weekday()) % 7)
+        return [(first + timedelta(weeks=i)).isoformat() for i in range(weeks)]
+
+    raise ValueError(f"unknown schedule mode: {mode!r}")
+
+
+def schedule_routine(
+    hevy_routine_id: str,
+    dates: list[str],
+    *,
+    config: dict[str, Any] | None = None,
+    **overrides: Any,
+) -> dict:
+    """Schedule an already-synced routine's Garmin workout on the given dates.
+
+    Looks up the routine's ``garmin_workout_id`` (it must have been synced first),
+    then calls the Garmin schedule endpoint once per date. Persists the earliest
+    date on the routine record for display. Returns
+    ``{"scheduled": n, "workout_id": id, "dates": [...]}``.
+    """
+    if not dates:
+        raise ValueError("no dates to schedule")
+
+    cfg = config or load_config()
+    candidate_store = db.get_db() if callable(getattr(db, "get_db", None)) else None
+    store = candidate_store if isinstance(candidate_store, Database) else db
+
+    record = store.get_synced_routine(hevy_routine_id)
+    if not record or not record.get("garmin_workout_id"):
+        raise ValueError("Routine is not synced yet — sync it before scheduling.")
+    workout_id = record["garmin_workout_id"]
+
+    garmin_email = overrides.get("garmin_email") or cfg.get("garmin_email")
+    garmin_password = overrides.get("garmin_password") or cfg.get("garmin_password", "")
+    garmin_token_dir = cfg.get("garmin_token_dir", "~/.garminconnect")
+
+    logger.info("Authenticating with Garmin Connect...")
+    client = get_client(garmin_email, garmin_password, garmin_token_dir)
+
+    for day in dates:
+        schedule_workout(client, workout_id, day)
+
+    store.mark_routine_synced(
+        hevy_routine_id,
+        garmin_workout_id=workout_id,
+        title=record.get("title", ""),
+        hevy_updated_at=record.get("hevy_updated_at"),
+        scheduled_date=min(dates),
+        content_hash=record.get("content_hash"),
+    )
+    logger.info("Scheduled routine %s on %d date(s)", hevy_routine_id, len(dates))
+    return {"scheduled": len(dates), "workout_id": workout_id, "dates": dates}

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -750,6 +750,11 @@ def sync_routines(
     hevy = HevyClient(api_key=hevy_api_key)
     routines = fetch_all_routines(hevy)
     logger.info("Fetched %d routines to process", len(routines))
+    # Cache the total so the dashboard can show "pending" without a Hevy call.
+    try:
+        store.set_app_config("routines_total", {"count": len(routines)})
+    except Exception:
+        logger.debug("Could not cache routines_total", exc_info=True)
 
     garmin_client = None
     if not dry_run:

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -737,6 +737,9 @@ def sync_routines(
     garmin_password = overrides.get("garmin_password") or cfg.get("garmin_password", "")
     garmin_token_dir = cfg.get("garmin_token_dir", "~/.garminconnect")
     weight_unit = cfg.get("sync", {}).get("weight_unit", "kilogram")
+    # Fallback rest between sets when a Hevy routine doesn't specify one, mirroring
+    # the FIT timing default used for logged workouts.
+    default_rest_seconds = cfg.get("timing", {}).get("rest_between_sets_seconds", 75)
 
     hevy = HevyClient(api_key=hevy_api_key)
     routines = fetch_all_routines(hevy)
@@ -768,7 +771,9 @@ def sync_routines(
             continue
 
         try:
-            payload = routine_to_garmin_workout(routine, weight_unit=weight_unit)
+            payload = routine_to_garmin_workout(
+                routine, weight_unit=weight_unit, default_rest_seconds=default_rest_seconds
+            )
             if dry_run:
                 logger.info(
                     "[dry-run] Would create Garmin workout '%s' with %d step(s)",

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -759,6 +759,7 @@ def sync_routines(
 
     stats = {
         "created": 0,
+        "updated": 0,
         "skipped": 0,
         "failed": 0,
         "scheduled": 0,
@@ -785,13 +786,19 @@ def sync_routines(
                 stats["skipped"] += 1
                 continue
 
+            # A prior sync record means this run replaces it (an update), not a
+            # brand-new create — tracked separately for the summary.
+            outcome = "updated" if existing else "created"
+
             if dry_run:
+                verb = "update" if existing else "create"
                 logger.info(
-                    "[dry-run] Would create Garmin workout '%s' with %d step(s)",
+                    "[dry-run] Would %s Garmin workout '%s' with %d step(s)",
+                    verb,
                     title,
                     len(payload["workoutSegments"][0]["workoutSteps"]),
                 )
-                stats["created"] += 1
+                stats[outcome] += 1
                 continue
 
             # Content changed (or forced) — drop the stale Garmin workout first.
@@ -819,13 +826,13 @@ def sync_routines(
                 scheduled_date=schedule_date,
                 content_hash=content_hash,
             )
-            stats["created"] += 1
+            stats[outcome] += 1
         except Exception:
             logger.exception("Failed to sync routine %s (%s)", rid, title)
             stats["failed"] += 1
 
     logger.info(
-        "Routine sync done — created=%d skipped=%d failed=%d scheduled=%d",
-        stats["created"], stats["skipped"], stats["failed"], stats["scheduled"],
+        "Routine sync done — created=%d updated=%d skipped=%d failed=%d scheduled=%d",
+        stats["created"], stats["updated"], stats["skipped"], stats["failed"], stats["scheduled"],
     )
     return stats

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -710,6 +710,7 @@ def sync_routines(
     config: dict[str, Any] | None = None,
     dry_run: bool = False,
     schedule_date: str | None = None,
+    force: bool = False,
     **overrides: Any,
 ) -> dict:
     """Sync Hevy routines (templates) to Garmin as planned workouts.
@@ -724,6 +725,9 @@ def sync_routines(
         config: Config dict (loaded from file if None).
         dry_run: Build payloads and log them, but don't call Garmin.
         schedule_date: Optional ``YYYY-MM-DD`` to schedule the workouts.
+        force: Re-create every routine even if already synced and unchanged
+            (deletes the old Garmin workout first). Use after changing how the
+            payload is built — e.g. to pick up newly added rest steps.
         **overrides: Override config values (hevy_api_key, garmin_email, garmin_password).
 
     Returns:
@@ -765,7 +769,7 @@ def sync_routines(
         updated_at = routine.get("updated_at")
 
         existing = store.get_synced_routine(rid)
-        if existing and store.is_routine_synced(rid, updated_at):
+        if not force and existing and store.is_routine_synced(rid, updated_at):
             logger.debug("Skipping routine %s (%s) — already synced", rid, title)
             stats["skipped"] += 1
             continue

--- a/src/hevy2garmin/templates/base.html
+++ b/src/hevy2garmin/templates/base.html
@@ -224,6 +224,7 @@
         <div class="nav-links">
             <a href="/" {% if request and request.url.path == '/' %}class="active"{% endif %}>Dashboard</a>
             <a href="/workouts" {% if request and request.url.path == '/workouts' %}class="active"{% endif %}>Workouts</a>
+            <a href="/routines" {% if request and request.url.path == '/routines' %}class="active"{% endif %}>Routines</a>
             <a href="/history" {% if request and request.url.path == '/history' %}class="active"{% endif %}>History</a>
             <a href="/mappings" {% if request and request.url.path == '/mappings' %}class="active"{% endif %}>Mappings</a>
             <a href="/settings" {% if request and request.url.path == '/settings' %}class="active"{% endif %}>Settings</a>

--- a/src/hevy2garmin/templates/dashboard.html
+++ b/src/hevy2garmin/templates/dashboard.html
@@ -104,6 +104,10 @@
         <div class="stat-value {% if pending > 0 %}amber{% endif %}" id="stat-pending">{{ pending }}</div>
         <div class="stat-label">Pending</div>
     </div>
+    <div class="stat-card">
+        <div class="stat-value blue">{{ routine_stats.synced }}</div>
+        <div class="stat-label">Routines synced</div>
+    </div>
 </div>
 
 <!-- Sync card -->
@@ -276,6 +280,41 @@
             </div>
         {% endif %}
     </div>
+</div>
+
+<!-- Routines summary -->
+<div class="card" style="margin-bottom: 20px;">
+    <div class="card-header">
+        <span class="card-title">Routines</span>
+        <a href="/routines" style="font-size: 12px;">Manage &rarr;</a>
+    </div>
+    <div style="display: flex; gap: 20px; flex-wrap: wrap; margin-bottom: 6px; font-size: 13px; color: var(--text-muted);">
+        <span><strong style="color: var(--text);">{{ routine_stats.synced }}</strong> synced</span>
+        <span><strong style="color: var(--text);">{{ routine_stats.scheduled }}</strong> scheduled</span>
+        {% if routines_pending is not none %}
+        <span><strong style="color: {% if routines_pending > 0 %}var(--amber){% else %}var(--text){% endif %};">{{ routines_pending }}</strong> pending</span>
+        {% endif %}
+    </div>
+    {% if recent_routines %}
+        {% for r in recent_routines %}
+        <div class="list-item" style="padding: 10px 0;">
+            <div>
+                <div style="font-weight: 600; font-size: 13px;">{{ r.title or 'Routine' }}</div>
+                <div style="font-size: 11px; color: var(--text-muted); margin-top: 2px;">
+                    {{ r.synced_at.strftime('%Y-%m-%d') if r.synced_at is not string else r.synced_at[:10] }}
+                    {% if r.scheduled_date %} · 📅 {{ r.scheduled_date }}{% endif %}
+                </div>
+            </div>
+            <span class="badge badge-success" style="font-size: 11px;">
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg>
+            </span>
+        </div>
+        {% endfor %}
+    {% else %}
+        <div style="text-align: center; padding: 20px 0;">
+            <p style="color: var(--text-muted); font-size: 13px;">No routines synced yet. <a href="/routines">Sync your routines &rarr;</a></p>
+        </div>
+    {% endif %}
 </div>
 
 <!-- Pipeline visualization - full SVG diagram -->

--- a/src/hevy2garmin/templates/routines.html
+++ b/src/hevy2garmin/templates/routines.html
@@ -1,0 +1,52 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="page-header">
+  <h1>Routines</h1>
+  <p class="subtitle">Create Garmin planned workouts from your Hevy routines.</p>
+</div>
+
+<div class="card" style="margin-bottom:16px;">
+  <form hx-post="/api/routines/sync" hx-target="#routines-result" hx-indicator="#routines-spinner"
+        style="display:flex; gap:12px; align-items:center; flex-wrap:wrap;">
+    <button type="submit" class="btn btn-primary">Sync all routines</button>
+    <label style="display:flex; gap:6px; align-items:center; color:var(--text-muted); font-size:14px;">
+      Schedule date (optional):
+      <input type="date" name="date" style="background:var(--bg-primary); color:var(--text); border:1px solid var(--border); border-radius:var(--radius-sm); padding:6px 8px;">
+    </label>
+    <span id="routines-spinner" class="htmx-indicator" style="color:var(--text-muted);">Syncing…</span>
+  </form>
+  <div id="routines-result" style="margin-top:12px;"></div>
+</div>
+
+{% if fetch_error %}
+<div class="toast toast-error">Could not load routines: {{ fetch_error }}</div>
+{% else %}
+<div class="card">
+  {% if routines %}
+  <table style="width:100%; border-collapse:collapse;">
+    <thead>
+      <tr style="text-align:left; color:var(--text-muted); font-size:13px;">
+        <th style="padding:8px;">Routine</th>
+        <th style="padding:8px;">Exercises</th>
+        <th style="padding:8px;">Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for r in routines %}
+      <tr style="border-top:1px solid var(--border);">
+        <td style="padding:8px;">{{ r.title }}</td>
+        <td style="padding:8px;">{{ r.exercise_count }}</td>
+        <td style="padding:8px;">
+          {% if r.synced %}<span style="color:var(--green);">✓ synced</span>
+          {% else %}<span style="color:var(--text-muted);">not synced</span>{% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p style="color:var(--text-muted);">No routines found in your Hevy account.</p>
+  {% endif %}
+</div>
+{% endif %}
+{% endblock %}

--- a/src/hevy2garmin/templates/routines.html
+++ b/src/hevy2garmin/templates/routines.html
@@ -32,16 +32,53 @@
         <th style="padding:8px;">Routine</th>
         <th style="padding:8px;">Exercises</th>
         <th style="padding:8px;">Status</th>
+        <th style="padding:8px;">Schedule</th>
       </tr>
     </thead>
     <tbody>
       {% for r in routines %}
-      <tr style="border-top:1px solid var(--border);">
+      <tr style="border-top:1px solid var(--border); vertical-align:top;">
         <td style="padding:8px;">{{ r.title }}</td>
         <td style="padding:8px;">{{ r.exercise_count }}</td>
         <td style="padding:8px;">
           {% if r.synced %}<span style="color:var(--green);">✓ synced</span>
           {% else %}<span style="color:var(--text-muted);">not synced</span>{% endif %}
+          {% if r.scheduled_date %}<br><span style="color:var(--text-muted); font-size:12px;">📅 {{ r.scheduled_date }}</span>{% endif %}
+        </td>
+        <td style="padding:8px;">
+          {% if r.synced %}
+          <details>
+            <summary style="cursor:pointer; user-select:none;" title="Schedule on the Garmin calendar">📅 Schedule</summary>
+            <form hx-post="/api/routines/{{ r.id }}/schedule" hx-target="#routines-result" hx-swap="innerHTML"
+                  style="margin-top:8px; display:flex; flex-direction:column; gap:8px; font-size:13px; max-width:320px;">
+              <label style="display:flex; gap:6px; align-items:center;">
+                <input type="radio" name="mode" value="once" checked> One-off
+                <input type="date" name="date"
+                       style="background:var(--bg-primary); color:var(--text); border:1px solid var(--border); border-radius:var(--radius-sm); padding:4px 6px;">
+              </label>
+              <label style="display:flex; gap:6px; align-items:center; flex-wrap:wrap;">
+                <input type="radio" name="mode" value="recurring"> Weekly on
+                <select name="weekday" style="background:var(--bg-primary); color:var(--text); border:1px solid var(--border); border-radius:var(--radius-sm); padding:4px 6px;">
+                  <option value="0">Monday</option>
+                  <option value="1">Tuesday</option>
+                  <option value="2">Wednesday</option>
+                  <option value="3">Thursday</option>
+                  <option value="4">Friday</option>
+                  <option value="5">Saturday</option>
+                  <option value="6">Sunday</option>
+                </select>
+              </label>
+              <label style="display:flex; gap:6px; align-items:center; flex-wrap:wrap; color:var(--text-muted);">
+                from <input type="date" name="start_date"
+                       style="background:var(--bg-primary); color:var(--text); border:1px solid var(--border); border-radius:var(--radius-sm); padding:4px 6px;">
+                for <input type="number" name="weeks" min="1" max="52" value="4" style="width:60px; background:var(--bg-primary); color:var(--text); border:1px solid var(--border); border-radius:var(--radius-sm); padding:4px 6px;"> weeks
+              </label>
+              <button type="submit" class="btn btn-primary" style="align-self:flex-start;">Add to calendar</button>
+            </form>
+          </details>
+          {% else %}
+          <span style="color:var(--text-muted); font-size:12px;">sync first</span>
+          {% endif %}
         </td>
       </tr>
       {% endfor %}

--- a/src/hevy2garmin/templates/routines.html
+++ b/src/hevy2garmin/templates/routines.html
@@ -6,7 +6,7 @@
 </div>
 
 <div class="card" style="margin-bottom:16px;">
-  <form hx-post="/api/routines/sync" hx-target="#routines-result" hx-indicator="#routines-spinner"
+  <form hx-post="/api/routines/sync" hx-target="#routines-result" hx-disabled-elt="find button"
         style="display:flex; gap:12px; align-items:center; flex-wrap:wrap;">
     <button type="submit" class="btn btn-primary">Sync all routines</button>
     <label style="display:flex; gap:6px; align-items:center; color:var(--text-muted); font-size:14px;">
@@ -16,7 +16,9 @@
     <label style="display:flex; gap:6px; align-items:center; color:var(--text-muted); font-size:14px;" title="Re-create even routines already synced">
       <input type="checkbox" name="force" value="1"> Force re-create
     </label>
-    <span id="routines-spinner" class="htmx-indicator" style="color:var(--text-muted);">Syncing…</span>
+    <span class="htmx-indicator" style="align-items:center; gap:6px; color:var(--text-muted); font-size:14px;">
+      <span class="spinner"></span> Syncing…
+    </span>
   </form>
   <div id="routines-result" style="margin-top:12px;"></div>
 </div>
@@ -49,7 +51,7 @@
           {% if r.synced %}
           <details>
             <summary style="cursor:pointer; user-select:none;" title="Schedule on the Garmin calendar">📅 Schedule</summary>
-            <form hx-post="/api/routines/{{ r.id }}/schedule" hx-target="#routines-result" hx-swap="innerHTML"
+            <form hx-post="/api/routines/{{ r.id }}/schedule" hx-target="#routines-result" hx-swap="innerHTML" hx-disabled-elt="find button"
                   style="margin-top:8px; display:flex; flex-direction:column; gap:8px; font-size:13px; max-width:320px;">
               <label style="display:flex; gap:6px; align-items:center;">
                 <input type="radio" name="mode" value="once" checked> One-off
@@ -73,7 +75,12 @@
                        style="background:var(--bg-primary); color:var(--text); border:1px solid var(--border); border-radius:var(--radius-sm); padding:4px 6px;">
                 for <input type="number" name="weeks" min="1" max="52" value="4" style="width:60px; background:var(--bg-primary); color:var(--text); border:1px solid var(--border); border-radius:var(--radius-sm); padding:4px 6px;"> weeks
               </label>
-              <button type="submit" class="btn btn-primary" style="align-self:flex-start;">Add to calendar</button>
+              <div style="display:flex; gap:8px; align-items:center;">
+                <button type="submit" class="btn btn-primary">Add to calendar</button>
+                <span class="htmx-indicator" style="align-items:center; gap:6px; color:var(--text-muted);">
+                  <span class="spinner"></span> Scheduling…
+                </span>
+              </div>
             </form>
           </details>
           {% else %}

--- a/src/hevy2garmin/templates/routines.html
+++ b/src/hevy2garmin/templates/routines.html
@@ -9,10 +9,6 @@
   <form hx-post="/api/routines/sync" hx-target="#routines-result" hx-disabled-elt="find button"
         style="display:flex; gap:12px; align-items:center; flex-wrap:wrap;">
     <button type="submit" class="btn btn-primary">Sync all routines</button>
-    <label style="display:flex; gap:6px; align-items:center; color:var(--text-muted); font-size:14px;">
-      Schedule date (optional):
-      <input type="date" name="date" style="background:var(--bg-primary); color:var(--text); border:1px solid var(--border); border-radius:var(--radius-sm); padding:6px 8px;">
-    </label>
     <label style="display:flex; gap:6px; align-items:center; color:var(--text-muted); font-size:14px;" title="Re-create even routines already synced">
       <input type="checkbox" name="force" value="1"> Force re-create
     </label>

--- a/src/hevy2garmin/templates/routines.html
+++ b/src/hevy2garmin/templates/routines.html
@@ -13,6 +13,9 @@
       Schedule date (optional):
       <input type="date" name="date" style="background:var(--bg-primary); color:var(--text); border:1px solid var(--border); border-radius:var(--radius-sm); padding:6px 8px;">
     </label>
+    <label style="display:flex; gap:6px; align-items:center; color:var(--text-muted); font-size:14px;" title="Re-create even routines already synced">
+      <input type="checkbox" name="force" value="1"> Force re-create
+    </label>
     <span id="routines-spinner" class="htmx-indicator" style="color:var(--text-muted);">Syncing…</span>
   </form>
   <div id="routines-result" style="margin-top:12px;"></div>

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -80,6 +80,14 @@ class TestRoutineTracking:
         assert db.is_routine_synced("r1") is False
         assert db.delete_synced_routine("r1") is False
 
+    def test_content_hash_round_trip(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        db.mark_routine_synced("r1", garmin_workout_id="w1", content_hash="abc123")
+        assert db.get_synced_routine("r1")["content_hash"] == "abc123"
+        # Upsert updates the hash.
+        db.mark_routine_synced("r1", garmin_workout_id="w1", content_hash="def456")
+        assert db.get_synced_routine("r1")["content_hash"] == "def456"
+
 
 class TestSyncTracking:
     def test_not_synced_initially(self, tmp_path: Path) -> None:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -38,9 +38,47 @@ def _make_db(tmp_path):
                 cur.execute("DELETE FROM synced_workouts")
                 cur.execute("DELETE FROM sync_log")
                 cur.execute("DELETE FROM hr_cache")
+                cur.execute("DELETE FROM synced_routines")
             conn.commit()
         return db
     return SQLiteDatabase(tmp_path / "test.db")
+
+
+class TestRoutineTracking:
+    def test_not_synced_initially(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        assert db.is_routine_synced("r-unknown") is False
+        assert db.get_synced_routine("r-unknown") is None
+
+    def test_mark_then_check(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        db.mark_routine_synced("r1", garmin_workout_id="w9", title="Push",
+                               hevy_updated_at="2026-01-01T00:00:00Z")
+        assert db.is_routine_synced("r1") is True
+        record = db.get_synced_routine("r1")
+        assert record["garmin_workout_id"] == "w9"
+        assert record["title"] == "Push"
+
+    def test_stale_when_edited_since(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        db.mark_routine_synced("r1", hevy_updated_at="2026-01-01T00:00:00Z")
+        # Edited later on Hevy → treated as not synced (will be recreated).
+        assert db.is_routine_synced("r1", "2026-02-01T00:00:00Z") is False
+        # Unchanged timestamp → still synced.
+        assert db.is_routine_synced("r1", "2026-01-01T00:00:00Z") is True
+
+    def test_upsert_updates_record(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        db.mark_routine_synced("r1", garmin_workout_id="w1", title="Old")
+        db.mark_routine_synced("r1", garmin_workout_id="w2", title="New")
+        assert db.get_synced_routine("r1")["garmin_workout_id"] == "w2"
+
+    def test_delete(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        db.mark_routine_synced("r1", garmin_workout_id="w1")
+        assert db.delete_synced_routine("r1") is True
+        assert db.is_routine_synced("r1") is False
+        assert db.delete_synced_routine("r1") is False
 
 
 class TestSyncTracking:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -88,6 +88,31 @@ class TestRoutineTracking:
         db.mark_routine_synced("r1", garmin_workout_id="w1", content_hash="def456")
         assert db.get_synced_routine("r1")["content_hash"] == "def456"
 
+    def test_routine_stats_empty(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        assert db.get_routine_stats() == {"synced": 0, "scheduled": 0}
+
+    def test_routine_stats_counts_synced_and_scheduled(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        db.mark_routine_synced("r1", garmin_workout_id="w1", title="Push")
+        db.mark_routine_synced("r2", garmin_workout_id="w2", title="Pull", scheduled_date="2026-07-20")
+        db.mark_routine_synced("r3", garmin_workout_id="w3", title="Legs", scheduled_date="2026-07-21")
+        assert db.get_routine_stats() == {"synced": 3, "scheduled": 2}
+
+    def test_recent_synced_routines_fields_and_limit(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        for i in range(7):
+            db.mark_routine_synced(f"r{i}", garmin_workout_id=f"w{i}", title=f"Routine {i}")
+        recent = db.get_recent_synced_routines(5)
+        assert len(recent) == 5
+        sample = recent[0]
+        assert set(sample) >= {"hevy_routine_id", "title", "scheduled_date",
+                               "garmin_workout_id", "synced_at"}
+
+    def test_recent_synced_routines_empty(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        assert db.get_recent_synced_routines(5) == []
+
 
 class TestSyncTracking:
     def test_not_synced_initially(self, tmp_path: Path) -> None:

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -412,3 +412,16 @@ class TestScheduleRoutine:
         with patches[0], patches[1], patches[2], patches[3]:
             with pytest.raises(ValueError):
                 sync_module.schedule_routine("r1", [])
+
+
+class TestDbFacade:
+    def test_get_synced_routine_facade_delegates(self) -> None:
+        # Regression: the `db` module facade must expose get_synced_routine, else
+        # `hevy2garmin sync-routines --list` crashes (it calls db.get_synced_routine).
+        from hevy2garmin import db as db_facade
+
+        store = MagicMock()
+        store.get_synced_routine.return_value = {"garmin_workout_id": "w1"}
+        with patch.object(db_facade, "get_db", return_value=store):
+            assert db_facade.get_synced_routine("r1") == {"garmin_workout_id": "w1"}
+            store.get_synced_routine.assert_called_once_with("r1")

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -307,6 +307,27 @@ class TestSyncRoutines:
         create_mock.assert_not_called()
         assert store.get_synced_routine("r1") is None
 
+    def test_resync_preserves_prior_schedule(self, tmp_path: Path) -> None:
+        # A routine synced AND scheduled, then re-synced because its content changed:
+        # recreating the Garmin workout drops its calendar entry, so the stored date
+        # must be re-applied to the new workout (a restore, not a new booking).
+        routines = [{"id": "r1", "title": "Push", "updated_at": "2026-01-01T00:00:00Z", "exercises": []}]
+        store, create_mock, schedule_mock, patches = self._patched(tmp_path, routines)
+        store.mark_routine_synced("r1", garmin_workout_id="555",
+                                  scheduled_date="2026-08-01", content_hash="stale-hash")
+        delete_mock = MagicMock()
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+                patch.object(sync_module, "delete_workout", delete_mock), patches[6]:
+            result = sync_module.sync_routines()
+        assert result["updated"] == 1
+        # Restoring the old date is not counted as a new schedule.
+        assert result["scheduled"] == 0
+        # The new workout (777) is re-scheduled on the stored date...
+        schedule_mock.assert_called_once()
+        assert schedule_mock.call_args[0][1:] == (777, "2026-08-01")
+        # ...and the date is kept on the record instead of being wiped to None.
+        assert store.get_synced_routine("r1")["scheduled_date"] == "2026-08-01"
+
 
 class TestRoutineScheduleDates:
     def test_once_returns_single_date(self) -> None:

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -1,0 +1,199 @@
+"""Tests for Hevy routine → Garmin planned-workout conversion and ops."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from hevy2garmin import sync as sync_module
+from hevy2garmin.db_sqlite import SQLiteDatabase
+from hevy2garmin.garmin import create_workout, delete_workout, schedule_workout
+from hevy2garmin.mapper import fit_exercise_strings
+from hevy2garmin.routine import routine_to_garmin_workout
+
+
+class TestFitExerciseStrings:
+    def test_known_category_and_exercise(self) -> None:
+        # Bench Press (Barbell) maps to FIT (0, 1).
+        assert fit_exercise_strings(0, 1) == ("BENCH_PRESS", "BARBELL_BENCH_PRESS")
+
+    def test_unknown_category_is_none(self) -> None:
+        assert fit_exercise_strings(65534, 0) == (None, None)
+
+    def test_bad_subcategory_keeps_category(self) -> None:
+        cat, name = fit_exercise_strings(0, 99999)
+        assert cat == "BENCH_PRESS"
+        assert name is None
+
+
+class TestRoutineToGarminWorkout:
+    def _routine(self) -> dict:
+        return {
+            "id": "r1",
+            "title": "Push Day",
+            "notes": "chest/shoulders",
+            "exercises": [
+                {
+                    "title": "Bench Press (Barbell)",
+                    "sets": [
+                        {"type": "warmup", "reps": 10, "weight_kg": 40},
+                        {"type": "normal", "reps": 8, "weight_kg": 60},
+                    ],
+                },
+                {
+                    "title": "Totally Made Up Exercise",
+                    "sets": [{"type": "normal", "reps": 12, "weight_kg": None}],
+                },
+            ],
+        }
+
+    def test_top_level_shape(self) -> None:
+        payload = routine_to_garmin_workout(self._routine())
+        assert payload["workoutName"] == "Push Day"
+        assert payload["description"] == "chest/shoulders"
+        assert payload["sportType"]["sportTypeKey"] == "strength_training"
+        assert len(payload["workoutSegments"]) == 1
+
+    def test_steps_and_order(self) -> None:
+        steps = routine_to_garmin_workout(self._routine())["workoutSegments"][0]["workoutSteps"]
+        assert [s["stepOrder"] for s in steps] == [1, 2, 3]
+
+    def test_warmup_vs_working_step_type(self) -> None:
+        steps = routine_to_garmin_workout(self._routine())["workoutSegments"][0]["workoutSteps"]
+        assert steps[0]["stepType"]["stepTypeKey"] == "warmup"
+        assert steps[1]["stepType"]["stepTypeKey"] == "interval"
+
+    def test_reps_and_weight_encoding(self) -> None:
+        steps = routine_to_garmin_workout(self._routine())["workoutSegments"][0]["workoutSteps"]
+        assert steps[1]["endCondition"]["conditionTypeKey"] == "reps"
+        assert steps[1]["endConditionValue"] == 8.0
+        assert steps[1]["weightValue"] == 60.0
+        assert steps[1]["weightUnit"]["unitKey"] == "kilogram"
+
+    def test_mapped_exercise_carries_garmin_strings(self) -> None:
+        steps = routine_to_garmin_workout(self._routine())["workoutSegments"][0]["workoutSteps"]
+        assert steps[0]["category"] == "BENCH_PRESS"
+        assert steps[0]["exerciseName"] == "BARBELL_BENCH_PRESS"
+
+    def test_unmapped_exercise_falls_back_to_named_step(self) -> None:
+        steps = routine_to_garmin_workout(self._routine())["workoutSegments"][0]["workoutSteps"]
+        unknown = steps[2]
+        assert "category" not in unknown
+        assert "exerciseName" not in unknown
+        assert unknown["stepName"] == "Totally Made Up Exercise"
+
+    def test_no_weight_omits_weight_fields(self) -> None:
+        steps = routine_to_garmin_workout(self._routine())["workoutSegments"][0]["workoutSteps"]
+        assert "weightValue" not in steps[2]
+
+    def test_pound_conversion(self) -> None:
+        payload = routine_to_garmin_workout(self._routine(), weight_unit="pound")
+        step = payload["workoutSegments"][0]["workoutSteps"][1]  # 60 kg working set
+        assert step["weightUnit"]["unitKey"] == "pound"
+        assert step["weightValue"] == round(60 * 2.2046226218, 2)
+
+    def test_duration_based_step(self) -> None:
+        routine = {"title": "Core", "exercises": [
+            {"title": "Plank", "sets": [{"type": "normal", "duration_seconds": 60}]},
+        ]}
+        step = routine_to_garmin_workout(routine)["workoutSegments"][0]["workoutSteps"][0]
+        assert step["endCondition"]["conditionTypeKey"] == "time"
+        assert step["endConditionValue"] == 60.0
+
+    def test_empty_routine(self) -> None:
+        payload = routine_to_garmin_workout({"title": "Empty", "exercises": []})
+        assert payload["workoutSegments"][0]["workoutSteps"] == []
+
+
+class TestGarminWorkoutOps:
+    def test_create_workout_posts_and_returns_id(self) -> None:
+        client = MagicMock()
+        client.client.request.return_value.json.return_value = {"workoutId": 999}
+        wid = create_workout(client, {"workoutName": "Push"})
+        assert wid == 999
+        method, service, path = client.client.request.call_args[0][:3]
+        assert method == "POST"
+        assert path == "/workout-service/workout"
+        assert client.client.request.call_args[1]["json"] == {"workoutName": "Push"}
+
+    def test_create_workout_missing_id_returns_none(self) -> None:
+        client = MagicMock()
+        client.client.request.return_value.json.return_value = {}
+        assert create_workout(client, {"workoutName": "Push"}) is None
+
+    def test_delete_workout_hits_delete_endpoint(self) -> None:
+        client = MagicMock()
+        delete_workout(client, 42)
+        method, service, path = client.client.request.call_args[0][:3]
+        assert method == "DELETE"
+        assert path == "/workout-service/workout/42"
+
+    def test_schedule_workout_posts_date(self) -> None:
+        client = MagicMock()
+        schedule_workout(client, 42, "2026-08-01")
+        method, service, path = client.client.request.call_args[0][:3]
+        assert method == "POST"
+        assert path == "/workout-service/schedule/42"
+        assert client.client.request.call_args[1]["json"] == {"date": "2026-08-01"}
+
+
+class TestSyncRoutines:
+    def _patched(self, tmp_path: Path, routines: list[dict]):
+        """Patch sync_routines' collaborators; return (db, create_mock, schedule_mock)."""
+        store = SQLiteDatabase(tmp_path / "routines.db")
+        hevy = MagicMock()
+        hevy.get_routines.return_value = {"routines": routines, "page_count": 1}
+        create_mock = MagicMock(return_value=777)
+        schedule_mock = MagicMock()
+        patches = [
+            patch.object(sync_module, "load_config", return_value={
+                "hevy_api_key": "k", "garmin_email": "e", "garmin_password": "p"}),
+            patch.object(sync_module.db, "get_db", return_value=store),
+            patch.object(sync_module, "HevyClient", return_value=hevy),
+            patch.object(sync_module, "get_client", return_value=MagicMock()),
+            patch.object(sync_module, "create_workout", create_mock),
+            patch.object(sync_module, "delete_workout", MagicMock()),
+            patch.object(sync_module, "schedule_workout", schedule_mock),
+        ]
+        return store, create_mock, schedule_mock, patches
+
+    def test_creates_and_tracks(self, tmp_path: Path) -> None:
+        routines = [{"id": "r1", "title": "Push", "updated_at": "2026-01-01T00:00:00Z",
+                     "exercises": [{"title": "Bench Press (Barbell)",
+                                    "sets": [{"type": "normal", "reps": 5, "weight_kg": 60}]}]}]
+        store, create_mock, _, patches = self._patched(tmp_path, routines)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+            result = sync_module.sync_routines()
+        assert result == {"created": 1, "skipped": 0, "failed": 0, "scheduled": 0, "total": 1}
+        create_mock.assert_called_once()
+        assert store.get_synced_routine("r1")["garmin_workout_id"] == "777"
+
+    def test_skips_already_synced(self, tmp_path: Path) -> None:
+        routines = [{"id": "r1", "title": "Push", "updated_at": "2026-01-01T00:00:00Z", "exercises": []}]
+        store, create_mock, _, patches = self._patched(tmp_path, routines)
+        store.mark_routine_synced("r1", garmin_workout_id="777",
+                                  hevy_updated_at="2026-01-01T00:00:00Z")
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+            result = sync_module.sync_routines()
+        assert result["skipped"] == 1
+        assert result["created"] == 0
+        create_mock.assert_not_called()
+
+    def test_schedule_when_date_given(self, tmp_path: Path) -> None:
+        routines = [{"id": "r1", "title": "Push", "updated_at": "2026-01-01T00:00:00Z", "exercises": []}]
+        store, _, schedule_mock, patches = self._patched(tmp_path, routines)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+            result = sync_module.sync_routines(schedule_date="2026-08-01")
+        assert result["scheduled"] == 1
+        assert schedule_mock.call_count == 1
+        assert schedule_mock.call_args[0][1:] == (777, "2026-08-01")
+        assert store.get_synced_routine("r1")["scheduled_date"] == "2026-08-01"
+
+    def test_dry_run_does_not_call_garmin(self, tmp_path: Path) -> None:
+        routines = [{"id": "r1", "title": "Push", "updated_at": "2026-01-01T00:00:00Z", "exercises": []}]
+        store, create_mock, _, patches = self._patched(tmp_path, routines)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+            result = sync_module.sync_routines(dry_run=True)
+        assert result["created"] == 1
+        create_mock.assert_not_called()
+        assert store.get_synced_routine("r1") is None

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -9,7 +9,7 @@ from hevy2garmin import sync as sync_module
 from hevy2garmin.db_sqlite import SQLiteDatabase
 from hevy2garmin.garmin import create_workout, delete_workout, schedule_workout
 from hevy2garmin.mapper import fit_exercise_strings
-from hevy2garmin.routine import routine_to_garmin_workout
+from hevy2garmin.routine import routine_to_garmin_workout, workout_content_hash
 
 
 class TestFitExerciseStrings:
@@ -233,16 +233,36 @@ class TestSyncRoutines:
         create_mock.assert_called_once()
         assert store.get_synced_routine("r1")["garmin_workout_id"] == "777"
 
-    def test_skips_already_synced(self, tmp_path: Path) -> None:
+    def _hash_for(self, routine: dict) -> str:
+        # Mirror how sync_routines builds the payload (no timing config → 75s default).
+        payload = routine_to_garmin_workout(routine, weight_unit="kilogram", default_rest_seconds=75)
+        return workout_content_hash(payload)
+
+    def test_skips_when_hash_unchanged(self, tmp_path: Path) -> None:
         routines = [{"id": "r1", "title": "Push", "updated_at": "2026-01-01T00:00:00Z", "exercises": []}]
         store, create_mock, _, patches = self._patched(tmp_path, routines)
         store.mark_routine_synced("r1", garmin_workout_id="777",
-                                  hevy_updated_at="2026-01-01T00:00:00Z")
+                                  content_hash=self._hash_for(routines[0]))
         with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
             result = sync_module.sync_routines()
         assert result["skipped"] == 1
         assert result["created"] == 0
         create_mock.assert_not_called()
+
+    def test_resyncs_when_hash_changed(self, tmp_path: Path) -> None:
+        routines = [{"id": "r1", "title": "Push", "updated_at": "2026-01-01T00:00:00Z", "exercises": []}]
+        store, create_mock, _, patches = self._patched(tmp_path, routines)
+        delete_mock = MagicMock()
+        # Stored under a stale hash → payload differs → recreate.
+        store.mark_routine_synced("r1", garmin_workout_id="555", content_hash="stale-hash")
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+                patch.object(sync_module, "delete_workout", delete_mock), patches[6]:
+            result = sync_module.sync_routines()
+        assert result["created"] == 1
+        assert result["skipped"] == 0
+        create_mock.assert_called_once()
+        delete_mock.assert_called_once_with(delete_mock.call_args[0][0], "555")
+        assert store.get_synced_routine("r1")["content_hash"] == self._hash_for(routines[0])
 
     def test_schedule_when_date_given(self, tmp_path: Path) -> None:
         routines = [{"id": "r1", "title": "Push", "updated_at": "2026-01-01T00:00:00Z", "exercises": []}]

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from hevy2garmin import sync as sync_module
+from hevy2garmin.sync import routine_schedule_dates
 from hevy2garmin.db_sqlite import SQLiteDatabase
 from hevy2garmin.garmin import create_workout, delete_workout, schedule_workout
 from hevy2garmin.mapper import fit_exercise_strings
@@ -303,3 +306,88 @@ class TestSyncRoutines:
         assert result["created"] == 1
         create_mock.assert_not_called()
         assert store.get_synced_routine("r1") is None
+
+
+class TestRoutineScheduleDates:
+    def test_once_returns_single_date(self) -> None:
+        assert routine_schedule_dates("once", date="2026-07-20") == ["2026-07-20"]
+
+    def test_once_requires_date(self) -> None:
+        with pytest.raises(ValueError):
+            routine_schedule_dates("once")
+
+    def test_once_rejects_bad_date(self) -> None:
+        with pytest.raises(ValueError):
+            routine_schedule_dates("once", date="not-a-date")
+
+    def test_recurring_weekly(self) -> None:
+        # 2026-07-15 is a Wednesday; first Monday on/after is 2026-07-20.
+        dates = routine_schedule_dates("recurring", weekday=0, start_date="2026-07-15", weeks=5)
+        assert dates == ["2026-07-20", "2026-07-27", "2026-08-03", "2026-08-10", "2026-08-17"]
+
+    def test_recurring_start_on_weekday_includes_start(self) -> None:
+        # 2026-07-20 is a Monday → the start date itself is the first occurrence.
+        dates = routine_schedule_dates("recurring", weekday=0, start_date="2026-07-20", weeks=2)
+        assert dates == ["2026-07-20", "2026-07-27"]
+
+    def test_recurring_accepts_string_inputs(self) -> None:
+        dates = routine_schedule_dates("recurring", weekday="2", start_date="2026-07-15", weeks="1")
+        assert dates == ["2026-07-15"]  # 2026-07-15 is a Wednesday (weekday 2)
+
+    def test_recurring_requires_all_fields(self) -> None:
+        with pytest.raises(ValueError):
+            routine_schedule_dates("recurring", weekday=0, weeks=3)
+
+    def test_recurring_rejects_bad_weekday(self) -> None:
+        with pytest.raises(ValueError):
+            routine_schedule_dates("recurring", weekday=9, start_date="2026-07-15", weeks=2)
+
+    def test_recurring_capped(self) -> None:
+        dates = routine_schedule_dates("recurring", weekday=0, start_date="2026-01-05", weeks=999)
+        assert len(dates) == sync_module.MAX_SCHEDULE_OCCURRENCES
+
+    def test_unknown_mode(self) -> None:
+        with pytest.raises(ValueError):
+            routine_schedule_dates("bogus")
+
+
+class TestScheduleRoutine:
+    def _patched(self, tmp_path: Path):
+        store = SQLiteDatabase(tmp_path / "sched.db")
+        schedule_mock = MagicMock()
+        client = MagicMock()
+        patches = [
+            patch.object(sync_module, "load_config", return_value={
+                "garmin_email": "e", "garmin_password": "p"}),
+            patch.object(sync_module.db, "get_db", return_value=store),
+            patch.object(sync_module, "get_client", return_value=client),
+            patch.object(sync_module, "schedule_workout", schedule_mock),
+        ]
+        return store, schedule_mock, patches
+
+    def test_schedules_each_date(self, tmp_path: Path) -> None:
+        store, schedule_mock, patches = self._patched(tmp_path)
+        store.mark_routine_synced("r1", garmin_workout_id="900", title="Push")
+        dates = ["2026-07-20", "2026-07-27"]
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = sync_module.schedule_routine("r1", dates)
+        assert result == {"scheduled": 2, "workout_id": "900", "dates": dates}
+        assert schedule_mock.call_count == 2
+        assert [c.args[1:] for c in schedule_mock.call_args_list] == [
+            ("900", "2026-07-20"), ("900", "2026-07-27")]
+        # Earliest date persisted for display.
+        assert store.get_synced_routine("r1")["scheduled_date"] == "2026-07-20"
+
+    def test_raises_when_not_synced(self, tmp_path: Path) -> None:
+        store, schedule_mock, patches = self._patched(tmp_path)
+        with patches[0], patches[1], patches[2], patches[3]:
+            with pytest.raises(ValueError, match="not synced"):
+                sync_module.schedule_routine("missing", ["2026-07-20"])
+        schedule_mock.assert_not_called()
+
+    def test_raises_on_empty_dates(self, tmp_path: Path) -> None:
+        store, _, patches = self._patched(tmp_path)
+        store.mark_routine_synced("r1", garmin_workout_id="900")
+        with patches[0], patches[1], patches[2], patches[3]:
+            with pytest.raises(ValueError):
+                sync_module.schedule_routine("r1", [])

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -104,6 +104,71 @@ class TestRoutineToGarminWorkout:
         payload = routine_to_garmin_workout({"title": "Empty", "exercises": []})
         assert payload["workoutSegments"][0]["workoutSteps"] == []
 
+    def test_no_rest_by_default(self) -> None:
+        # _routine() has no rest_seconds and no default → no rest steps.
+        steps = routine_to_garmin_workout(self._routine())["workoutSegments"][0]["workoutSteps"]
+        assert all(s["stepType"]["stepTypeKey"] != "rest" for s in steps)
+
+
+class TestRestSteps:
+    def _routine(self, rest=None) -> dict:
+        ex: dict = {"title": "Bench Press (Barbell)", "sets": [
+            {"type": "normal", "reps": 8, "weight_kg": 60},
+            {"type": "normal", "reps": 8, "weight_kg": 60},
+            {"type": "normal", "reps": 8, "weight_kg": 60},
+        ]}
+        if rest is not None:
+            ex["rest_seconds"] = rest
+        return {"title": "Push", "exercises": [ex]}
+
+    def test_rest_between_sets_from_hevy(self) -> None:
+        steps = routine_to_garmin_workout(self._routine(rest=90))["workoutSegments"][0]["workoutSteps"]
+        # 3 sets + 2 rests between them.
+        assert [s["stepType"]["stepTypeKey"] for s in steps] == [
+            "interval", "rest", "interval", "rest", "interval"]
+        assert [s["stepOrder"] for s in steps] == [1, 2, 3, 4, 5]
+
+    def test_rest_step_shape(self) -> None:
+        steps = routine_to_garmin_workout(self._routine(rest=90))["workoutSegments"][0]["workoutSteps"]
+        rest = steps[1]
+        assert rest["stepType"] == {"stepTypeId": 5, "stepTypeKey": "rest"}
+        assert rest["endCondition"]["conditionTypeKey"] == "time"
+        assert rest["endConditionValue"] == 90.0
+        assert "category" not in rest and "weightValue" not in rest
+
+    def test_no_rest_after_last_set(self) -> None:
+        steps = routine_to_garmin_workout(self._routine(rest=90))["workoutSegments"][0]["workoutSteps"]
+        assert steps[-1]["stepType"]["stepTypeKey"] == "interval"
+
+    def test_hevy_rest_overrides_default(self) -> None:
+        steps = routine_to_garmin_workout(
+            self._routine(rest=30), default_rest_seconds=120
+        )["workoutSegments"][0]["workoutSteps"]
+        assert steps[1]["endConditionValue"] == 30.0
+
+    def test_default_used_when_hevy_omits(self) -> None:
+        steps = routine_to_garmin_workout(
+            self._routine(), default_rest_seconds=75
+        )["workoutSegments"][0]["workoutSteps"]
+        rests = [s for s in steps if s["stepType"]["stepTypeKey"] == "rest"]
+        assert len(rests) == 2
+        assert all(s["endConditionValue"] == 75.0 for s in rests)
+
+    def test_zero_rest_adds_no_steps(self) -> None:
+        steps = routine_to_garmin_workout(self._routine(rest=0))["workoutSegments"][0]["workoutSteps"]
+        assert all(s["stepType"]["stepTypeKey"] != "rest" for s in steps)
+
+    def test_rest_not_added_across_exercises(self) -> None:
+        routine = {"title": "Full", "exercises": [
+            {"title": "Bench Press (Barbell)", "rest_seconds": 60,
+             "sets": [{"type": "normal", "reps": 5, "weight_kg": 60}]},
+            {"title": "Bench Press (Barbell)", "rest_seconds": 60,
+             "sets": [{"type": "normal", "reps": 5, "weight_kg": 60}]},
+        ]}
+        steps = routine_to_garmin_workout(routine)["workoutSegments"][0]["workoutSteps"]
+        # One set each, so no intra-exercise rest and none between exercises.
+        assert [s["stepType"]["stepTypeKey"] for s in steps] == ["interval", "interval"]
+
 
 class TestGarminWorkoutOps:
     def test_create_workout_posts_and_returns_id(self) -> None:

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -229,7 +229,8 @@ class TestSyncRoutines:
         store, create_mock, _, patches = self._patched(tmp_path, routines)
         with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
             result = sync_module.sync_routines()
-        assert result == {"created": 1, "skipped": 0, "failed": 0, "scheduled": 0, "total": 1}
+        assert result == {"created": 1, "updated": 0, "skipped": 0, "failed": 0,
+                          "scheduled": 0, "total": 1}
         create_mock.assert_called_once()
         assert store.get_synced_routine("r1")["garmin_workout_id"] == "777"
 
@@ -258,7 +259,8 @@ class TestSyncRoutines:
         with patches[0], patches[1], patches[2], patches[3], patches[4], \
                 patch.object(sync_module, "delete_workout", delete_mock), patches[6]:
             result = sync_module.sync_routines()
-        assert result["created"] == 1
+        assert result["updated"] == 1
+        assert result["created"] == 0
         assert result["skipped"] == 0
         create_mock.assert_called_once()
         delete_mock.assert_called_once_with(delete_mock.call_args[0][0], "555")
@@ -285,7 +287,9 @@ class TestSyncRoutines:
         with patches[0], patches[1], patches[2], patches[3], patches[4], \
                 patch.object(sync_module, "delete_workout", delete_mock), patches[6]:
             result = sync_module.sync_routines(force=True)
-        assert result["created"] == 1
+        # Forcing a routine that was already synced counts as an update.
+        assert result["updated"] == 1
+        assert result["created"] == 0
         assert result["skipped"] == 0
         create_mock.assert_called_once()
         delete_mock.assert_called_once_with(delete_mock.call_args[0][0], "555")

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -254,6 +254,23 @@ class TestSyncRoutines:
         assert schedule_mock.call_args[0][1:] == (777, "2026-08-01")
         assert store.get_synced_routine("r1")["scheduled_date"] == "2026-08-01"
 
+    def test_force_recreates_already_synced(self, tmp_path: Path) -> None:
+        routines = [{"id": "r1", "title": "Push", "updated_at": "2026-01-01T00:00:00Z",
+                     "exercises": [{"title": "Bench Press (Barbell)",
+                                    "sets": [{"type": "normal", "reps": 5, "weight_kg": 60}]}]}]
+        store, create_mock, _, patches = self._patched(tmp_path, routines)
+        store.mark_routine_synced("r1", garmin_workout_id="555",
+                                  hevy_updated_at="2026-01-01T00:00:00Z")
+        delete_mock = MagicMock()
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+                patch.object(sync_module, "delete_workout", delete_mock), patches[6]:
+            result = sync_module.sync_routines(force=True)
+        assert result["created"] == 1
+        assert result["skipped"] == 0
+        create_mock.assert_called_once()
+        delete_mock.assert_called_once_with(delete_mock.call_args[0][0], "555")
+        assert store.get_synced_routine("r1")["garmin_workout_id"] == "777"
+
     def test_dry_run_does_not_call_garmin(self, tmp_path: Path) -> None:
         routines = [{"id": "r1", "title": "Push", "updated_at": "2026-01-01T00:00:00Z", "exercises": []}]
         store, create_mock, _, patches = self._patched(tmp_path, routines)

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hevy2garmin",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Sync Hevy workouts to Garmin Connect (TypeScript). FIT generation, exercise mapping, and upload. The TS twin of the Python hevy2garmin.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## What & why

hevy2garmin syncs completed Hevy workouts to Garmin, but there was no way to push Hevy **routines** (templates) into Garmin as planned workouts. This PR adds routine syncing: it pulls routines from the Hevy API and creates them in Garmin's workout-service as planned workouts, so your Hevy program shows up on the Garmin calendar. It supports per-routine scheduling (one-off and recurring weekly), timed rest steps between sets, and checksum-based re-sync so unchanged routines are skipped.

## Files changed

- `src/hevy2garmin/routine.py` — new module orchestrating routine → Garmin planned-workout sync (payload build, checksum, scheduling).
- `src/hevy2garmin/mapper.py` — routine exercise → Garmin workout-service exercise IDs (validated against a real Garmin export).
- `src/hevy2garmin/garmin.py` — Garmin workout-service operations (create/update/schedule workouts).
- `src/hevy2garmin/sync.py` — integrate routine sync into the pipeline; report created vs updated separately.
- `src/hevy2garmin/cli.py` — CLI commands to sync/schedule routines, incl. `--force` re-sync.
- `src/hevy2garmin/server.py` + `templates/routines.html`, `templates/dashboard.html`, `templates/base.html` — dashboard routines page, home-screen routine summary, and loading spinners.
- `src/hevy2garmin/db_interface.py`, `db_sqlite.py`, `db_postgres.py`, `db.py` — track synced routines (schedule + payload checksum) across both backends.
- `scripts/dump_garmin_workout.py` — dev helper to dump a Garmin workout, used to validate exercise IDs.
- `tests/test_routine.py`, `tests/test_db.py` — coverage for routine sync and the new DB surface.

## How to test

```bash
PYTHONPATH=src pytest tests/ -q          # SQLite (default)
DATABASE_URL=postgresql://test:test@localhost:5432/hevy2garmin_test PYTHONPATH=src pytest tests/ -q   # Postgres
```

Manual: run the dashboard (`PYTHONPATH=src python -m hevy2garmin.cli serve`), open the Routines page, sync a routine, then schedule it (one-off and recurring weekly) and confirm it lands on the Garmin calendar. Re-running a sync should report the routine as unchanged unless its payload changed (or `--force` is passed).

Locally: `382 passed, 7 skipped`.

## Breaking changes

None. The feature is additive; the new routine-tracking columns/table are created idempotently on startup for both SQLite and Postgres.

## Note on the version bump

This branch also bumps the version (`pyproject.toml` 0.5.19 → 0.5.20, `typescript/package.json` 0.1.3 → 0.1.4). Since merging to `main` triggers `publish.yml`, feel free to drop those commits or fold the release into your own process — whatever fits your release flow best.

Closes #235
