### PR TITLE
feat(routines): scheduled workouts table; fix(scheduling) append-only re-scheduling

### DIFF
--- a/src/hevy2garmin/db_interface.py
+++ b/src/hevy2garmin/db_interface.py
@@ -162,7 +162,21 @@ class Database(ABC):
 
     @abstractmethod
     def delete_synced_routine(self, hevy_routine_id: str) -> bool:
-        """Remove a routine sync record. Returns True if a record was deleted."""
+        """Remove a routine sync record (and its calendar entries). True if deleted."""
+
+    @abstractmethod
+    def add_routine_schedule(
+        self, hevy_routine_id: str, schedule_id: str, scheduled_date: str | None = None
+    ) -> None:
+        """Record a Garmin calendar entry (``workoutScheduleId``) for a routine."""
+
+    @abstractmethod
+    def get_routine_schedule_ids(self, hevy_routine_id: str) -> list[str]:
+        """Return the Garmin calendar entry ids currently booked for a routine."""
+
+    @abstractmethod
+    def clear_routine_schedules(self, hevy_routine_id: str) -> None:
+        """Drop all tracked calendar entries for a routine (after unscheduling them)."""
 
     @abstractmethod
     def get_routine_stats(self) -> dict:

--- a/src/hevy2garmin/db_interface.py
+++ b/src/hevy2garmin/db_interface.py
@@ -179,6 +179,24 @@ class Database(ABC):
         """Drop all tracked calendar entries for a routine (after unscheduling them)."""
 
     @abstractmethod
+    def delete_routine_schedule(self, hevy_routine_id: str, schedule_id: str) -> bool:
+        """Drop one tracked calendar entry. Returns True if a row was removed."""
+
+    @abstractmethod
+    def get_upcoming_routine_schedules(
+        self, on_or_after: str, limit: int, offset: int
+    ) -> list[dict]:
+        """Return scheduled calendar entries on/after ``on_or_after`` (ISO date), with
+        the routine title, ordered by date. Paginated via ``limit``/``offset``.
+
+        Each dict has ``hevy_routine_id``, ``schedule_id``, ``scheduled_date``, ``title``.
+        """
+
+    @abstractmethod
+    def count_upcoming_routine_schedules(self, on_or_after: str) -> int:
+        """Count scheduled calendar entries on/after ``on_or_after`` (for pagination)."""
+
+    @abstractmethod
     def get_routine_stats(self) -> dict:
         """Return routine sync counts: ``{"synced": int, "scheduled": int}``."""
 

--- a/src/hevy2garmin/db_interface.py
+++ b/src/hevy2garmin/db_interface.py
@@ -184,17 +184,22 @@ class Database(ABC):
 
     @abstractmethod
     def get_upcoming_routine_schedules(
-        self, on_or_after: str, limit: int, offset: int
+        self, on_or_after: str, limit: int, offset: int, title_query: str | None = None
     ) -> list[dict]:
         """Return scheduled calendar entries on/after ``on_or_after`` (ISO date), with
         the routine title, ordered by date. Paginated via ``limit``/``offset``.
 
-        Each dict has ``hevy_routine_id``, ``schedule_id``, ``scheduled_date``, ``title``.
+        ``title_query`` (optional) filters to routines whose title contains it
+        (case-insensitive substring). Each dict has ``hevy_routine_id``,
+        ``schedule_id``, ``scheduled_date``, ``title``.
         """
 
     @abstractmethod
-    def count_upcoming_routine_schedules(self, on_or_after: str) -> int:
-        """Count scheduled calendar entries on/after ``on_or_after`` (for pagination)."""
+    def count_upcoming_routine_schedules(
+        self, on_or_after: str, title_query: str | None = None
+    ) -> int:
+        """Count scheduled entries on/after ``on_or_after`` (optionally filtered by
+        ``title_query``), for pagination."""
 
     @abstractmethod
     def get_routine_stats(self) -> dict:

--- a/src/hevy2garmin/db_interface.py
+++ b/src/hevy2garmin/db_interface.py
@@ -175,6 +175,10 @@ class Database(ABC):
         """Return the Garmin calendar entry ids currently booked for a routine."""
 
     @abstractmethod
+    def get_routine_scheduled_dates(self, hevy_routine_id: str) -> list[str]:
+        """Return the distinct dates (ISO) a routine currently has booked, ascending."""
+
+    @abstractmethod
     def clear_routine_schedules(self, hevy_routine_id: str) -> None:
         """Drop all tracked calendar entries for a routine (after unscheduling them)."""
 

--- a/src/hevy2garmin/db_postgres.py
+++ b/src/hevy2garmin/db_postgres.py
@@ -270,6 +270,42 @@ class PostgresDatabase(Database):
                 )
             conn.commit()
 
+    def delete_routine_schedule(self, hevy_routine_id: str, schedule_id: str) -> bool:
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM routine_schedules WHERE hevy_routine_id = %s AND schedule_id = %s",
+                    (hevy_routine_id, str(schedule_id)),
+                )
+                deleted = cur.rowcount > 0
+            conn.commit()
+            return deleted
+
+    def get_upcoming_routine_schedules(
+        self, on_or_after: str, limit: int, offset: int
+    ) -> list[dict]:
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT rs.hevy_routine_id, rs.schedule_id, rs.scheduled_date, sr.title "
+                    "FROM routine_schedules rs "
+                    "LEFT JOIN synced_routines sr ON rs.hevy_routine_id = sr.hevy_routine_id "
+                    "WHERE rs.scheduled_date >= %s "
+                    "ORDER BY rs.scheduled_date ASC, sr.title ASC "
+                    "LIMIT %s OFFSET %s",
+                    (on_or_after, limit, offset),
+                )
+                return [dict(r) for r in cur.fetchall()]
+
+    def count_upcoming_routine_schedules(self, on_or_after: str) -> int:
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT COUNT(*) AS n FROM routine_schedules WHERE scheduled_date >= %s",
+                    (on_or_after,),
+                )
+                return cur.fetchone()["n"]
+
     def get_routine_stats(self) -> dict:
         with self._get_conn() as conn:
             with conn.cursor() as cur:

