### PR TITLE
fix(routines): persist synced routine before scheduling to prevent duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- Routine sync no longer risks a duplicate planned workout when Garmin scheduling fails mid-sync. Previously the created workout was only recorded *after* the schedule call, so a Garmin 429/500 on scheduling left the workout orphaned and untracked, and the next sync created a second copy. The workout is now persisted right after creation (as `schedule_pending`); if scheduling then fails, the next sync deletes and recreates that tracked workout and retries the schedule instead of duplicating it.
+
 ## [0.5.21] - 2026-07-19
 
 ### Fixed

--- a/src/hevy2garmin/db_interface.py
+++ b/src/hevy2garmin/db_interface.py
@@ -151,8 +151,14 @@ class Database(ABC):
         hevy_updated_at: str | None = None,
         scheduled_date: str | None = None,
         content_hash: str | None = None,
+        status: str = "success",
     ) -> None:
-        """Record a routine synced to a Garmin planned workout."""
+        """Record a routine synced to a Garmin planned workout.
+
+        ``status="schedule_pending"`` marks a workout that was created on Garmin
+        but whose calendar scheduling hasn't been confirmed yet, so the next sync
+        retries it instead of skipping the routine as already done.
+        """
 
     @abstractmethod
     def delete_synced_routine(self, hevy_routine_id: str) -> bool:

--- a/src/hevy2garmin/db_postgres.py
+++ b/src/hevy2garmin/db_postgres.py
@@ -198,6 +198,7 @@ class PostgresDatabase(Database):
         hevy_updated_at: str | None = None,
         scheduled_date: str | None = None,
         content_hash: str | None = None,
+        status: str = "success",
     ) -> None:
         with self._get_conn() as conn:
             with conn.cursor() as cur:
@@ -205,7 +206,7 @@ class PostgresDatabase(Database):
                     """
                     INSERT INTO synced_routines
                         (hevy_routine_id, garmin_workout_id, title, hevy_updated_at, scheduled_date, content_hash, status)
-                    VALUES (%s, %s, %s, %s, %s, %s, 'success')
+                    VALUES (%s, %s, %s, %s, %s, %s, %s)
                     ON CONFLICT (hevy_routine_id) DO UPDATE SET
                         garmin_workout_id = EXCLUDED.garmin_workout_id,
                         title = EXCLUDED.title,
@@ -213,9 +214,9 @@ class PostgresDatabase(Database):
                         scheduled_date = EXCLUDED.scheduled_date,
                         content_hash = EXCLUDED.content_hash,
                         synced_at = NOW(),
-                        status = 'success'
+                        status = EXCLUDED.status
                     """,
-                    (hevy_routine_id, garmin_workout_id, title, hevy_updated_at, scheduled_date, content_hash),
+                    (hevy_routine_id, garmin_workout_id, title, hevy_updated_at, scheduled_date, content_hash, status),
                 )
             conn.commit()
 

--- a/src/hevy2garmin/db_sqlite.py
+++ b/src/hevy2garmin/db_sqlite.py
@@ -192,13 +192,14 @@ class SQLiteDatabase(Database):
         hevy_updated_at: str | None = None,
         scheduled_date: str | None = None,
         content_hash: str | None = None,
+        status: str = "success",
     ) -> None:
         conn = self._get_conn()
         conn.execute(
             """
             INSERT INTO synced_routines
                 (hevy_routine_id, garmin_workout_id, title, hevy_updated_at, scheduled_date, content_hash, status)
-            VALUES (?, ?, ?, ?, ?, ?, 'success')
+            VALUES (?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(hevy_routine_id) DO UPDATE SET
                 garmin_workout_id = excluded.garmin_workout_id,
                 title = excluded.title,
@@ -206,9 +207,9 @@ class SQLiteDatabase(Database):
                 scheduled_date = excluded.scheduled_date,
                 content_hash = excluded.content_hash,
                 synced_at = datetime('now'),
-                status = 'success'
+                status = excluded.status
             """,
-            (hevy_routine_id, garmin_workout_id, title, hevy_updated_at, scheduled_date, content_hash),
+            (hevy_routine_id, garmin_workout_id, title, hevy_updated_at, scheduled_date, content_hash, status),
         )
         conn.commit()
         conn.close()

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -852,11 +852,16 @@ def sync_routines(
             )
             content_hash = workout_content_hash(payload)
 
-            # Skip when the generated payload is byte-for-byte what we last synced.
+            # Skip when the generated payload is byte-for-byte what we last synced
+            # AND the workout is fully landed. A row left in 'schedule_pending' (the
+            # workout was created but a prior run's schedule call failed) is not done,
+            # so we don't skip it — the next sync retries the schedule below.
             # Hashing the payload (not Hevy's updated_at) also re-syncs when this
             # builder changes — e.g. after adding rest steps. --force overrides it.
             existing = store.get_synced_routine(rid)
-            if not force and existing and existing.get("content_hash") == content_hash:
+            content_synced = bool(existing and existing.get("content_hash") == content_hash)
+            already_done = content_synced and (existing.get("status") or "success") == "success"
+            if not force and already_done:
                 logger.debug("Skipping routine %s (%s) — unchanged", rid, title)
                 stats["skipped"] += 1
                 continue
