### PR TITLE
ci: run the TypeScript package tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,25 @@ jobs:
         env:
           DATABASE_URL: postgresql://test:test@localhost:5432/hevy2garmin_test
         run: python -m pytest tests/ -v
+
+  check-typescript:
+    name: Tests (TypeScript)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: typescript
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install
+        run: npm ci || npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test


### PR DESCRIPTION
Closes #240. Adds a check-typescript CI job (build + vitest) — the TS core previously had tests that never ran in CI.