--- a/src/hevy2garmin/db_postgres.py
+++ b/src/hevy2garmin/db_postgres.py
@@ -139,6 +139,14 @@ class PostgresDatabase(Database):
                     )
                 """)
                 cur.execute("ALTER TABLE synced_routines ADD COLUMN IF NOT EXISTS content_hash TEXT")
+                cur.execute("""
+                    CREATE TABLE IF NOT EXISTS routine_schedules (
+                        hevy_routine_id TEXT NOT NULL,
+                        schedule_id TEXT NOT NULL,
+                        scheduled_date TEXT,
+                        PRIMARY KEY (hevy_routine_id, schedule_id)
+                    )
+                """)
             conn.commit()
 
     def is_synced(self, hevy_id: str) -> bool:
@@ -227,8 +235,40 @@ class PostgresDatabase(Database):
                     "DELETE FROM synced_routines WHERE hevy_routine_id = %s", (hevy_routine_id,)
                 )
                 deleted = cur.rowcount > 0
+                cur.execute(
+                    "DELETE FROM routine_schedules WHERE hevy_routine_id = %s", (hevy_routine_id,)
+                )
             conn.commit()
             return deleted
+
+    def add_routine_schedule(
+        self, hevy_routine_id: str, schedule_id: str, scheduled_date: str | None = None
+    ) -> None:
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO routine_schedules (hevy_routine_id, schedule_id, scheduled_date) "
+                    "VALUES (%s, %s, %s) ON CONFLICT (hevy_routine_id, schedule_id) DO NOTHING",
+                    (hevy_routine_id, str(schedule_id), scheduled_date),
+                )
+            conn.commit()
+
+    def get_routine_schedule_ids(self, hevy_routine_id: str) -> list[str]:
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT schedule_id FROM routine_schedules WHERE hevy_routine_id = %s",
+                    (hevy_routine_id,),
+                )
+                return [r["schedule_id"] for r in cur.fetchall()]
+
+    def clear_routine_schedules(self, hevy_routine_id: str) -> None:
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "DELETE FROM routine_schedules WHERE hevy_routine_id = %s", (hevy_routine_id,)
+                )
+            conn.commit()
 
     def get_routine_stats(self) -> dict:
         with self._get_conn() as conn:

--- a/src/hevy2garmin/db_postgres.py
+++ b/src/hevy2garmin/db_postgres.py
@@ -282,28 +282,40 @@ class PostgresDatabase(Database):
             return deleted
 
     def get_upcoming_routine_schedules(
-        self, on_or_after: str, limit: int, offset: int
+        self, on_or_after: str, limit: int, offset: int, title_query: str | None = None
     ) -> list[dict]:
+        sql = (
+            "SELECT rs.hevy_routine_id, rs.schedule_id, rs.scheduled_date, sr.title "
+            "FROM routine_schedules rs "
+            "LEFT JOIN synced_routines sr ON rs.hevy_routine_id = sr.hevy_routine_id "
+            "WHERE rs.scheduled_date >= %s"
+        )
+        params: list = [on_or_after]
+        if title_query:
+            sql += " AND LOWER(sr.title) LIKE '%%' || LOWER(%s) || '%%'"
+            params.append(title_query)
+        sql += " ORDER BY rs.scheduled_date ASC, sr.title ASC LIMIT %s OFFSET %s"
+        params += [limit, offset]
         with self._get_conn() as conn:
             with conn.cursor() as cur:
-                cur.execute(
-                    "SELECT rs.hevy_routine_id, rs.schedule_id, rs.scheduled_date, sr.title "
-                    "FROM routine_schedules rs "
-                    "LEFT JOIN synced_routines sr ON rs.hevy_routine_id = sr.hevy_routine_id "
-                    "WHERE rs.scheduled_date >= %s "
-                    "ORDER BY rs.scheduled_date ASC, sr.title ASC "
-                    "LIMIT %s OFFSET %s",
-                    (on_or_after, limit, offset),
-                )
+                cur.execute(sql, params)
                 return [dict(r) for r in cur.fetchall()]
 
-    def count_upcoming_routine_schedules(self, on_or_after: str) -> int:
+    def count_upcoming_routine_schedules(
+        self, on_or_after: str, title_query: str | None = None
+    ) -> int:
+        sql = (
+            "SELECT COUNT(*) AS n FROM routine_schedules rs "
+            "LEFT JOIN synced_routines sr ON rs.hevy_routine_id = sr.hevy_routine_id "
+            "WHERE rs.scheduled_date >= %s"
+        )
+        params: list = [on_or_after]
+        if title_query:
+            sql += " AND LOWER(sr.title) LIKE '%%' || LOWER(%s) || '%%'"
+            params.append(title_query)
         with self._get_conn() as conn:
             with conn.cursor() as cur:
-                cur.execute(
-                    "SELECT COUNT(*) AS n FROM routine_schedules WHERE scheduled_date >= %s",
-                    (on_or_after,),
-                )
+                cur.execute(sql, params)
                 return cur.fetchone()["n"]
 
     def get_routine_stats(self) -> dict:

--- a/src/hevy2garmin/db_postgres.py
+++ b/src/hevy2garmin/db_postgres.py
@@ -262,6 +262,17 @@ class PostgresDatabase(Database):
                 )
                 return [r["schedule_id"] for r in cur.fetchall()]
 
+    def get_routine_scheduled_dates(self, hevy_routine_id: str) -> list[str]:
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT DISTINCT scheduled_date FROM routine_schedules "
+                    "WHERE hevy_routine_id = %s AND scheduled_date IS NOT NULL "
+                    "ORDER BY scheduled_date ASC",
+                    (hevy_routine_id,),
+                )
+                return [r["scheduled_date"] for r in cur.fetchall()]
+
     def clear_routine_schedules(self, hevy_routine_id: str) -> None:
         with self._get_conn() as conn:
             with conn.cursor() as cur:
@@ -281,41 +292,42 @@ class PostgresDatabase(Database):
             conn.commit()
             return deleted
 
-    def get_upcoming_routine_schedules(
-        self, on_or_after: str, limit: int, offset: int, title_query: str | None = None
-    ) -> list[dict]:
+    @staticmethod
+    def _upcoming_from_where(on_or_after: str, title_query: str | None) -> tuple[str, list]:
+        """Shared FROM/JOIN/WHERE for the upcoming-schedules get + count queries."""
         sql = (
-            "SELECT rs.hevy_routine_id, rs.schedule_id, rs.scheduled_date, sr.title "
             "FROM routine_schedules rs "
             "LEFT JOIN synced_routines sr ON rs.hevy_routine_id = sr.hevy_routine_id "
             "WHERE rs.scheduled_date >= %s"
         )
         params: list = [on_or_after]
         if title_query:
+            # %% is an escaped literal % under psycopg2's parameter substitution.
             sql += " AND LOWER(sr.title) LIKE '%%' || LOWER(%s) || '%%'"
             params.append(title_query)
-        sql += " ORDER BY rs.scheduled_date ASC, sr.title ASC LIMIT %s OFFSET %s"
-        params += [limit, offset]
+        return sql, params
+
+    def get_upcoming_routine_schedules(
+        self, on_or_after: str, limit: int, offset: int, title_query: str | None = None
+    ) -> list[dict]:
+        from_where, params = self._upcoming_from_where(on_or_after, title_query)
+        sql = (
+            "SELECT rs.hevy_routine_id, rs.schedule_id, rs.scheduled_date, sr.title "
+            + from_where
+            + " ORDER BY rs.scheduled_date ASC, sr.title ASC LIMIT %s OFFSET %s"
+        )
         with self._get_conn() as conn:
             with conn.cursor() as cur:
-                cur.execute(sql, params)
+                cur.execute(sql, params + [limit, offset])
                 return [dict(r) for r in cur.fetchall()]
 
     def count_upcoming_routine_schedules(
         self, on_or_after: str, title_query: str | None = None
     ) -> int:
-        sql = (
-            "SELECT COUNT(*) AS n FROM routine_schedules rs "
-            "LEFT JOIN synced_routines sr ON rs.hevy_routine_id = sr.hevy_routine_id "
-            "WHERE rs.scheduled_date >= %s"
-        )
-        params: list = [on_or_after]
-        if title_query:
-            sql += " AND LOWER(sr.title) LIKE '%%' || LOWER(%s) || '%%'"
-            params.append(title_query)
+        from_where, params = self._upcoming_from_where(on_or_after, title_query)
         with self._get_conn() as conn:
             with conn.cursor() as cur:
-                cur.execute(sql, params)
+                cur.execute("SELECT COUNT(*) AS n " + from_where, params)
                 return cur.fetchone()["n"]
 
     def get_routine_stats(self) -> dict:

--- a/src/hevy2garmin/db_sqlite.py
+++ b/src/hevy2garmin/db_sqlite.py
@@ -264,6 +264,43 @@ class SQLiteDatabase(Database):
         conn.commit()
         conn.close()
 
+    def delete_routine_schedule(self, hevy_routine_id: str, schedule_id: str) -> bool:
+        conn = self._get_conn()
+        cur = conn.execute(
+            "DELETE FROM routine_schedules WHERE hevy_routine_id = ? AND schedule_id = ?",
+            (hevy_routine_id, str(schedule_id)),
+        )
+        deleted = cur.rowcount > 0
+        conn.commit()
+        conn.close()
+        return deleted
+
+    def get_upcoming_routine_schedules(
+        self, on_or_after: str, limit: int, offset: int
+    ) -> list[dict]:
+        conn = self._get_conn()
+        rows = conn.execute(
+            "SELECT rs.hevy_routine_id, rs.schedule_id, rs.scheduled_date, sr.title "
+            "FROM routine_schedules rs "
+            "LEFT JOIN synced_routines sr ON rs.hevy_routine_id = sr.hevy_routine_id "
+            "WHERE rs.scheduled_date >= ? "
+            "ORDER BY rs.scheduled_date ASC, sr.title ASC "
+            "LIMIT ? OFFSET ?",
+            (on_or_after, limit, offset),
+        ).fetchall()
+        conn.close()
+        keys = ("hevy_routine_id", "schedule_id", "scheduled_date", "title")
+        return [dict(zip(keys, r)) for r in rows]
+
+    def count_upcoming_routine_schedules(self, on_or_after: str) -> int:
+        conn = self._get_conn()
+        row = conn.execute(
+            "SELECT COUNT(*) FROM routine_schedules WHERE scheduled_date >= ?",
+            (on_or_after,),
+        ).fetchone()
+        conn.close()
+        return row[0] or 0
+
     def get_routine_stats(self) -> dict:
         conn = self._get_conn()
         row = conn.execute(

--- a/src/hevy2garmin/db_sqlite.py
+++ b/src/hevy2garmin/db_sqlite.py
@@ -134,6 +134,14 @@ class SQLiteDatabase(Database):
                 status TEXT DEFAULT 'success'
             )
         """)
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS routine_schedules (
+                hevy_routine_id TEXT NOT NULL,
+                schedule_id TEXT NOT NULL,
+                scheduled_date TEXT,
+                PRIMARY KEY (hevy_routine_id, schedule_id)
+            )
+        """)
         # Migration: add content_hash to routine tables created before it existed.
         try:
             conn.execute("ALTER TABLE synced_routines ADD COLUMN content_hash TEXT")
@@ -220,9 +228,41 @@ class SQLiteDatabase(Database):
             "DELETE FROM synced_routines WHERE hevy_routine_id = ?", (hevy_routine_id,)
         )
         deleted = cur.rowcount > 0
+        conn.execute(
+            "DELETE FROM routine_schedules WHERE hevy_routine_id = ?", (hevy_routine_id,)
+        )
         conn.commit()
         conn.close()
         return deleted
+
+    def add_routine_schedule(
+        self, hevy_routine_id: str, schedule_id: str, scheduled_date: str | None = None
+    ) -> None:
+        conn = self._get_conn()
+        conn.execute(
+            "INSERT INTO routine_schedules (hevy_routine_id, schedule_id, scheduled_date) "
+            "VALUES (?, ?, ?) ON CONFLICT(hevy_routine_id, schedule_id) DO NOTHING",
+            (hevy_routine_id, str(schedule_id), scheduled_date),
+        )
+        conn.commit()
+        conn.close()
+
+    def get_routine_schedule_ids(self, hevy_routine_id: str) -> list[str]:
+        conn = self._get_conn()
+        rows = conn.execute(
+            "SELECT schedule_id FROM routine_schedules WHERE hevy_routine_id = ?",
+            (hevy_routine_id,),
+        ).fetchall()
+        conn.close()
+        return [r[0] for r in rows]
+
+    def clear_routine_schedules(self, hevy_routine_id: str) -> None:
+        conn = self._get_conn()
+        conn.execute(
+            "DELETE FROM routine_schedules WHERE hevy_routine_id = ?", (hevy_routine_id,)
+        )
+        conn.commit()
+        conn.close()
 
     def get_routine_stats(self) -> dict:
         conn = self._get_conn()

--- a/src/hevy2garmin/db_sqlite.py
+++ b/src/hevy2garmin/db_sqlite.py
@@ -256,6 +256,17 @@ class SQLiteDatabase(Database):
         conn.close()
         return [r[0] for r in rows]
 
+    def get_routine_scheduled_dates(self, hevy_routine_id: str) -> list[str]:
+        conn = self._get_conn()
+        rows = conn.execute(
+            "SELECT DISTINCT scheduled_date FROM routine_schedules "
+            "WHERE hevy_routine_id = ? AND scheduled_date IS NOT NULL "
+            "ORDER BY scheduled_date ASC",
+            (hevy_routine_id,),
+        ).fetchall()
+        conn.close()
+        return [r[0] for r in rows]
+
     def clear_routine_schedules(self, hevy_routine_id: str) -> None:
         conn = self._get_conn()
         conn.execute(
@@ -275,11 +286,10 @@ class SQLiteDatabase(Database):
         conn.close()
         return deleted
 
-    def get_upcoming_routine_schedules(
-        self, on_or_after: str, limit: int, offset: int, title_query: str | None = None
-    ) -> list[dict]:
+    @staticmethod
+    def _upcoming_from_where(on_or_after: str, title_query: str | None) -> tuple[str, list]:
+        """Shared FROM/JOIN/WHERE for the upcoming-schedules get + count queries."""
         sql = (
-            "SELECT rs.hevy_routine_id, rs.schedule_id, rs.scheduled_date, sr.title "
             "FROM routine_schedules rs "
             "LEFT JOIN synced_routines sr ON rs.hevy_routine_id = sr.hevy_routine_id "
             "WHERE rs.scheduled_date >= ?"
@@ -288,10 +298,19 @@ class SQLiteDatabase(Database):
         if title_query:
             sql += " AND LOWER(sr.title) LIKE '%' || LOWER(?) || '%'"
             params.append(title_query)
-        sql += " ORDER BY rs.scheduled_date ASC, sr.title ASC LIMIT ? OFFSET ?"
-        params += [limit, offset]
+        return sql, params
+
+    def get_upcoming_routine_schedules(
+        self, on_or_after: str, limit: int, offset: int, title_query: str | None = None
+    ) -> list[dict]:
+        from_where, params = self._upcoming_from_where(on_or_after, title_query)
+        sql = (
+            "SELECT rs.hevy_routine_id, rs.schedule_id, rs.scheduled_date, sr.title "
+            + from_where
+            + " ORDER BY rs.scheduled_date ASC, sr.title ASC LIMIT ? OFFSET ?"
+        )
         conn = self._get_conn()
-        rows = conn.execute(sql, params).fetchall()
+        rows = conn.execute(sql, params + [limit, offset]).fetchall()
         conn.close()
         keys = ("hevy_routine_id", "schedule_id", "scheduled_date", "title")
         return [dict(zip(keys, r)) for r in rows]
@@ -299,17 +318,9 @@ class SQLiteDatabase(Database):
     def count_upcoming_routine_schedules(
         self, on_or_after: str, title_query: str | None = None
     ) -> int:
-        sql = (
-            "SELECT COUNT(*) FROM routine_schedules rs "
-            "LEFT JOIN synced_routines sr ON rs.hevy_routine_id = sr.hevy_routine_id "
-            "WHERE rs.scheduled_date >= ?"
-        )
-        params: list = [on_or_after]
-        if title_query:
-            sql += " AND LOWER(sr.title) LIKE '%' || LOWER(?) || '%'"
-            params.append(title_query)
+        from_where, params = self._upcoming_from_where(on_or_after, title_query)
         conn = self._get_conn()
-        row = conn.execute(sql, params).fetchone()
+        row = conn.execute("SELECT COUNT(*) " + from_where, params).fetchone()
         conn.close()
         return row[0] or 0
 

--- a/src/hevy2garmin/db_sqlite.py
+++ b/src/hevy2garmin/db_sqlite.py
@@ -276,28 +276,40 @@ class SQLiteDatabase(Database):
         return deleted
 
     def get_upcoming_routine_schedules(
-        self, on_or_after: str, limit: int, offset: int
+        self, on_or_after: str, limit: int, offset: int, title_query: str | None = None
     ) -> list[dict]:
-        conn = self._get_conn()
-        rows = conn.execute(
+        sql = (
             "SELECT rs.hevy_routine_id, rs.schedule_id, rs.scheduled_date, sr.title "
             "FROM routine_schedules rs "
             "LEFT JOIN synced_routines sr ON rs.hevy_routine_id = sr.hevy_routine_id "
-            "WHERE rs.scheduled_date >= ? "
-            "ORDER BY rs.scheduled_date ASC, sr.title ASC "
-            "LIMIT ? OFFSET ?",
-            (on_or_after, limit, offset),
-        ).fetchall()
+            "WHERE rs.scheduled_date >= ?"
+        )
+        params: list = [on_or_after]
+        if title_query:
+            sql += " AND LOWER(sr.title) LIKE '%' || LOWER(?) || '%'"
+            params.append(title_query)
+        sql += " ORDER BY rs.scheduled_date ASC, sr.title ASC LIMIT ? OFFSET ?"
+        params += [limit, offset]
+        conn = self._get_conn()
+        rows = conn.execute(sql, params).fetchall()
         conn.close()
         keys = ("hevy_routine_id", "schedule_id", "scheduled_date", "title")
         return [dict(zip(keys, r)) for r in rows]
 
-    def count_upcoming_routine_schedules(self, on_or_after: str) -> int:
+    def count_upcoming_routine_schedules(
+        self, on_or_after: str, title_query: str | None = None
+    ) -> int:
+        sql = (
+            "SELECT COUNT(*) FROM routine_schedules rs "
+            "LEFT JOIN synced_routines sr ON rs.hevy_routine_id = sr.hevy_routine_id "
+            "WHERE rs.scheduled_date >= ?"
+        )
+        params: list = [on_or_after]
+        if title_query:
+            sql += " AND LOWER(sr.title) LIKE '%' || LOWER(?) || '%'"
+            params.append(title_query)
         conn = self._get_conn()
-        row = conn.execute(
-            "SELECT COUNT(*) FROM routine_schedules WHERE scheduled_date >= ?",
-            (on_or_after,),
-        ).fetchone()
+        row = conn.execute(sql, params).fetchone()
         conn.close()
         return row[0] or 0
 

--- a/src/hevy2garmin/garmin.py
+++ b/src/hevy2garmin/garmin.py
@@ -441,16 +441,36 @@ def delete_workout(client: Garmin, workout_id: int | str) -> None:
     logger.info("  Deleted Garmin workout %s", workout_id)
 
 
-def schedule_workout(client: Garmin, workout_id: int | str, date: str) -> None:
-    """Schedule a saved Garmin workout onto the calendar for ``date`` (YYYY-MM-DD)."""
+def schedule_workout(client: Garmin, workout_id: int | str, date: str) -> int | None:
+    """Schedule a saved Garmin workout onto the calendar for ``date`` (YYYY-MM-DD).
+
+    Returns the ``workoutScheduleId`` Garmin assigns to the new calendar entry so
+    the caller can track and later unschedule it (Garmin appends a fresh entry on
+    every POST — it does not dedup server-side). Returns ``None`` if the response
+    carries no parseable id, so scheduling still succeeds even if the shape drifts.
+    """
     time.sleep(1.0)  # manual rate limit
-    client.client.request(
+    resp = client.client.request(
         "POST",
         "connectapi",
         f"/workout-service/schedule/{workout_id}",
         json={"date": date},
     )
     logger.info("  Scheduled Garmin workout %s for %s", workout_id, date)
+    try:
+        data = resp.json() if hasattr(resp, "json") else resp
+        return data.get("workoutScheduleId") if isinstance(data, dict) else None
+    except Exception:
+        return None
+
+
+def unschedule_workout(client: Garmin, scheduled_id: int | str) -> None:
+    """Remove a calendar entry (``workoutScheduleId``) without deleting the workout."""
+    time.sleep(1.0)  # manual rate limit
+    client.client.request(
+        "DELETE", "connectapi", f"/workout-service/schedule/{scheduled_id}"
+    )
+    logger.info("  Unscheduled Garmin calendar entry %s", scheduled_id)
 
 
 def generate_description(workout: dict, calories: int | None = None, avg_hr: int | None = None) -> str:

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -1413,7 +1413,11 @@ async def api_routines_sync(request: Request):
         + (f", {result['scheduled']} scheduled" if result.get("scheduled") else "")
     )
     cls = "toast-error" if result["failed"] else "toast-success"
-    return HTMLResponse(f'<div class="toast {cls}">Routine sync complete: {msg}</div>')
+    # Sync's restore path can (re)schedule routines, so refresh the schedules table too.
+    return HTMLResponse(
+        f'<div class="toast {cls}">Routine sync complete: {msg}</div>',
+        headers={"HX-Trigger": "refreshSchedules"},
+    )
 
 
 @app.post("/api/routines/{hevy_routine_id}/schedule", response_class=HTMLResponse)
@@ -1450,8 +1454,10 @@ async def api_routine_schedule(request: Request, hevy_routine_id: str):
 
     n = result["scheduled"]
     span = f" ({result['dates'][0]} → {result['dates'][-1]})" if n > 1 else f" on {result['dates'][0]}"
+    # HX-Trigger fires a client event so the "Scheduled workouts" table refreshes itself.
     return HTMLResponse(
-        f'<div class="toast toast-success">Scheduled {n} session(s){span}.</div>'
+        f'<div class="toast toast-success">Scheduled {n} session(s){span}.</div>',
+        headers={"HX-Trigger": "refreshSchedules"},
     )
 
 

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -7,7 +7,8 @@ import os
 import re
 import threading
 import time
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
+from math import ceil
 from pathlib import Path
 from typing import Any
 
@@ -22,7 +23,13 @@ from hevy2garmin.auth import auth_enabled, verify_session, sign_session, check_p
 from hevy2garmin.config import is_configured, load_config, save_config
 from hevy2garmin.demo import is_demo_mode
 from hevy2garmin.ratelimit import record_rate_limit, cooldown_remaining, clear_rate_limit, format_cooldown
-from hevy2garmin.sync import sync, sync_routines, routine_schedule_dates, schedule_routine
+from hevy2garmin.sync import (
+    sync,
+    sync_routines,
+    routine_schedule_dates,
+    schedule_routine,
+    unschedule_routine_entry,
+)
 
 logger = logging.getLogger("hevy2garmin")
 
@@ -1310,12 +1317,40 @@ async def api_sync(request: Request):
     return _render("partials/sync_result.html", result=result)
 
 
+_SCHEDULES_PAGE_SIZE = 10
+
+
+def _schedules_context(page: int) -> dict:
+    """Build the paginated 'upcoming scheduled workouts' context (local DB only)."""
+    _db = db.get_db()
+    today = date.today().isoformat()
+    total = _db.count_upcoming_routine_schedules(today)
+    total_pages = max(1, ceil(total / _SCHEDULES_PAGE_SIZE))
+    page = max(1, min(page, total_pages))
+    rows = _db.get_upcoming_routine_schedules(
+        today, _SCHEDULES_PAGE_SIZE, (page - 1) * _SCHEDULES_PAGE_SIZE
+    )
+    return {
+        "scheduled_workouts": rows,
+        "page": page,
+        "total_pages": total_pages,
+        "sched_total": total,
+    }
+
+
 @app.get("/routines", response_class=HTMLResponse)
 async def routines_page(request: Request):
     """List Hevy routines and their sync status."""
     config = load_config()
     routines: list[dict] = []
     fetch_error = None
+    # Local-DB data — load it outside the Hevy fetch so the schedules table still
+    # renders even when Hevy is unreachable.
+    try:
+        schedules = _schedules_context(1)
+    except Exception:
+        logger.exception("Failed to load scheduled workouts")
+        schedules = {"scheduled_workouts": [], "page": 1, "total_pages": 1, "sched_total": 0}
     try:
         from hevy2garmin.hevy import HevyClient
         from hevy2garmin.sync import fetch_all_routines, _cache_routines_total
@@ -1336,7 +1371,20 @@ async def routines_page(request: Request):
     except Exception:
         logger.exception("Failed to load Hevy routines")
         fetch_error = "Could not load routines from Hevy. Check your API key and try again."
-    return _render("routines.html", request=request, routines=routines, fetch_error=fetch_error)
+    return _render(
+        "routines.html", request=request, routines=routines, fetch_error=fetch_error, **schedules
+    )
+
+
+@app.get("/api/routines/schedules", response_class=HTMLResponse)
+async def api_routines_schedules(request: Request, page: int = 1):
+    """Return the paginated 'scheduled workouts' table fragment (HTMX navigation)."""
+    try:
+        ctx = _schedules_context(page)
+    except Exception:
+        logger.exception("Failed to load scheduled workouts")
+        return HTMLResponse('<div class="toast toast-error">Could not load scheduled workouts.</div>')
+    return _render("routine_schedules.html", **ctx)
 
 
 @app.post("/api/routines/sync", response_class=HTMLResponse)
@@ -1405,6 +1453,26 @@ async def api_routine_schedule(request: Request, hevy_routine_id: str):
     return HTMLResponse(
         f'<div class="toast toast-success">Scheduled {n} session(s){span}.</div>'
     )
+
+
+@app.post("/api/routines/{hevy_routine_id}/schedule/{schedule_id}/unschedule", response_class=HTMLResponse)
+async def api_routine_unschedule(request: Request, hevy_routine_id: str, schedule_id: str, page: int = 1):
+    """Remove one scheduled calendar entry, then re-render the schedules table."""
+    if is_demo_mode():
+        return HTMLResponse('<div class="toast toast-success">Unscheduling disabled in demo mode.</div>')
+
+    if not _acquire_sync_lock():
+        return HTMLResponse('<div class="toast toast-error">Another sync is already running. Please wait.</div>')
+
+    try:
+        unschedule_routine_entry(hevy_routine_id, schedule_id)
+    except Exception:
+        logger.exception("Unscheduling routine %s entry %s failed", hevy_routine_id, schedule_id)
+        return HTMLResponse('<div class="toast toast-error">Could not remove the scheduled workout. Check the logs.</div>')
+    finally:
+        _sync_executing.release()
+
+    return _render("routine_schedules.html", **_schedules_context(page))
 
 
 @app.post("/api/sync/{workout_id}", response_class=HTMLResponse)

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -1320,21 +1320,33 @@ async def api_sync(request: Request):
 _SCHEDULES_PAGE_SIZE = 10
 
 
-def _schedules_context(page: int) -> dict:
-    """Build the paginated 'upcoming scheduled workouts' context (local DB only)."""
+def _schedules_context(page: int, start_date: str | None = None, title: str | None = None) -> dict:
+    """Build the paginated 'scheduled workouts' context (local DB only).
+
+    ``start_date`` (default today) filters to entries on/after that date; ``title``
+    filters by routine name (case-insensitive substring). Both are echoed back so the
+    filter form and the pagination/refresh URLs keep the current selection.
+    """
     _db = db.get_db()
-    today = date.today().isoformat()
-    total = _db.count_upcoming_routine_schedules(today)
+    start = start_date or date.today().isoformat()
+    try:
+        date.fromisoformat(start)  # guard the query and the value echoed into the form
+    except (ValueError, TypeError):
+        start = date.today().isoformat()
+    title = (title or "").strip()
+    total = _db.count_upcoming_routine_schedules(start, title or None)
     total_pages = max(1, ceil(total / _SCHEDULES_PAGE_SIZE))
     page = max(1, min(page, total_pages))
     rows = _db.get_upcoming_routine_schedules(
-        today, _SCHEDULES_PAGE_SIZE, (page - 1) * _SCHEDULES_PAGE_SIZE
+        start, _SCHEDULES_PAGE_SIZE, (page - 1) * _SCHEDULES_PAGE_SIZE, title or None
     )
     return {
         "scheduled_workouts": rows,
         "page": page,
         "total_pages": total_pages,
         "sched_total": total,
+        "start_date": start,
+        "title_query": title,
     }
 
 
@@ -1377,10 +1389,12 @@ async def routines_page(request: Request):
 
 
 @app.get("/api/routines/schedules", response_class=HTMLResponse)
-async def api_routines_schedules(request: Request, page: int = 1):
-    """Return the paginated 'scheduled workouts' table fragment (HTMX navigation)."""
+async def api_routines_schedules(
+    request: Request, page: int = 1, start: str | None = None, q: str | None = None
+):
+    """Return the paginated 'scheduled workouts' table fragment (HTMX navigation/filter)."""
     try:
-        ctx = _schedules_context(page)
+        ctx = _schedules_context(page, start, q)
     except Exception:
         logger.exception("Failed to load scheduled workouts")
         return HTMLResponse('<div class="toast toast-error">Could not load scheduled workouts.</div>')
@@ -1462,7 +1476,10 @@ async def api_routine_schedule(request: Request, hevy_routine_id: str):
 
 
 @app.post("/api/routines/{hevy_routine_id}/schedule/{schedule_id}/unschedule", response_class=HTMLResponse)
-async def api_routine_unschedule(request: Request, hevy_routine_id: str, schedule_id: str, page: int = 1):
+async def api_routine_unschedule(
+    request: Request, hevy_routine_id: str, schedule_id: str,
+    page: int = 1, start: str | None = None, q: str | None = None,
+):
     """Remove one scheduled calendar entry, then re-render the schedules table."""
     if is_demo_mode():
         return HTMLResponse('<div class="toast toast-success">Unscheduling disabled in demo mode.</div>')
@@ -1478,7 +1495,7 @@ async def api_routine_unschedule(request: Request, hevy_routine_id: str, schedul
     finally:
         _sync_executing.release()
 
-    return _render("routine_schedules.html", **_schedules_context(page))
+    return _render("routine_schedules.html", **_schedules_context(page, start, q))
 
 
 @app.post("/api/sync/{workout_id}", response_class=HTMLResponse)

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -1317,15 +1317,19 @@ async def api_sync(request: Request):
     return _render("partials/sync_result.html", result=result)
 
 
-_SCHEDULES_PAGE_SIZE = 10
+_SCHEDULES_PAGE_SIZES = (10, 25, 100)
+_SCHEDULES_PAGE_SIZE = _SCHEDULES_PAGE_SIZES[0]
 
 
-def _schedules_context(page: int, start_date: str | None = None, title: str | None = None) -> dict:
+def _schedules_context(
+    page: int, start_date: str | None = None, title: str | None = None, page_size: int | None = None
+) -> dict:
     """Build the paginated 'scheduled workouts' context (local DB only).
 
     ``start_date`` (default today) filters to entries on/after that date; ``title``