@@ -894,7 +899,21 @@ def sync_routines(
             # explicit schedule_date counts toward the "scheduled" stat; re-applying a
             # stored date is a restore, not a new booking.
             effective_schedule_date = schedule_date or (existing or {}).get("scheduled_date")
+
             if effective_schedule_date:
+                # Persist the created workout *before* the schedule call, marked
+                # 'schedule_pending'. If scheduling then errors (Garmin 429/500), the
+                # workout is already tracked, so the next sync deletes+recreates it
+                # instead of orphaning it and creating a duplicate.
+                store.mark_routine_synced(
+                    rid,
+                    garmin_workout_id=str(workout_id),
+                    title=title,
+                    hevy_updated_at=updated_at,
+                    scheduled_date=effective_schedule_date,
+                    content_hash=content_hash,
+                    status="schedule_pending",
+                )
                 schedule_workout(garmin_client, workout_id, effective_schedule_date)
                 if schedule_date:
                     stats["scheduled"] += 1

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -328,6 +328,41 @@ class TestSyncRoutines:
         # ...and the date is kept on the record instead of being wiped to None.
         assert store.get_synced_routine("r1")["scheduled_date"] == "2026-08-01"
 
+    def test_schedule_failure_persists_workout_then_recovers(self, tmp_path: Path) -> None:
+        # #2 regression: create_workout succeeds, then schedule_workout errors. The
+        # created workout must be recorded (as schedule_pending) so the next sync
+        # recovers it instead of orphaning it and creating a duplicate.
+        routines = [{"id": "r1", "title": "Push", "updated_at": "2026-01-01T00:00:00Z", "exercises": []}]
+        store, create_mock, schedule_mock, patches = self._patched(tmp_path, routines)
+        schedule_mock.side_effect = RuntimeError("Garmin 429")
+
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+            first = sync_module.sync_routines(schedule_date="2026-08-01")
+
+        # The schedule failed, but the created workout is tracked (not orphaned).
+        assert first["failed"] == 1
+        assert first["created"] == 0
+        record = store.get_synced_routine("r1")
+        assert record is not None
+        assert record["garmin_workout_id"] == "777"
+        assert record["status"] == "schedule_pending"
+
+        # Next sync: scheduling recovers. The pending workout is deleted and recreated
+        # (no second, untracked copy) and the schedule is retried on the stored date.
+        schedule_mock.side_effect = None
+        delete_mock = MagicMock()
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+                patch.object(sync_module, "delete_workout", delete_mock), patches[6]:
+            second = sync_module.sync_routines()
+
+        assert second["updated"] == 1
+        assert second["failed"] == 0
+        # The previously-created workout (777) is deleted before recreating — orphan recovered.
+        delete_mock.assert_called_once_with(delete_mock.call_args[0][0], "777")
+        final = store.get_synced_routine("r1")
+        assert final["status"] == "success"
+        assert final["scheduled_date"] == "2026-08-01"
+
 
 class TestRoutineScheduleDates:
     def test_once_returns_single_date(self) -> None:


### PR DESCRIPTION
## What changed and why

Routine sync recorded the created Garmin workout only *after* the schedule call, so a Garmin 429/500 while scheduling left the workout orphaned and untracked — and the next sync created a second copy on the user's real calendar. This persists the workout right after `create_workout` returns an id (marked `schedule_pending`), then schedules as a separate step. A row left pending isn't skipped, so the next sync deletes and recreates that *tracked* workout and retries the schedule instead of duplicating it. Addresses point #2 from the #236 review.

## Technical details

### Files changed
- `src/hevy2garmin/sync.py` — in `sync_routines`, persist the created workout as `schedule_pending` before the schedule call; skip only when content is synced **and** status is `success`, so a pending row is retried.
- `src/hevy2garmin/db_interface.py`, `db_sqlite.py`, `db_postgres.py` — thread a `status` arg through `mark_routine_synced` (default `"success"`, so all existing callers are unchanged).
- `tests/test_routine.py` — regression test: a schedule failure persists the workout (no orphan), and the next sync recovers it (deletes the tracked `777`, recreates, retries schedule) without duplicating.
- `CHANGELOG.md` — Unreleased entry.

### Approach and trade-offs
Reuses the existing `status` column (already `DEFAULT 'success'` on both backends) as a pending flag — no schema migration. On a retry the workout is deleted+recreated rather than adopted in place; slightly more Garmin calls on the rare failure path, but it reuses the module's established delete-then-recreate pattern and keeps the diff small. Full Garmin-library reconciliation (review point #3) would make this even more robust but is intentionally out of scope here.

### How to test
```bash
PYTHONPATH=src pytest tests/test_routine.py tests/test_db.py -q
DATABASE_URL=postgresql://test:test@localhost:5432/hevy2garmin_test PYTHONPATH=src pytest tests/ -q
```
Local: `384 passed, 7 skipped`.

### Breaking changes
None. `status` defaults to `"success"`; the column already exists on SQLite and Postgres (no migration).

### Checklist
- [x] Tests added or updated
- [x] No sensitive data in logs or responses
- [x] Migrations are backward-compatible (no schema change)
- [ ] Feature flag added (n/a)

---

Follow-up to the review on #236 (point #2). No version bump — leaving the release to your own process. Happy to fold in #3 (reconcile against the Garmin library) and #4 (unschedule-before-reschedule) here or in separate PRs, whichever you prefer.
