### PR TITLE
chore(release): v0.5.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.20] - 2026-07-18
+
 ### Added
 - The watch-activity **Replace** strategy now extracts high-resolution heart-rate samples from the original Garmin FIT and embeds them in the named Hevy replacement before deleting the watch copy. If the source cannot be extracted or restored from backup, replacement stops and preserves the original activity.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hevy2garmin"
-version = "0.5.19"
+version = "0.5.20"
 description = "Sync Hevy gym workouts to Garmin Connect — exercise mapping, FIT file generation, and automatic upload"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Release 0.5.20.

Ships the watch-activity **Replace** strategy preserving the watch's native high-resolution heart rate (#228, thanks @donndonn) before deleting the watch copy, so a replaced watch-recorded activity keeps crisp HR alongside named exercises.

Version bump 0.5.19 → 0.5.20 + CHANGELOG. Merging to `main` triggers the PyPI publish.