-    filters by routine name (case-insensitive substring). Both are echoed back so the
-    filter form and the pagination/refresh URLs keep the current selection.
+    filters by routine name (case-insensitive substring); ``page_size`` (one of
+    ``_SCHEDULES_PAGE_SIZES``, default 10) sets rows per page. All are echoed back so
+    the filter form, selector and the pagination/refresh URLs keep the current state.
     """
     _db = db.get_db()
     start = start_date or date.today().isoformat()
@@ -1334,11 +1338,12 @@ def _schedules_context(page: int, start_date: str | None = None, title: str | No
     except (ValueError, TypeError):
         start = date.today().isoformat()
     title = (title or "").strip()
+    size = page_size if page_size in _SCHEDULES_PAGE_SIZES else _SCHEDULES_PAGE_SIZE
     total = _db.count_upcoming_routine_schedules(start, title or None)
-    total_pages = max(1, ceil(total / _SCHEDULES_PAGE_SIZE))
+    total_pages = max(1, ceil(total / size))
     page = max(1, min(page, total_pages))
     rows = _db.get_upcoming_routine_schedules(
-        start, _SCHEDULES_PAGE_SIZE, (page - 1) * _SCHEDULES_PAGE_SIZE, title or None
+        start, size, (page - 1) * size, title or None
     )
     return {
         "scheduled_workouts": rows,
@@ -1347,6 +1352,8 @@ def _schedules_context(page: int, start_date: str | None = None, title: str | No
         "sched_total": total,
         "start_date": start,
         "title_query": title,
+        "page_size": size,
+        "page_sizes": _SCHEDULES_PAGE_SIZES,
     }
 
 
@@ -1390,11 +1397,12 @@ async def routines_page(request: Request):
 
 @app.get("/api/routines/schedules", response_class=HTMLResponse)
 async def api_routines_schedules(
-    request: Request, page: int = 1, start: str | None = None, q: str | None = None
+    request: Request, page: int = 1, start: str | None = None, q: str | None = None,
+    size: int = _SCHEDULES_PAGE_SIZE,
 ):
     """Return the paginated 'scheduled workouts' table fragment (HTMX navigation/filter)."""
     try:
-        ctx = _schedules_context(page, start, q)
+        ctx = _schedules_context(page, start, q, size)
     except Exception:
         logger.exception("Failed to load scheduled workouts")
         return HTMLResponse('<div class="toast toast-error">Could not load scheduled workouts.</div>')
@@ -1479,6 +1487,7 @@ async def api_routine_schedule(request: Request, hevy_routine_id: str):
 async def api_routine_unschedule(
     request: Request, hevy_routine_id: str, schedule_id: str,
     page: int = 1, start: str | None = None, q: str | None = None,
+    size: int = _SCHEDULES_PAGE_SIZE,
 ):
     """Remove one scheduled calendar entry, then re-render the schedules table."""
     if is_demo_mode():
@@ -1495,7 +1504,7 @@ async def api_routine_unschedule(
     finally:
         _sync_executing.release()
 
-    return _render("routine_schedules.html", **_schedules_context(page, start, q))
+    return _render("routine_schedules.html", **_schedules_context(page, start, q, size))
 
 
 @app.post("/api/sync/{workout_id}", response_class=HTMLResponse)

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -1089,3 +1089,31 @@ def schedule_routine(
     )
     logger.info("Scheduled routine %s on %d date(s)", hevy_routine_id, len(dates))
     return {"scheduled": len(dates), "workout_id": workout_id, "dates": dates}
+
+
+def unschedule_routine_entry(
+    hevy_routine_id: str,
+    schedule_id: str,
+    *,
+    config: dict[str, Any] | None = None,
+    **overrides: Any,
+) -> None:
+    """Remove one Garmin calendar entry of a routine and stop tracking it.
+
+    Unscheduling is best-effort — an entry already gone on Garmin just 404s — but
+    the local row is always dropped afterward so the UI reflects the removal.
+    """
+    cfg = config or load_config()
+    store = _resolve_store()
+    garmin_email = overrides.get("garmin_email") or cfg.get("garmin_email")
+    garmin_password = overrides.get("garmin_password") or cfg.get("garmin_password", "")
+    garmin_token_dir = cfg.get("garmin_token_dir", "~/.garminconnect")
+
+    logger.info("Authenticating with Garmin Connect...")
+    client = get_client(garmin_email, garmin_password, garmin_token_dir)
+    try:
+        unschedule_workout(client, schedule_id)
+    except Exception:
+        logger.warning("  Could not unschedule calendar entry %s", schedule_id)
+    store.delete_routine_schedule(hevy_routine_id, schedule_id)
+    logger.info("Unscheduled routine %s entry %s", hevy_routine_id, schedule_id)

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -27,6 +27,7 @@ from hevy2garmin.garmin import (
     rename_activity,
     schedule_workout,
     set_description,
+    unschedule_workout,
     upload_fit,
 )
 from hevy2garmin.hevy import HevyClient
@@ -785,6 +786,27 @@ def fetch_all_routines(hevy: HevyClient, page_size: int = 10) -> list[dict]:
     return routines
 
 
+def _reschedule_routine(client, store, hevy_routine_id, workout_id, dates: list[str]) -> None:
+    """Book ``dates`` for a routine's workout, replacing its prior calendar entries.
+
+    Garmin appends a fresh calendar entry on every schedule POST (no server-side
+    dedup), so re-scheduling would stack duplicates. We unschedule every entry we
+    previously tracked for this routine first — best-effort, since an id whose
+    workout was already deleted just 404s — then book the new dates and record the
+    ids Garmin returns so the next reschedule can clean them up too.
+    """
+    for old_id in store.get_routine_schedule_ids(hevy_routine_id):
+        try:
+            unschedule_workout(client, old_id)
+        except Exception:
+            logger.warning("  Could not unschedule stale calendar entry %s", old_id)
+    store.clear_routine_schedules(hevy_routine_id)
+    for day in dates:
+        schedule_id = schedule_workout(client, workout_id, day)
+        if schedule_id is not None:
+            store.add_routine_schedule(hevy_routine_id, str(schedule_id), day)
+
+
 def sync_routines(
     config: dict[str, Any] | None = None,
     dry_run: bool = False,
@@ -951,7 +973,12 @@ def sync_routines(
                     content_hash=content_hash,
                     status="schedule_pending",
                 )
-                schedule_workout(garmin_client, workout_id, effective_schedule_date)
+                # The old workout (and its Garmin calendar entries) was just deleted,
+                # so unschedule prior tracked ids too and record the new entry — keeps
+                # a later manual reschedule idempotent instead of stacking duplicates.
+                _reschedule_routine(
+                    garmin_client, store, rid, workout_id, [effective_schedule_date]
+                )
                 if schedule_date:
                     stats["scheduled"] += 1
 
@@ -1048,8 +1075,9 @@ def schedule_routine(
     logger.info("Authenticating with Garmin Connect...")
     client = get_client(garmin_email, garmin_password, garmin_token_dir)
 
-    for day in dates:
-        schedule_workout(client, workout_id, day)
+    # Unschedule the routine's prior calendar entries before booking the new dates,
+    # so re-scheduling replaces rather than stacks duplicate entries (Garmin appends).
+    _reschedule_routine(client, store, hevy_routine_id, workout_id, dates)
 
     store.mark_routine_synced(
         hevy_routine_id,

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -786,20 +786,38 @@ def fetch_all_routines(hevy: HevyClient, page_size: int = 10) -> list[dict]:
     return routines
 
 
-def _reschedule_routine(client, store, hevy_routine_id, workout_id, dates: list[str]) -> None:
+def _is_not_found(exc: Exception) -> bool:
+    """True when ``exc`` is a Garmin HTTP 404 (the calendar entry is already gone).
+
+    garth raises ``requests`` ``HTTPError`` with a ``response`` carrying ``status_code``;
+    fall back to a string check for wrappers that don't preserve it.
+    """
+    resp = getattr(exc, "response", None)
+    if resp is not None and getattr(resp, "status_code", None) == 404:
+        return True
+    return "404" in str(exc)
+
+
+def _reschedule_routine(
+    client, store, hevy_routine_id, workout_id, dates: list[str], *, unschedule_prior: bool = True
+) -> None:
     """Book ``dates`` for a routine's workout, replacing its prior calendar entries.
 
     Garmin appends a fresh calendar entry on every schedule POST (no server-side
     dedup), so re-scheduling would stack duplicates. We unschedule every entry we
