### PR TITLE
fix(sync): Replace degrades gracefully when watch HR can't be extracted (#244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.21] - 2026-07-19
+
+### Fixed
+- The **Replace** watch strategy no longer aborts the whole sync when the watch's high-resolution HR cannot be extracted (a 0.5.20 regression, [#244](https://github.com/drkostas/hevy2garmin/issues/244)). It now keeps the watch activity and merges the sets into it in place, so the workout still syncs and the watch HR is never lost. Only the named-exercise display is dropped when the HR cannot be preserved. HR extraction also tolerates a small clock offset between the Hevy workout window and the watch recording.
+
 ## [0.5.20] - 2026-07-18
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hevy2garmin"
-version = "0.5.20"
+version = "0.5.21"
 description = "Sync Hevy gym workouts to Garmin Connect — exercise mapping, FIT file generation, and automatic upload"
 readme = "README.md"
 license = "MIT"

--- a/src/hevy2garmin/hr.py
+++ b/src/hevy2garmin/hr.py
@@ -162,6 +162,11 @@ def fetch_activity_hr(
         logger.debug("activity HR fetch failed for %s: %s", activity_id, exc)
         return []
 
+    # Tolerate a small offset between the Hevy workout window and the watch's
+    # own recording clock (#244): a strict in-window match dropped every sample
+    # when the two differed even slightly, which then hard-failed Replace. The
+    # graceful merge fallback in sync_one_workout covers larger gaps.
+    window_buffer_ms = 180_000  # 3 minutes
     samples: list[dict] = []
     for record in fit_file.records:
         message = record.message
@@ -180,7 +185,7 @@ def fetch_activity_hr(
             bpm_int = int(bpm)
         except (TypeError, ValueError):
             continue
-        if start_ms <= timestamp_ms <= end_ms and 0 < bpm_int < 256:
+        if (start_ms - window_buffer_ms) <= timestamp_ms <= (end_ms + window_buffer_ms) and 0 < bpm_int < 256:
             samples.append({
                 "time": max(0.0, (timestamp_ms - start_ms) / 1000.0),
                 "hr": bpm_int,

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -354,18 +354,79 @@ def sync_one_workout(
         merge_fallback = False
 
     if merge_delete_id is not None and not dry_run:
-        # Deletion is allowed only after the best-known source HR is durable.
-        # This runs even when HR embedding is disabled: disabling fusion should
-        # not discard the only recoverable high-resolution recording.
-        from hevy2garmin.hr import require_activity_hr_backup
+        # Replace wants to delete the watch activity. That is only safe once the
+        # watch's high-resolution HR is durably backed up so it can be embedded
+        # in the named replacement. Runs even with HR embedding disabled:
+        # disabling fusion must not discard the only recoverable recording.
+        from hevy2garmin.hr import HRBackupError, backup_activity_hr
 
-        protected_source_hr = require_activity_hr_backup(
-            merge_store,
-            garmin_client,
-            workout,
-            merge_delete_id,
-            _hr_limiter,
-        )
+        try:
+            protected_source_hr = backup_activity_hr(
+                merge_store, garmin_client, workout, merge_delete_id, _hr_limiter,
+            ) or None
+        except HRBackupError as exc:
+            logger.warning(
+                "  ⚠ Could not durably back up HR from watch activity %s: %s",
+                merge_delete_id, exc,
+            )
+            protected_source_hr = None
+
+        if protected_source_hr is None:
+            # The watch's hi-res HR could not be preserved (e.g. the FIT has no
+            # per-record HR, or the download failed). Deleting the watch copy
+            # would lose that HR for good, so instead of aborting the whole sync
+            # (#244 regression) fall back to merging the sets into the watch
+            # activity in place: the watch and its HR stay, the structured sets
+            # land, and the exercise names show as placeholders. Always syncs and
+            # never loses HR — only the named-exercise nicety is dropped when the
+            # HR cannot be preserved.
+            logger.info(
+                "  ⚠ Hi-res HR unavailable for watch activity %s; keeping it and "
+                "merging sets in place instead of replacing (names may show as Unknown)",
+                merge_delete_id,
+            )
+            fallback = attempt_merge(
+                garmin_client,
+                workout,
+                merge_store,
+                overlap_threshold=merge_overlap_pct,
+                max_drift_minutes=merge_max_drift_min,
+                activity_types=merge_activity_types,
+                watch_strategy="merge",
+            )
+            if fallback.merged:
+                fit_stats = _estimate_fit_stats(workout)
+                merge_store.mark_synced(
+                    hevy_id=wid,
+                    garmin_activity_id=str(fallback.activity_id),
+                    title=title,
+                    calories=fit_stats.get("calories"),
+                    avg_hr=fit_stats.get("avg_hr"),
+                    hevy_updated_at=workout.get("updated_at"),
+                    sync_method="merge",
+                )
+                logger.info(
+                    "  ⚡ Merged sets into watch activity %s (HR preserved in place)",
+                    fallback.activity_id,
+                )
+                return SyncOneResult(
+                    status="synced",
+                    activity_id=fallback.activity_id,
+                    sync_method="merge",
+                    merged=True,
+                    calories=fit_stats.get("calories"),
+                    avg_hr=fit_stats.get("avg_hr"),
+                )
+            # In-place merge also failed. Do NOT delete the watch activity —
+            # leave it intact and upload a fresh named activity alongside it, so
+            # the workout still syncs and nothing is lost.
+            logger.warning(
+                "  In-place merge fallback failed (%s); uploading a named activity "
+                "without removing the watch copy",
+                fallback.fallback_reason,
+            )
+            merge_delete_id = None
+            merge_forced_fresh = True
 
     hr_samples = None
     if not dry_run and hr_fusion_on:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -349,36 +349,53 @@ class TestSyncOneWorkout:
                 sync_method="merge",
             )
 
-    def test_watch_replacement_requires_backup_even_with_hr_fusion_off(
+    def test_watch_replacement_falls_back_to_merge_when_hr_unextractable(
         self, sample_workout: dict
     ) -> None:
-        from hevy2garmin.hr import HRBackupError
+        # Regression #244: when Replace cannot preserve the watch's hi-res HR, it
+        # must NOT hard-abort and must NOT delete the watch activity. It falls
+        # back to merging the sets into the watch in place (keeps the watch and
+        # its HR), so the sync still succeeds and no HR is lost.
+        mock_db = MagicMock()
+        with patch("hevy2garmin.sync.attempt_merge") as mock_merge, \
+             patch("hevy2garmin.hr.backup_activity_hr", return_value=[]) as backup, \
+             patch("hevy2garmin.sync._estimate_fit_stats", return_value={"calories": 100, "avg_hr": 90}), \
+             patch("hevy2garmin.sync.generate_fit") as generate_fit, \
+             patch("hevy2garmin.sync.upload_fit") as upload_fit:
+            mock_merge.side_effect = [
+                MergeResult(
+                    merged=False,
+                    force_fresh_upload=True,
+                    delete_after_upload=444,
+                    fallback_reason="watch replacement",
+                ),
+                MergeResult(merged=True, activity_id=444),
+            ]
 
-        with patch("hevy2garmin.sync.attempt_merge") as mock_merge, patch(
-            "hevy2garmin.hr.require_activity_hr_backup",
-            side_effect=HRBackupError("source activity preserved"),
-        ) as require_backup, patch("hevy2garmin.sync.generate_fit") as generate_fit:
-            mock_merge.return_value = MergeResult(
-                merged=False,
-                force_fresh_upload=True,
-                delete_after_upload=444,
-                fallback_reason="watch replacement",
+            result = sync_one_workout(
+                sample_workout,
+                cfg={
+                    "merge_mode": True,
+                    "merge_watch_strategy": "replace",
+                    "hr_fusion": {"enabled": False},
+                },
+                garmin_client=MagicMock(),
+                database=mock_db,
             )
 
-            with pytest.raises(HRBackupError, match="source activity preserved"):
-                sync_one_workout(
-                    sample_workout,
-                    cfg={
-                        "merge_mode": True,
-                        "merge_watch_strategy": "replace",
-                        "hr_fusion": {"enabled": False},
-                    },
-                    garmin_client=MagicMock(),
-                    database=MagicMock(),
-                )
-
-        require_backup.assert_called_once()
+        # HR backup was attempted (data-safety intent preserved) ...
+        backup.assert_called_once()
+        # ... but no hard abort, no fresh upload, and no watch deletion.
         generate_fit.assert_not_called()
+        upload_fit.assert_not_called()
+        # Fell back to an in-place merge (second attempt_merge, watch_strategy=merge).
+        assert mock_merge.call_count == 2
+        assert mock_merge.call_args_list[1].kwargs["watch_strategy"] == "merge"
+        assert result.status == "synced"
+        assert result.sync_method == "merge"
+        assert result.merged is True
+        assert result.activity_id == 444
+        mock_db.mark_synced.assert_called_once()
 
     def test_description_disabled_skips_set_description(self, sample_workout: dict) -> None:
         with patch("hevy2garmin.sync.db") as mock_db, \


### PR DESCRIPTION
Fixes #244, a regression introduced in 0.5.20.

0.5.20 (#228) made the Replace watch strategy extract and back up the watch's high-resolution HR before deleting the watch copy, and abort the whole sync if that extraction failed. For watch activities where the HR cannot be extracted, that turned a working sync into a hard failure (`HR could not be extracted ... source activity preserved`).

This makes Replace degrade gracefully instead:
- When the hi-res HR cannot be preserved, keep the watch activity and merge the sets into it in place (watch + HR retained, structured sets land, names show as placeholders) rather than aborting or deleting.
- The watch activity is now deleted **only** when its HR was successfully backed up, so there is no new data-loss path.
- HR extraction tolerates a small clock offset between the Hevy window and the watch recording.

Full suite: **327 passed, 7 skipped**. New regression test: `test_watch_replacement_falls_back_to_merge_when_hr_unextractable`.

Closes #244