-    previously tracked for this routine first — best-effort, since an id whose
-    workout was already deleted just 404s — then book the new dates and record the
-    ids Garmin returns so the next reschedule can clean them up too.
+    previously tracked for this routine first, then book the new dates and record
+    the ids Garmin returns so the next reschedule can clean them up too.
+
+    ``unschedule_prior=False`` skips the unschedule calls — used when the workout was
+    just deleted (its calendar entries already cascaded away on Garmin), so hitting
+    the schedule endpoint for each stale id would only waste rate-limited 404s.
     """
-    for old_id in store.get_routine_schedule_ids(hevy_routine_id):
-        try:
-            unschedule_workout(client, old_id)
-        except Exception:
-            logger.warning("  Could not unschedule stale calendar entry %s", old_id)
+    if unschedule_prior:
+        for old_id in store.get_routine_schedule_ids(hevy_routine_id):
+            try:
+                unschedule_workout(client, old_id)
+            except Exception:
+                logger.warning("  Could not unschedule stale calendar entry %s", old_id)
     store.clear_routine_schedules(hevy_routine_id)
     for day in dates:
         schedule_id = schedule_workout(client, workout_id, day)
@@ -953,13 +971,21 @@ def sync_routines(
                 stats["failed"] += 1
                 continue
 
-            # Recreating the workout drops any calendar entry the old one had, so
-            # re-apply a prior schedule when this run doesn't set a new one. Only an
-            # explicit schedule_date counts toward the "scheduled" stat; re-applying a
-            # stored date is a restore, not a new booking.
-            effective_schedule_date = schedule_date or (existing or {}).get("scheduled_date")
+            # Recreating the workout drops the calendar entries the old one had, so
+            # re-apply the prior schedule when this run doesn't set a new one. An
+            # explicit schedule_date overrides; otherwise restore *every* date the
+            # routine had booked (so a recurring routine keeps all its entries), falling
+            # back to the single stored date for rows created before per-entry tracking.
+            # Only an explicit schedule_date counts toward the "scheduled" stat.
+            if schedule_date:
+                dates_to_book = [schedule_date]
+            else:
+                dates_to_book = store.get_routine_scheduled_dates(rid)
+                if not dates_to_book and (existing or {}).get("scheduled_date"):
+                    dates_to_book = [existing["scheduled_date"]]
+            effective_schedule_date = min(dates_to_book) if dates_to_book else None
 
-            if effective_schedule_date:
+            if dates_to_book:
                 # Persist the created workout *before* the schedule call, marked
                 # 'schedule_pending'. If scheduling then errors (Garmin 429/500), the
                 # workout is already tracked, so the next sync deletes+recreates it
@@ -974,10 +1000,10 @@ def sync_routines(
                     status="schedule_pending",
                 )
                 # The old workout (and its Garmin calendar entries) was just deleted,
-                # so unschedule prior tracked ids too and record the new entry — keeps
-                # a later manual reschedule idempotent instead of stacking duplicates.
+                # so its tracked ids are already gone — clear+rebook without spending a
+                # rate-limited unschedule call per stale id.
                 _reschedule_routine(
-                    garmin_client, store, rid, workout_id, [effective_schedule_date]
+                    garmin_client, store, rid, workout_id, dates_to_book, unschedule_prior=False
                 )
                 if schedule_date:
                     stats["scheduled"] += 1
@@ -1113,7 +1139,13 @@ def unschedule_routine_entry(
     client = get_client(garmin_email, garmin_password, garmin_token_dir)
     try:
         unschedule_workout(client, schedule_id)
-    except Exception:
-        logger.warning("  Could not unschedule calendar entry %s", schedule_id)
+    except Exception as e:
+        # A 404 means the entry is already gone on Garmin — safe to drop our row. Any
+        # other error (429/500/network) is transient: keep the row and re-raise so the
+        # caller surfaces the failure and the user can retry, instead of orphaning a
+        # calendar entry we can no longer see or remove.
+        if not _is_not_found(e):
+            raise
+        logger.info("  Calendar entry %s already gone on Garmin", schedule_id)
     store.delete_routine_schedule(hevy_routine_id, schedule_id)
     logger.info("Unscheduled routine %s entry %s", hevy_routine_id, schedule_id)

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -787,15 +787,16 @@ def fetch_all_routines(hevy: HevyClient, page_size: int = 10) -> list[dict]:
 
 
 def _is_not_found(exc: Exception) -> bool:
-    """True when ``exc`` is a Garmin HTTP 404 (the calendar entry is already gone).
+    """True only when ``exc`` is a Garmin HTTP 404 (the calendar entry is already gone).
 
-    garth raises ``requests`` ``HTTPError`` with a ``response`` carrying ``status_code``;
-    fall back to a string check for wrappers that don't preserve it.
+    garth raises ``requests`` ``HTTPError`` carrying ``response.status_code``; trust only
+    that. A missing status is treated as transient (keep the row and re-raise) rather than
+    string-matching "404" in the message — a transient error whose text merely contains
+    404 (a scheduleId, a retry delay like ``40400ms``) would otherwise drop the row, the
+    exact orphan this guard prevents.
     """
     resp = getattr(exc, "response", None)
-    if resp is not None and getattr(resp, "status_code", None) == 404:
-        return True
-    return "404" in str(exc)
+    return resp is not None and getattr(resp, "status_code", None) == 404
 
 
 def _reschedule_routine(

--- a/src/hevy2garmin/templates/routine_schedules.html
+++ b/src/hevy2garmin/templates/routine_schedules.html
@@ -1,4 +1,8 @@
-<div id="scheduled-table">
+<div id="scheduled-table"
+     hx-get="/api/routines/schedules"
+     hx-trigger="refreshSchedules from:body"
+     hx-target="#scheduled-table"
+     hx-swap="outerHTML">
   {% if scheduled_workouts %}
   <table style="width:100%; border-collapse:collapse;">
     <thead>

--- a/src/hevy2garmin/templates/routine_schedules.html
+++ b/src/hevy2garmin/templates/routine_schedules.html
@@ -1,0 +1,49 @@
+<div id="scheduled-table">
+  {% if scheduled_workouts %}
+  <table style="width:100%; border-collapse:collapse;">
+    <thead>
+      <tr style="text-align:left; color:var(--text-muted); font-size:13px;">
+        <th style="padding:8px;">Date</th>
+        <th style="padding:8px;">Routine</th>
+        <th style="padding:8px; width:1px;"></th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for s in scheduled_workouts %}
+      <tr style="border-top:1px solid var(--border-subtle);">
+        <td style="padding:8px; font-variant-numeric:tabular-nums; color:var(--text-secondary);">📅 {{ s.scheduled_date }}</td>
+        <td style="padding:8px;">{{ s.title or 'Routine' }}</td>
+        <td style="padding:8px; text-align:right; white-space:nowrap;">
+          {% if not demo_mode %}
+          <button type="button" class="btn btn-secondary"
+                  hx-post="/api/routines/{{ s.hevy_routine_id }}/schedule/{{ s.schedule_id }}/unschedule?page={{ page }}"
+                  hx-target="#scheduled-table" hx-swap="outerHTML"
+                  hx-confirm="Remove this scheduled workout from your Garmin calendar?"
+                  hx-disabled-elt="this" style="font-size:12px; padding:4px 10px;">
+            Remove <span class="htmx-indicator"><span class="spinner"></span></span>
+          </button>
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% if total_pages > 1 %}
+  <div style="display:flex; gap:12px; align-items:center; justify-content:flex-end; margin-top:12px; font-size:13px; color:var(--text-muted);">
+    <button type="button" class="btn btn-secondary"
+            style="font-size:12px; padding:4px 10px;{% if page <= 1 %} opacity:0.4; cursor:not-allowed;{% endif %}"
+            hx-get="/api/routines/schedules?page={{ page - 1 }}"
+            hx-target="#scheduled-table" hx-swap="outerHTML"
+            {% if page <= 1 %}disabled{% endif %}>Prev</button>
+    <span>Page {{ page }} of {{ total_pages }}</span>
+    <button type="button" class="btn btn-secondary"
+            style="font-size:12px; padding:4px 10px;{% if page >= total_pages %} opacity:0.4; cursor:not-allowed;{% endif %}"
+            hx-get="/api/routines/schedules?page={{ page + 1 }}"
+            hx-target="#scheduled-table" hx-swap="outerHTML"
+            {% if page >= total_pages %}disabled{% endif %}>Next</button>
+  </div>
+  {% endif %}
+  {% else %}
+  <p style="color:var(--text-muted); font-size:13px; margin:0;">No upcoming scheduled workouts.</p>
+  {% endif %}
+</div>

--- a/src/hevy2garmin/templates/routine_schedules.html
+++ b/src/hevy2garmin/templates/routine_schedules.html
@@ -1,5 +1,5 @@
 <div id="scheduled-table"
-     hx-get="/api/routines/schedules"
+     hx-get="/api/routines/schedules?start={{ start_date }}&q={{ title_query|urlencode }}"
      hx-trigger="refreshSchedules from:body"
      hx-target="#scheduled-table"
      hx-swap="outerHTML">
@@ -20,7 +20,7 @@
         <td style="padding:8px; text-align:right; white-space:nowrap;">
           {% if not demo_mode %}
           <button type="button" class="btn btn-secondary"
-                  hx-post="/api/routines/{{ s.hevy_routine_id }}/schedule/{{ s.schedule_id }}/unschedule?page={{ page }}"
+                  hx-post="/api/routines/{{ s.hevy_routine_id }}/schedule/{{ s.schedule_id }}/unschedule?page={{ page }}&start={{ start_date }}&q={{ title_query|urlencode }}"
                   hx-target="#scheduled-table" hx-swap="outerHTML"
                   hx-confirm="Remove this scheduled workout from your Garmin calendar?"
                   hx-disabled-elt="this" style="font-size:12px; padding:4px 10px;">
@@ -36,13 +36,13 @@
   <div style="display:flex; gap:12px; align-items:center; justify-content:flex-end; margin-top:12px; font-size:13px; color:var(--text-muted);">
     <button type="button" class="btn btn-secondary"
             style="font-size:12px; padding:4px 10px;{% if page <= 1 %} opacity:0.4; cursor:not-allowed;{% endif %}"
-            hx-get="/api/routines/schedules?page={{ page - 1 }}"
+            hx-get="/api/routines/schedules?page={{ page - 1 }}&start={{ start_date }}&q={{ title_query|urlencode }}"
             hx-target="#scheduled-table" hx-swap="outerHTML"
             {% if page <= 1 %}disabled{% endif %}>Prev</button>
     <span>Page {{ page }} of {{ total_pages }}</span>
     <button type="button" class="btn btn-secondary"
             style="font-size:12px; padding:4px 10px;{% if page >= total_pages %} opacity:0.4; cursor:not-allowed;{% endif %}"
-            hx-get="/api/routines/schedules?page={{ page + 1 }}"
+            hx-get="/api/routines/schedules?page={{ page + 1 }}&start={{ start_date }}&q={{ title_query|urlencode }}"
             hx-target="#scheduled-table" hx-swap="outerHTML"
             {% if page >= total_pages %}disabled{% endif %}>Next</button>
   </div>

--- a/src/hevy2garmin/templates/routine_schedules.html
+++ b/src/hevy2garmin/templates/routine_schedules.html
@@ -1,5 +1,5 @@
 <div id="scheduled-table"
-     hx-get="/api/routines/schedules?start={{ start_date }}&q={{ title_query|urlencode }}"
+     hx-get="/api/routines/schedules?start={{ start_date }}&q={{ title_query|urlencode }}&size={{ page_size }}"
      hx-trigger="refreshSchedules from:body"
      hx-target="#scheduled-table"
      hx-swap="outerHTML">
@@ -20,7 +20,7 @@
         <td style="padding:8px; text-align:right; white-space:nowrap;">
           {% if not demo_mode %}
           <button type="button" class="btn btn-secondary"
-                  hx-post="/api/routines/{{ s.hevy_routine_id }}/schedule/{{ s.schedule_id }}/unschedule?page={{ page }}&start={{ start_date }}&q={{ title_query|urlencode }}"
+                  hx-post="/api/routines/{{ s.hevy_routine_id }}/schedule/{{ s.schedule_id }}/unschedule?page={{ page }}&start={{ start_date }}&q={{ title_query|urlencode }}&size={{ page_size }}"
                   hx-target="#scheduled-table" hx-swap="outerHTML"
                   hx-confirm="Remove this scheduled workout from your Garmin calendar?"
                   hx-disabled-elt="this" style="font-size:12px; padding:4px 10px;">
@@ -36,17 +36,28 @@
   <div style="display:flex; gap:12px; align-items:center; justify-content:flex-end; margin-top:12px; font-size:13px; color:var(--text-muted);">
     <button type="button" class="btn btn-secondary"
             style="font-size:12px; padding:4px 10px;{% if page <= 1 %} opacity:0.4; cursor:not-allowed;{% endif %}"
-            hx-get="/api/routines/schedules?page={{ page - 1 }}&start={{ start_date }}&q={{ title_query|urlencode }}"
+            hx-get="/api/routines/schedules?page={{ page - 1 }}&start={{ start_date }}&q={{ title_query|urlencode }}&size={{ page_size }}"
             hx-target="#scheduled-table" hx-swap="outerHTML"
             {% if page <= 1 %}disabled{% endif %}>Prev</button>
     <span>Page {{ page }} of {{ total_pages }}</span>
     <button type="button" class="btn btn-secondary"
             style="font-size:12px; padding:4px 10px;{% if page >= total_pages %} opacity:0.4; cursor:not-allowed;{% endif %}"
-            hx-get="/api/routines/schedules?page={{ page + 1 }}&start={{ start_date }}&q={{ title_query|urlencode }}"
+            hx-get="/api/routines/schedules?page={{ page + 1 }}&start={{ start_date }}&q={{ title_query|urlencode }}&size={{ page_size }}"
             hx-target="#scheduled-table" hx-swap="outerHTML"
             {% if page >= total_pages %}disabled{% endif %}>Next</button>
   </div>
   {% endif %}
+  <div style="display:flex; gap:6px; align-items:center; justify-content:flex-end; margin-top:12px; font-size:13px; color:var(--text-muted);">
+    Per page
+    <select name="size"
+            hx-get="/api/routines/schedules?start={{ start_date }}&q={{ title_query|urlencode }}"
+            hx-target="#scheduled-table" hx-swap="outerHTML" hx-trigger="change"
+            style="background:var(--bg-primary); color:var(--text); border:1px solid var(--border); border-radius:var(--radius-sm); padding:4px 6px;">
+      {% for sz in page_sizes %}
+      <option value="{{ sz }}" {% if sz == page_size %}selected{% endif %}>{{ sz }}</option>
+      {% endfor %}
+    </select>
+  </div>
   {% else %}
   <p style="color:var(--text-muted); font-size:13px; margin:0;">No upcoming scheduled workouts.</p>
   {% endif %}

--- a/src/hevy2garmin/templates/routines.html
+++ b/src/hevy2garmin/templates/routines.html
@@ -92,4 +92,9 @@
   {% endif %}
 </div>
 {% endif %}
+
+<div class="card" style="margin-top:16px;">
+  <div class="card-header" style="margin-bottom:12px;"><span class="card-title">Scheduled workouts</span></div>
+  {% include "routine_schedules.html" %}
+</div>
 {% endblock %}

--- a/src/hevy2garmin/templates/routines.html
+++ b/src/hevy2garmin/templates/routines.html
@@ -95,6 +95,19 @@
 
 <div class="card" style="margin-top:16px;">
   <div class="card-header" style="margin-bottom:12px;"><span class="card-title">Scheduled workouts</span></div>
+  <form hx-get="/api/routines/schedules" hx-target="#scheduled-table" hx-swap="outerHTML"
+        hx-trigger="submit, change, keyup changed delay:400ms"
+        style="display:flex; gap:12px; flex-wrap:wrap; align-items:center; margin-bottom:12px; font-size:13px; color:var(--text-muted);"
+        onsubmit="return false;">
+    <label style="display:flex; gap:6px; align-items:center;">
+      From <input type="date" name="start" value="{{ start_date }}"
+             style="background:var(--bg-primary); color:var(--text); border:1px solid var(--border); border-radius:var(--radius-sm); padding:4px 6px;">
+    </label>
+    <label style="display:flex; gap:6px; align-items:center;">
+      Routine <input type="text" name="q" value="{{ title_query }}" placeholder="filter by name"
+             style="background:var(--bg-primary); color:var(--text); border:1px solid var(--border); border-radius:var(--radius-sm); padding:4px 6px;">
+    </label>
+  </form>
   {% include "routine_schedules.html" %}
 </div>
 {% endblock %}

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -39,6 +39,7 @@ def _make_db(tmp_path):
                 cur.execute("DELETE FROM sync_log")
                 cur.execute("DELETE FROM hr_cache")
                 cur.execute("DELETE FROM synced_routines")
+                cur.execute("DELETE FROM routine_schedules")
             conn.commit()
         return db
     return SQLiteDatabase(tmp_path / "test.db")
@@ -79,6 +80,25 @@ class TestRoutineTracking:
         assert db.delete_synced_routine("r1") is True
         assert db.is_routine_synced("r1") is False
         assert db.delete_synced_routine("r1") is False
+
+    def test_routine_schedule_round_trip(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        db.add_routine_schedule("r1", "111", "2026-07-20")
+        db.add_routine_schedule("r1", "222", "2026-07-27")
+        assert set(db.get_routine_schedule_ids("r1")) == {"111", "222"}
+        # Re-adding the same id is a no-op (idempotent), not a duplicate/error.
+        db.add_routine_schedule("r1", "111", "2026-07-20")
+        assert set(db.get_routine_schedule_ids("r1")) == {"111", "222"}
+        db.clear_routine_schedules("r1")
+        assert db.get_routine_schedule_ids("r1") == []
+
+    def test_delete_synced_routine_clears_schedules(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        db.mark_routine_synced("r1", garmin_workout_id="w1")
+        db.add_routine_schedule("r1", "111", "2026-07-20")
+        assert db.delete_synced_routine("r1") is True
+        # Removing the routine also drops its tracked calendar entries.
+        assert db.get_routine_schedule_ids("r1") == []
 
     def test_content_hash_round_trip(self, tmp_path: Path) -> None:
         db = _make_db(tmp_path)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -100,6 +100,31 @@ class TestRoutineTracking:
         # Removing the routine also drops its tracked calendar entries.
         assert db.get_routine_schedule_ids("r1") == []
 
+    def test_upcoming_schedules_filters_orders_and_paginates(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        db.mark_routine_synced("r1", garmin_workout_id="w1", title="Push")
+        db.mark_routine_synced("r2", garmin_workout_id="w2", title="Pull")
+        db.add_routine_schedule("r1", "s-past", "2026-06-01")   # past → excluded
+        db.add_routine_schedule("r1", "s-b", "2026-07-27")
+        db.add_routine_schedule("r2", "s-a", "2026-07-20")
+        today = "2026-07-15"
+        # Only future entries are counted, and the title comes from the join.
+        assert db.count_upcoming_routine_schedules(today) == 2
+        page1 = db.get_upcoming_routine_schedules(today, 1, 0)
+        assert [(r["scheduled_date"], r["title"]) for r in page1] == [("2026-07-20", "Pull")]
+        page2 = db.get_upcoming_routine_schedules(today, 1, 1)
+        assert [(r["scheduled_date"], r["title"]) for r in page2] == [("2026-07-27", "Push")]
+        assert page2[0]["schedule_id"] == "s-b" and page2[0]["hevy_routine_id"] == "r1"
+
+    def test_delete_routine_schedule_one_entry(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        db.add_routine_schedule("r1", "111", "2026-07-20")
+        db.add_routine_schedule("r1", "222", "2026-07-27")
+        assert db.delete_routine_schedule("r1", "111") is True
+        assert db.get_routine_schedule_ids("r1") == ["222"]
+        # Deleting a non-existent entry reports no removal.
+        assert db.delete_routine_schedule("r1", "999") is False
+
     def test_content_hash_round_trip(self, tmp_path: Path) -> None:
         db = _make_db(tmp_path)
         db.mark_routine_synced("r1", garmin_workout_id="w1", content_hash="abc123")

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -116,6 +116,21 @@ class TestRoutineTracking:
         assert [(r["scheduled_date"], r["title"]) for r in page2] == [("2026-07-27", "Push")]
         assert page2[0]["schedule_id"] == "s-b" and page2[0]["hevy_routine_id"] == "r1"
 
+    def test_upcoming_schedules_title_filter(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        db.mark_routine_synced("r1", garmin_workout_id="w1", title="Push Day")
+        db.mark_routine_synced("r2", garmin_workout_id="w2", title="Leg Day")
+        db.add_routine_schedule("r1", "s1", "2999-01-05")
+        db.add_routine_schedule("r2", "s2", "2999-01-06")
+        today = "2026-07-15"
+        # Case-insensitive substring match on the routine title.
+        assert db.count_upcoming_routine_schedules(today, "push") == 1
+        rows = db.get_upcoming_routine_schedules(today, 10, 0, "PUSH")
+        assert [r["title"] for r in rows] == ["Push Day"]
+        # A non-matching query returns nothing; no query returns everything.
+        assert db.count_upcoming_routine_schedules(today, "cardio") == 0
+        assert db.count_upcoming_routine_schedules(today) == 2
+
     def test_delete_routine_schedule_one_entry(self, tmp_path: Path) -> None:
         db = _make_db(tmp_path)
         db.add_routine_schedule("r1", "111", "2026-07-20")

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -131,6 +131,17 @@ class TestRoutineTracking:
         assert db.count_upcoming_routine_schedules(today, "cardio") == 0
         assert db.count_upcoming_routine_schedules(today) == 2
 
+    def test_get_routine_scheduled_dates(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        db.add_routine_schedule("r1", "s2", "2026-08-10")
+        db.add_routine_schedule("r1", "s1", "2026-08-03")
+        db.add_routine_schedule("r1", "s3", "2026-08-03")  # duplicate date
+        db.add_routine_schedule("r2", "s9", "2026-09-01")  # other routine
+        # Distinct dates for the routine, ascending.
+        assert db.get_routine_scheduled_dates("r1") == ["2026-08-03", "2026-08-10"]
+        assert db.get_routine_scheduled_dates("r2") == ["2026-09-01"]
+        assert db.get_routine_scheduled_dates("nope") == []
+
     def test_delete_routine_schedule_one_entry(self, tmp_path: Path) -> None:
         db = _make_db(tmp_path)
         db.add_routine_schedule("r1", "111", "2026-07-20")

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -10,7 +10,12 @@ import pytest
 from hevy2garmin import sync as sync_module
 from hevy2garmin.sync import routine_schedule_dates
 from hevy2garmin.db_sqlite import SQLiteDatabase
-from hevy2garmin.garmin import create_workout, delete_workout, schedule_workout
+from hevy2garmin.garmin import (
+    create_workout,
+    delete_workout,
+    schedule_workout,
+    unschedule_workout,
+)
 from hevy2garmin.mapper import fit_exercise_strings
 from hevy2garmin.routine import (
     ROUTINE_DESC_MARKER,
@@ -213,11 +218,27 @@ class TestGarminWorkoutOps:
 
     def test_schedule_workout_posts_date(self) -> None:
         client = MagicMock()
-        schedule_workout(client, 42, "2026-08-01")
+        client.client.request.return_value.json.return_value = {"workoutScheduleId": 99}
+        schedule_id = schedule_workout(client, 42, "2026-08-01")
         method, service, path = client.client.request.call_args[0][:3]
         assert method == "POST"
         assert path == "/workout-service/schedule/42"
         assert client.client.request.call_args[1]["json"] == {"date": "2026-08-01"}
+        # The returned scheduleId is what the caller tracks to unschedule later.
+        assert schedule_id == 99
+
+    def test_schedule_workout_returns_none_on_unparseable_body(self) -> None:
+        client = MagicMock()
+        client.client.request.return_value.json.side_effect = ValueError("no body")
+        # A missing/garbled id must not fail the schedule — it just isn't tracked.
+        assert schedule_workout(client, 42, "2026-08-01") is None
+
+    def test_unschedule_workout_deletes_entry(self) -> None:
+        client = MagicMock()
+        unschedule_workout(client, 99)
+        method, service, path = client.client.request.call_args[0][:3]
+        assert method == "DELETE"
+        assert path == "/workout-service/schedule/99"
 
 
 class TestSyncRoutines:
@@ -348,6 +369,17 @@ class TestSyncRoutines:
         assert schedule_mock.call_args[0][1:] == (777, "2026-08-01")
         # ...and the date is kept on the record instead of being wiped to None.
         assert store.get_synced_routine("r1")["scheduled_date"] == "2026-08-01"
+
+    def test_schedule_records_calendar_entry(self, tmp_path: Path) -> None:
+        # A first sync with an explicit date books the Garmin calendar and records the
+        # returned scheduleId, so a later reschedule can unschedule it instead of stacking.
+        routines = [{"id": "r1", "title": "Push", "updated_at": "2026-01-01T00:00:00Z", "exercises": []}]
+        store, _, schedule_mock, patches = self._patched(tmp_path, routines)
+        schedule_mock.return_value = 2001
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6], patches[7]:
+            result = sync_module.sync_routines(schedule_date="2026-08-01")
+        assert result["scheduled"] == 1
+        assert store.get_routine_schedule_ids("r1") == ["2001"]
 
     def test_schedule_failure_persists_workout_then_recovers(self, tmp_path: Path) -> None:
         # #2 regression: create_workout succeeds, then schedule_workout errors. The
@@ -515,7 +547,9 @@ class TestRoutineScheduleDates:
 class TestScheduleRoutine:
     def _patched(self, tmp_path: Path):
         store = SQLiteDatabase(tmp_path / "sched.db")
-        schedule_mock = MagicMock()
+        # Each schedule POST returns a distinct Garmin scheduleId (1001, 1002, ...).
+        schedule_mock = MagicMock(side_effect=lambda *_a, **_k: 1000 + schedule_mock.call_count)
+        unschedule_mock = MagicMock()
         client = MagicMock()
         patches = [
             patch.object(sync_module, "load_config", return_value={
@@ -523,33 +557,49 @@ class TestScheduleRoutine:
             patch.object(sync_module.db, "get_db", return_value=store),
             patch.object(sync_module, "get_client", return_value=client),
             patch.object(sync_module, "schedule_workout", schedule_mock),
+            patch.object(sync_module, "unschedule_workout", unschedule_mock),
         ]
-        return store, schedule_mock, patches
+        return store, schedule_mock, unschedule_mock, patches
 
     def test_schedules_each_date(self, tmp_path: Path) -> None:
-        store, schedule_mock, patches = self._patched(tmp_path)
+        store, schedule_mock, _, patches = self._patched(tmp_path)
         store.mark_routine_synced("r1", garmin_workout_id="900", title="Push")
         dates = ["2026-07-20", "2026-07-27"]
-        with patches[0], patches[1], patches[2], patches[3]:
+        with patches[0], patches[1], patches[2], patches[3], patches[4]:
             result = sync_module.schedule_routine("r1", dates)
         assert result == {"scheduled": 2, "workout_id": "900", "dates": dates}
         assert schedule_mock.call_count == 2
         assert [c.args[1:] for c in schedule_mock.call_args_list] == [
             ("900", "2026-07-20"), ("900", "2026-07-27")]
-        # Earliest date persisted for display.
+        # Earliest date persisted for display, and both scheduleIds tracked.
         assert store.get_synced_routine("r1")["scheduled_date"] == "2026-07-20"
+        assert set(store.get_routine_schedule_ids("r1")) == {"1001", "1002"}
+
+    def test_reschedule_unschedules_prior_entries(self, tmp_path: Path) -> None:
+        # Item #4 regression: scheduling the same routine again must remove the prior
+        # calendar entries first (Garmin appends, so re-POSTing would stack duplicates).
+        store, schedule_mock, unschedule_mock, patches = self._patched(tmp_path)
+        store.mark_routine_synced("r1", garmin_workout_id="900", title="Push")
+        with patches[0], patches[1], patches[2], patches[3], patches[4]:
+            sync_module.schedule_routine("r1", ["2026-07-20"])
+            unschedule_mock.assert_not_called()  # nothing to remove on the first booking
+            first_ids = store.get_routine_schedule_ids("r1")
+            sync_module.schedule_routine("r1", ["2026-07-21"])
+        # The second booking unscheduled the first entry before creating the new one.
+        assert [c.args[1] for c in unschedule_mock.call_args_list] == first_ids
+        assert store.get_routine_schedule_ids("r1") == ["1002"]
 
     def test_raises_when_not_synced(self, tmp_path: Path) -> None:
-        store, schedule_mock, patches = self._patched(tmp_path)
-        with patches[0], patches[1], patches[2], patches[3]:
+        store, schedule_mock, _, patches = self._patched(tmp_path)
+        with patches[0], patches[1], patches[2], patches[3], patches[4]:
             with pytest.raises(ValueError, match="not synced"):
                 sync_module.schedule_routine("missing", ["2026-07-20"])
         schedule_mock.assert_not_called()
 
     def test_raises_on_empty_dates(self, tmp_path: Path) -> None:
-        store, _, patches = self._patched(tmp_path)
+        store, _, _, patches = self._patched(tmp_path)
         store.mark_routine_synced("r1", garmin_workout_id="900")
-        with patches[0], patches[1], patches[2], patches[3]:
+        with patches[0], patches[1], patches[2], patches[3], patches[4]:
             with pytest.raises(ValueError):
                 sync_module.schedule_routine("r1", [])
 

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -7,6 +7,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from fastapi.testclient import TestClient
+
+import hevy2garmin.server as srv
 from hevy2garmin import sync as sync_module
 from hevy2garmin.sync import routine_schedule_dates
 from hevy2garmin.db_sqlite import SQLiteDatabase
@@ -602,6 +605,89 @@ class TestScheduleRoutine:
         with patches[0], patches[1], patches[2], patches[3], patches[4]:
             with pytest.raises(ValueError):
                 sync_module.schedule_routine("r1", [])
+
+
+class TestUnscheduleRoutineEntry:
+    def _patched(self, tmp_path: Path):
+        store = SQLiteDatabase(tmp_path / "unsched.db")
+        unschedule_mock = MagicMock()
+        patches = [
+            patch.object(sync_module, "load_config", return_value={
+                "garmin_email": "e", "garmin_password": "p"}),
+            patch.object(sync_module.db, "get_db", return_value=store),
+            patch.object(sync_module, "get_client", return_value=MagicMock()),
+            patch.object(sync_module, "unschedule_workout", unschedule_mock),
+        ]
+        return store, unschedule_mock, patches
+
+    def test_unschedules_and_removes_row(self, tmp_path: Path) -> None:
+        store, unschedule_mock, patches = self._patched(tmp_path)
+        store.add_routine_schedule("r1", "111", "2026-07-20")
+        store.add_routine_schedule("r1", "222", "2026-07-27")
+        with patches[0], patches[1], patches[2], patches[3]:
+            sync_module.unschedule_routine_entry("r1", "111")
+        assert unschedule_mock.call_args[0][1] == "111"
+        # Only the removed entry is dropped from tracking.
+        assert store.get_routine_schedule_ids("r1") == ["222"]
+
+    def test_removes_row_even_when_garmin_errors(self, tmp_path: Path) -> None:
+        # A Garmin failure (e.g. entry already gone) must not leave a stuck row.
+        store, unschedule_mock, patches = self._patched(tmp_path)
+        unschedule_mock.side_effect = RuntimeError("Garmin 500")
+        store.add_routine_schedule("r1", "111", "2026-07-20")
+        with patches[0], patches[1], patches[2], patches[3]:
+            sync_module.unschedule_routine_entry("r1", "111")
+        assert store.get_routine_schedule_ids("r1") == []
+
+
+class TestScheduledWorkoutsUI:
+    def _client(self, store: SQLiteDatabase):
+        srv._is_configured_cache = True  # skip the "not configured → /setup" redirect
+        return patch.object(srv.db, "get_db", return_value=store), TestClient(srv.app)
+
+    def _seed(self, store: SQLiteDatabase, n: int) -> None:
+        store.mark_routine_synced("r1", garmin_workout_id="w1", title="Push")
+        # Far-future dates so they always count as "upcoming" regardless of today.
+        for i in range(n):
+            store.add_routine_schedule("r1", f"s{i}", f"2999-01-{i + 1:02d}")
+
+    def test_schedules_fragment_paginates_and_clamps(self, tmp_path: Path) -> None:
+        store = SQLiteDatabase(tmp_path / "ui.db")
+        self._seed(store, 11)  # 11 entries → 2 pages of 10
+        db_patch, client = self._client(store)
+        with db_patch, client:
+            page1 = client.get("/api/routines/schedules?page=1").text
+            page2 = client.get("/api/routines/schedules?page=2").text
+            clamped = client.get("/api/routines/schedules?page=99").text
+        assert "Page 1 of 2" in page1
+        assert "2999-01-11" not in page1  # the 11th entry is on page 2
+        assert "Page 2 of 2" in page2 and "2999-01-11" in page2
+        # Out-of-range page clamps to the last page rather than erroring.
+        assert "Page 2 of 2" in clamped
+
+    def test_empty_state(self, tmp_path: Path) -> None:
+        store = SQLiteDatabase(tmp_path / "ui.db")
+        db_patch, client = self._client(store)
+        with db_patch, client:
+            html = client.get("/api/routines/schedules").text
+        assert "No upcoming scheduled workouts." in html
+
+    def test_unschedule_route_removes_and_rerenders(self, tmp_path: Path) -> None:
+        store = SQLiteDatabase(tmp_path / "ui.db")
+        self._seed(store, 2)
+        db_patch, client = self._client(store)
+        unschedule_mock = MagicMock()
+        with db_patch, client, \
+                patch.object(sync_module, "load_config", return_value={
+                    "garmin_email": "e", "garmin_password": "p"}), \
+                patch.object(sync_module, "get_client", return_value=MagicMock()), \
+                patch.object(sync_module, "unschedule_workout", unschedule_mock):
+            resp = client.post("/api/routines/r1/schedule/s0/unschedule?page=1")
+        assert resp.status_code == 200
+        unschedule_mock.assert_called_once()
+        # The entry is gone and the refreshed fragment is returned.
+        assert store.get_routine_schedule_ids("r1") == ["s1"]
+        assert 'id="scheduled-table"' in resp.text
 
 
 class TestDbFacade:

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -672,6 +672,20 @@ class TestScheduledWorkoutsUI:
             html = client.get("/api/routines/schedules").text
         assert "No upcoming scheduled workouts." in html
 
+    def test_schedule_route_triggers_table_refresh(self, tmp_path: Path) -> None:
+        # A successful schedule fires the HX-Trigger event the table listens for,
+        # so the "Scheduled workouts" table refreshes without a full page reload.
+        store = SQLiteDatabase(tmp_path / "ui.db")
+        store.mark_routine_synced("r1", garmin_workout_id="900", title="Push")
+        db_patch, client = self._client(store)
+        with db_patch, client, patch.object(
+            srv, "schedule_routine",
+            return_value={"scheduled": 1, "workout_id": "900", "dates": ["2999-01-05"]},
+        ):
+            resp = client.post("/api/routines/r1/schedule", data={"mode": "once", "date": "2999-01-05"})
+        assert resp.status_code == 200
+        assert resp.headers.get("HX-Trigger") == "refreshSchedules"
+
     def test_unschedule_route_removes_and_rerenders(self, tmp_path: Path) -> None:
         store = SQLiteDatabase(tmp_path / "ui.db")
         self._seed(store, 2)

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -663,13 +663,26 @@ class TestUnscheduleRoutineEntry:
         assert store.get_routine_schedule_ids("r1") == ["111"]
 
     def test_removes_row_when_entry_already_gone_404(self, tmp_path: Path) -> None:
-        # A 404 means the entry is already gone on Garmin → safe to drop the stale row.
+        # A real HTTP 404 (response.status_code) means the entry is already gone → drop it.
         store, unschedule_mock, patches = self._patched(tmp_path)
-        unschedule_mock.side_effect = RuntimeError("404 Client Error: Not Found")
+        err = RuntimeError("Not Found")
+        err.response = type("R", (), {"status_code": 404})()
+        unschedule_mock.side_effect = err
         store.add_routine_schedule("r1", "111", "2026-07-20")
         with patches[0], patches[1], patches[2], patches[3]:
             sync_module.unschedule_routine_entry("r1", "111")
         assert store.get_routine_schedule_ids("r1") == []
+
+    def test_transient_error_with_404_in_message_keeps_row(self, tmp_path: Path) -> None:
+        # A transient error with no HTTP status whose text merely contains "404" (a
+        # scheduleId or retry delay) must NOT be mistaken for "already gone" — keep the row.
+        store, unschedule_mock, patches = self._patched(tmp_path)
+        unschedule_mock.side_effect = RuntimeError("HTTP 500 at /schedule/40412, retry in 40400ms")
+        store.add_routine_schedule("r1", "111", "2026-07-20")
+        with patches[0], patches[1], patches[2], patches[3]:
+            with pytest.raises(RuntimeError):
+                sync_module.unschedule_routine_entry("r1", "111")
+        assert store.get_routine_schedule_ids("r1") == ["111"]
 
 
 class TestScheduledWorkoutsUI:

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -665,6 +665,21 @@ class TestScheduledWorkoutsUI:
         # Out-of-range page clamps to the last page rather than erroring.
         assert "Page 2 of 2" in clamped
 
+    def test_filter_by_routine_name_and_start_date(self, tmp_path: Path) -> None:
+        store = SQLiteDatabase(tmp_path / "ui.db")
+        store.mark_routine_synced("r1", garmin_workout_id="w1", title="Push Day")
+        store.mark_routine_synced("r2", garmin_workout_id="w2", title="Leg Day")
+        store.add_routine_schedule("r1", "s1", "2999-01-05")
+        store.add_routine_schedule("r2", "s2", "2999-02-10")
+        db_patch, client = self._client(store)
+        with db_patch, client:
+            by_name = client.get("/api/routines/schedules?q=leg").text
+            by_date = client.get("/api/routines/schedules?start=2999-02-01").text
+        # Text filter keeps only the matching routine.
+        assert "Leg Day" in by_name and "Push Day" not in by_name
+        # Start-date filter drops the earlier entry.
+        assert "Leg Day" in by_date and "Push Day" not in by_date
+
     def test_empty_state(self, tmp_path: Path) -> None:
         store = SQLiteDatabase(tmp_path / "ui.db")
         db_patch, client = self._client(store)

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -373,6 +373,27 @@ class TestSyncRoutines:
         # ...and the date is kept on the record instead of being wiped to None.
         assert store.get_synced_routine("r1")["scheduled_date"] == "2026-08-01"
 
+    def test_resync_restores_all_recurring_dates(self, tmp_path: Path) -> None:
+        # A recurring routine booked on 3 dates, then edited: the content-change re-sync
+        # must re-book ALL 3 dates on the recreated workout, not collapse to one.
+        routines = [{"id": "r1", "title": "Push", "updated_at": "2026-01-01T00:00:00Z", "exercises": []}]
+        store, create_mock, schedule_mock, patches = self._patched(tmp_path, routines)
+        store.mark_routine_synced("r1", garmin_workout_id="555",
+                                  scheduled_date="2026-08-03", content_hash="stale-hash")
+        for d in ("2026-08-03", "2026-08-10", "2026-08-17"):
+            store.add_routine_schedule("r1", f"old-{d}", d)
+        schedule_mock.side_effect = lambda _client, _wid, day: f"new-{day}"
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+                patch.object(sync_module, "delete_workout", MagicMock()), patches[6], patches[7]:
+            result = sync_module.sync_routines()
+        assert result["updated"] == 1
+        # All three dates re-booked on the new workout, and tracked with fresh ids.
+        assert sorted(c.args[2] for c in schedule_mock.call_args_list) == [
+            "2026-08-03", "2026-08-10", "2026-08-17"]
+        assert set(store.get_routine_schedule_ids("r1")) == {
+            "new-2026-08-03", "new-2026-08-10", "new-2026-08-17"}
+        assert store.get_synced_routine("r1")["scheduled_date"] == "2026-08-03"
+
     def test_schedule_records_calendar_entry(self, tmp_path: Path) -> None:
         # A first sync with an explicit date books the Garmin calendar and records the
         # returned scheduleId, so a later reschedule can unschedule it instead of stacking.
@@ -630,10 +651,21 @@ class TestUnscheduleRoutineEntry:
         # Only the removed entry is dropped from tracking.
         assert store.get_routine_schedule_ids("r1") == ["222"]
 
-    def test_removes_row_even_when_garmin_errors(self, tmp_path: Path) -> None:
-        # A Garmin failure (e.g. entry already gone) must not leave a stuck row.
+    def test_keeps_row_and_raises_on_transient_error(self, tmp_path: Path) -> None:
+        # A transient Garmin failure must NOT drop the row (else the calendar entry is
+        # orphaned and unremovable) — it re-raises so the caller can surface a retry.
         store, unschedule_mock, patches = self._patched(tmp_path)
         unschedule_mock.side_effect = RuntimeError("Garmin 500")
+        store.add_routine_schedule("r1", "111", "2026-07-20")
+        with patches[0], patches[1], patches[2], patches[3]:
+            with pytest.raises(RuntimeError, match="500"):
+                sync_module.unschedule_routine_entry("r1", "111")
+        assert store.get_routine_schedule_ids("r1") == ["111"]
+
+    def test_removes_row_when_entry_already_gone_404(self, tmp_path: Path) -> None:
+        # A 404 means the entry is already gone on Garmin → safe to drop the stale row.
+        store, unschedule_mock, patches = self._patched(tmp_path)
+        unschedule_mock.side_effect = RuntimeError("404 Client Error: Not Found")
         store.add_routine_schedule("r1", "111", "2026-07-20")
         with patches[0], patches[1], patches[2], patches[3]:
             sync_module.unschedule_routine_entry("r1", "111")
@@ -734,6 +766,21 @@ class TestScheduledWorkoutsUI:
         # The entry is gone and the refreshed fragment is returned.
         assert store.get_routine_schedule_ids("r1") == ["s1"]
         assert 'id="scheduled-table"' in resp.text
+
+    def test_unschedule_route_keeps_row_on_transient_error(self, tmp_path: Path) -> None:
+        store = SQLiteDatabase(tmp_path / "ui.db")
+        self._seed(store, 2)
+        db_patch, client = self._client(store)
+        with db_patch, client, \
+                patch.object(sync_module, "load_config", return_value={
+                    "garmin_email": "e", "garmin_password": "p"}), \
+                patch.object(sync_module, "get_client", return_value=MagicMock()), \
+                patch.object(sync_module, "unschedule_workout",
+                             MagicMock(side_effect=RuntimeError("Garmin 500"))):
+            resp = client.post("/api/routines/r1/schedule/s0/unschedule?page=1")
+        # Transient failure surfaces an error toast and keeps the entry tracked.
+        assert "toast-error" in resp.text
+        assert set(store.get_routine_schedule_ids("r1")) == {"s0", "s1"}
 
 
 class TestDbFacade:

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -680,6 +680,23 @@ class TestScheduledWorkoutsUI:
         # Start-date filter drops the earlier entry.
         assert "Leg Day" in by_date and "Push Day" not in by_date
 
+    def test_page_size_selector(self, tmp_path: Path) -> None:
+        store = SQLiteDatabase(tmp_path / "ui.db")
+        store.mark_routine_synced("r1", garmin_workout_id="w1", title="Push")
+        for i in range(30):  # 30 future entries
+            store.add_routine_schedule("r1", f"s{i}", f"2999-{i // 28 + 1:02d}-{i % 28 + 1:02d}")
+        db_patch, client = self._client(store)
+        with db_patch, client:
+            size25 = client.get("/api/routines/schedules?size=25").text
+            size100 = client.get("/api/routines/schedules?size=100").text
+            bad = client.get("/api/routines/schedules?size=7").text  # invalid → default 10
+        # One Remove button per row → count rows per page.
+        assert size25.count("/unschedule?") == 25 and "Page 1 of 2" in size25
+        assert '<option value="25" selected>' in size25
+        assert size100.count("/unschedule?") == 30 and "Page 1 of" not in size100
+        assert bad.count("/unschedule?") == 10 and "Page 1 of 3" in bad
+        assert '<option value="10" selected>' in bad
+
     def test_empty_state(self, tmp_path: Path) -> None:
         store = SQLiteDatabase(tmp_path / "ui.db")
         db_patch, client = self._client(store)


### PR DESCRIPTION
## What changed and why

This addresses **item 4** of the PR #236 review (append-only re-scheduling) and, on top of that fix, adds a **scheduled workouts table** to the Routines page with filters, configurable pagination, and auto-refresh.

Garmin does not dedup schedules server-side: each `POST /workout-service/schedule/{id}` appends a new calendar entry. As a result, re-scheduling a routine stacked duplicate entries. We now track the `workoutScheduleId` Garmin returns and unschedule the prior entries before booking new dates, making (re)scheduling idempotent. With that tracking stored in a new `routine_schedules` table, the `/routines` page now lists scheduled entries (date + routine), with start-date and name filters, an adjustable page size, and per-row removal.

## Technical details

### Files changed
- `src/hevy2garmin/garmin.py` — `schedule_workout` now returns the `workoutScheduleId` (defensive: `None` if the body has no parseable id); new `unschedule_workout` helper (`DELETE /workout-service/schedule/{id}`).
- `src/hevy2garmin/db_interface.py` / `db_sqlite.py` / `db_postgres.py` — new `routine_schedules` table (one row per calendar entry) and methods: `add_routine_schedule`, `get_routine_schedule_ids`, `get_routine_scheduled_dates`, `clear_routine_schedules`, `delete_routine_schedule`, `get_upcoming_routine_schedules`, `count_upcoming_routine_schedules` (the last two support an optional title filter and share a FROM/JOIN/WHERE builder); `delete_synced_routine` also clears the routine's schedule rows.
- `src/hevy2garmin/sync.py` — `_reschedule_routine` helper (unschedule prior ids → clear → book new dates → record the returned ids; `unschedule_prior` flag), used by `schedule_routine` and the `sync_routines` restore path; `unschedule_routine_entry` (removes one entry and stops tracking it); `_is_not_found` helper to distinguish a 404.
- `src/hevy2garmin/server.py` — `routines_page` loads the schedules from the DB outside the Hevy fetch try/except; `_schedules_context(page, start_date, title, page_size)` helper; routes `GET /api/routines/schedules` (with `page`/`start`/`q`/`size`) and `POST /api/routines/{id}/schedule/{schedule_id}/unschedule`; `HX-Trigger: refreshSchedules` header on the schedule/sync endpoints.
- `src/hevy2garmin/templates/routine_schedules.html` — new HTMX partial (table + pagination + page-size selector + Remove button + empty state) that refreshes itself on the `refreshSchedules` event; included by `routines.html`, which hosts the filter form.
- `tests/test_routine.py` / `tests/test_db.py` — coverage for the new behavior (backend + UI).

### UI features
- **Scheduled workouts table**: date + routine name.
- **Filters**: start date (default: today) and routine-name search (case-insensitive substring, debounced). The form lives outside the swapped table, so typing keeps focus.
- **Page size**: a "Per page" selector below the table with 10 / 25 / 100 (default 10), validated against the allowed set.
- **Auto-refresh**: creating a new schedule (or running a sync) reloads the table via an HTMX event, no full page reload.
- **Remove**: each row unschedules the entry on Garmin and stops tracking it locally.
- Start date, name, and page size are preserved across pagination, removal, and refresh.

### Review fixes
A code review flagged four points, all addressed:
1. **Orphaned entry on transient failure** — `unschedule_routine_entry` only drops the tracking row on success or a **404** (already gone on Garmin). On a transient error (429/500/network) it re-raises so the route shows an error toast and the entry stays tracked for retry, instead of becoming an orphaned, unremovable calendar entry.
2. **Recurring dates lost on re-sync** — a content-change re-sync now re-books **every** date the routine had tracked (not just the earliest), preventing silent loss of recurring sessions.
3. **Redundant unschedule calls** — in the restore path the old workout was just deleted (its calendar entries already cascaded away), so `_reschedule_routine(unschedule_prior=False)` skips the per-id `unschedule_workout` calls (1s rate-limit each, all 404s).
4. **Duplicated SQL** — `get_upcoming_routine_schedules` and `count_upcoming_routine_schedules` share an `_upcoming_from_where(...)` builder per backend instead of repeating the FROM/JOIN/WHERE.

### Approach and trade-offs
I chose a normalized `routine_schedules` table (keyed by `hevy_routine_id + schedule_id`) over a JSON list in a single column, because a routine can accumulate many entries (recurring goes up to 52) and mutating a serialized list in one cell is awkward to maintain. Unscheduling during a reschedule is best-effort (an entry already gone on Garmin just 404s and is ignored); the manual removal path distinguishes a 404 from transient errors. The UI table reads local DB state only, so it renders even when the Hevy fetch fails; "today" is computed on the server and injected into the DB methods, keeping them pure/testable (ISO dates compare correctly as text). The name filter is a case-insensitive substring, without escaping wildcards (the user's own data). Page size is validated against `(10, 25, 100)` and falls back to 10 if invalid.

### How to test
```bash
# SQLite (default)
PYTHONPATH=src pytest tests/test_routine.py tests/test_db.py -q
PYTHONPATH=src pytest tests/ -q
# Postgres (CI parity — the DB layer changed)
DATABASE_URL=postgresql://test:test@localhost:5432/hevy2garmin_test PYTHONPATH=src pytest tests/ -q
```
Manual: `PYTHONPATH=src python -m hevy2garmin.cli serve --port 8123`, open `http://localhost:8123/routines`, schedule a routine twice for the same date and confirm only one Garmin calendar entry exists; check the "Scheduled workouts" table, filter by name (the table updates without losing focus) and by start date, change the page size (10/25/100), paginate, and use the Remove button.

Reviewer note: the assumed key in the schedule POST response is `workoutScheduleId`. If it differs, parsing falls back to `None` (degrades to "not tracked", without breaking scheduling).

### Breaking changes
No contract breakage. There is an **additive, backward-compatible schema change**: a new `routine_schedules` table created via `CREATE TABLE IF NOT EXISTS` on both backends (SQLite and Postgres). No existing column was altered or removed.

### Checklist
- [x] Tests added or updated
- [x] No sensitive data in logs or responses
- [x] Migrations are backward-compatible (new table, `CREATE TABLE IF NOT EXISTS`)
- [ ] Feature flag (not applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)