### PR TITLE
feat(routines): per-routine sync button and "show only unsynced" filter

### DIFF
--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -26,6 +26,7 @@ from hevy2garmin.ratelimit import record_rate_limit, cooldown_remaining, clear_r
 from hevy2garmin.sync import (
     sync,
     sync_routines,
+    sync_routine,
     routine_schedule_dates,
     schedule_routine,
     unschedule_routine_entry,
@@ -1440,6 +1441,37 @@ async def api_routines_sync(request: Request):
         f'<div class="toast {cls}">Routine sync complete: {msg}</div>',
         headers={"HX-Trigger": "refreshSchedules"},
     )
+
+
+@app.post("/api/routines/{hevy_routine_id}/sync", response_class=HTMLResponse)
+async def api_routine_sync_one(request: Request, hevy_routine_id: str):
+    """Sync a single Hevy routine and swap its table row in place."""
+    if is_demo_mode():
+        return HTMLResponse('<div class="toast toast-success">Sync disabled in demo mode.</div>')
+
+    form = await request.form()
+    force = form.get("force") in ("1", "true", "on")
+
+    if not _acquire_sync_lock():
+        return HTMLResponse('<div class="toast toast-error">Another sync is already running. Please wait.</div>')
+
+    try:
+        result = sync_routine(hevy_routine_id, force=force)
+    except Exception:
+        logger.exception("Routine %s sync failed", hevy_routine_id)
+        return HTMLResponse('<div class="toast toast-error">Routine sync failed. Check the logs for details.</div>')
+    finally:
+        _sync_executing.release()
+
+    outcome = result["outcome"]
+    if outcome == "failed":
+        return HTMLResponse(f'<div class="toast toast-error">Could not sync "{result["row"]["title"]}". Check the logs.</div>')
+    # Toast into #routines-result plus an out-of-band swap of the updated row, so it flips
+    # to "synced" (and gains the Schedule form) without a full page reload. HX-Trigger
+    # refreshes the schedules table since the restore path may have re-booked dates.
+    row_html = _render("routine_row.html", r=result["row"], oob=True).body.decode()
+    toast = f'<div class="toast toast-success">Synced "{result["row"]["title"]}" ({outcome}).</div>'
+    return HTMLResponse(toast + row_html, headers={"HX-Trigger": "refreshSchedules"})
 
 
 @app.post("/api/routines/{hevy_routine_id}/schedule", response_class=HTMLResponse)

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -8,6 +8,7 @@ import re
 import threading
 import time
 from datetime import date, datetime, timezone
+from html import escape
 from math import ceil
 from pathlib import Path
 from typing import Any
@@ -1500,13 +1501,16 @@ async def api_routine_sync_one(request: Request, hevy_routine_id: str):
         _sync_executing.release()
 
     outcome = result["outcome"]
+    # The routine title is user-controlled (Hevy account data), so escape it before
+    # interpolating into the toast HTML — these f-strings bypass Jinja's autoescape.
+    title = escape(result["row"]["title"])
     if outcome == "failed":
-        return HTMLResponse(f'<div class="toast toast-error">Could not sync "{result["row"]["title"]}". Check the logs.</div>')
+        return HTMLResponse(f'<div class="toast toast-error">Could not sync "{title}". Check the logs.</div>')
     # Toast into #routines-result plus an out-of-band swap of the updated row, so it flips
     # to "synced" (and gains the Schedule form) without a full page reload. HX-Trigger
     # refreshes the schedules table since the restore path may have re-booked dates.
     row_html = _render("routine_row.html", r=result["row"], oob=True).body.decode()
-    toast = f'<div class="toast toast-success">Synced "{result["row"]["title"]}" ({outcome}).</div>'
+    toast = f'<div class="toast toast-success">Synced "{title}" ({outcome}).</div>'
     return HTMLResponse(toast + row_html, headers={"HX-Trigger": "refreshSchedules"})
 
 

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -55,6 +55,23 @@ def _get_cat_names() -> dict[int, str]:
 _jinja_env = Environment(loader=FileSystemLoader(str(TEMPLATES_DIR)), autoescape=True)
 
 
+# Weekday / short-date helpers for the routines "Upcoming schedule" timeline.
+_SCHED_WEEKDAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+_SCHED_MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+
+
+def _sched_parts(iso: Any) -> dict[str, str]:
+    """Format an ISO date (YYYY-MM-DD) into {'short': 'Jul 24', 'weekday': 'Friday'}."""
+    try:
+        d = date.fromisoformat(str(iso)[:10])
+        return {"short": f"{_SCHED_MONTHS[d.month - 1]} {d.day}", "weekday": _SCHED_WEEKDAYS[d.weekday()]}
+    except (ValueError, TypeError):
+        return {"short": str(iso or ""), "weekday": ""}
+
+
+_jinja_env.globals["sched_parts"] = _sched_parts
+
+
 def _render(template_name: str, **ctx) -> HTMLResponse:
     t = _jinja_env.get_template(template_name)
     ctx.setdefault("auth_enabled", auth_enabled())
@@ -1381,18 +1398,37 @@ async def routines_page(request: Request):
         _cache_routines_total(_db, len(all_routines))
         for r in all_routines:
             record = _db.get_synced_routine(r.get("id", ""))
+            exercises = [
+                {
+                    "name": ex.get("title") or ex.get("name") or "Exercise",
+                    "sets": len(ex.get("sets") or []),
+                }
+                for ex in (r.get("exercises") or [])
+            ]
             routines.append({
                 "id": r.get("id", ""),
                 "title": r.get("title") or r.get("name") or "Routine",
-                "exercise_count": len(r.get("exercises", [])),
+                "exercises": exercises,
+                "exercise_count": len(exercises),
                 "synced": record is not None,
                 "scheduled_date": (record or {}).get("scheduled_date"),
             })
     except Exception:
         logger.exception("Failed to load Hevy routines")
         fetch_error = "Could not load routines from Hevy. Check your API key and try again."
+
+    total = len(routines)
+    synced = sum(1 for r in routines if r["synced"])
+    stats = {
+        "total": total,
+        "synced": synced,
+        "pending": max(0, total - synced),
+        "scheduled": sum(1 for r in routines if r["scheduled_date"]),
+        "pct": round(synced / total * 100) if total else 0,
+    }
     return _render(
-        "routines.html", request=request, routines=routines, fetch_error=fetch_error, **schedules
+        "routines.html", request=request, routines=routines, stats=stats,
+        fetch_error=fetch_error, **schedules
     )
 
 

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -1046,8 +1046,8 @@ def sync_routine(
 
     Fetches the routine from Hevy, reconciles against the Garmin library, and runs the
     same per-routine logic as :func:`sync_routines`. Returns
-    ``{"outcome": ..., "row": {id, title, exercise_count, synced, scheduled_date}}`` —
-    ``row`` is a render-ready dict for the routines table. Raises ``ValueError`` when the
+    ``{"outcome": ..., "row": {id, title, exercises, exercise_count, synced, scheduled_date}}`` —
+    ``row`` is a render-ready dict for the routines card. Raises ``ValueError`` when the
     routine isn't found in the Hevy account.
     """
     cfg = config or load_config()
@@ -1076,10 +1076,18 @@ def sync_routine(
     )
 
     record = store.get_synced_routine(hevy_routine_id)
+    exercises = [
+        {
+            "name": ex.get("title") or ex.get("name") or "Exercise",
+            "sets": len(ex.get("sets") or []),
+        }
+        for ex in (routine.get("exercises") or [])
+    ]
     row = {
         "id": hevy_routine_id,
         "title": routine.get("title") or routine.get("name") or "Routine",
-        "exercise_count": len(routine.get("exercises") or []),
+        "exercises": exercises,
+        "exercise_count": len(exercises),
         "synced": record is not None,
         "scheduled_date": (record or {}).get("scheduled_date"),
     }

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -825,6 +825,136 @@ def _reschedule_routine(
             store.add_routine_schedule(hevy_routine_id, str(schedule_id), day)
 
 
+def _build_library_by_name(garmin_client) -> dict[str, list[dict]]:
+    """Map ``workoutName`` -> ``[{"id", "description"}, ...]`` of the workouts already in
+    the Garmin library, so a sync can reconcile against Garmin's actual state before
+    creating (not just the local DB row) — a DB reset or a crash in the create->persist
+    window would otherwise leave an untracked workout that gets recreated as a duplicate.
+    Best-effort: if the listing fails we fall back to DB-only dedup.
+    """
+    library_by_name: dict[str, list[dict]] = {}
+    try:
+        for w in list_workouts(garmin_client, limit=999):
+            name, wid = w.get("workoutName"), w.get("workoutId")
+            if name and wid is not None:
+                library_by_name.setdefault(name, []).append(
+                    {"id": str(wid), "description": w.get("description") or ""}
+                )
+    except Exception:
+        logger.warning("Could not list Garmin workouts; falling back to DB-only dedup")
+    return library_by_name
+
+
+def _sync_one_routine(
+    routine: dict,
+    store,
+    garmin_client,
+    library_by_name: dict[str, list[dict]],
+    *,
+    weight_unit: str,
+    default_rest_seconds: int | None,
+    schedule_date: str | None = None,
+    force: bool = False,
+    dry_run: bool = False,
+) -> dict:
+    """Sync one Hevy routine to a Garmin planned workout.
+
+    Returns ``{"outcome": "created"|"updated"|"skipped"|"failed", "scheduled": 0|1}``.
+    Shared by :func:`sync_routines` (bulk) and :func:`sync_routine` (single) so both
+    paths behave identically. Catches its own errors and reports ``"failed"``.
+    """
+    rid = routine.get("id", "unknown")
+    title = routine.get("title") or routine.get("name") or "Routine"
+    updated_at = routine.get("updated_at")
+    try:
+        payload = routine_to_garmin_workout(
+            routine, weight_unit=weight_unit, default_rest_seconds=default_rest_seconds
+        )
+        content_hash = workout_content_hash(payload)
+
+        # Skip when the generated payload is byte-for-byte what we last synced AND the
+        # workout is fully landed. A row left in 'schedule_pending' isn't done, so we
+        # don't skip it — the next sync retries the schedule below. --force overrides.
+        existing = store.get_synced_routine(rid)
+        content_synced = bool(existing and existing.get("content_hash") == content_hash)
+        already_done = content_synced and (existing.get("status") or "success") == "success"
+        if not force and already_done:
+            logger.debug("Skipping routine %s (%s) — unchanged", rid, title)
+            return {"outcome": "skipped", "scheduled": 0}
+
+        # A prior sync record means this run replaces it (an update), not a new create.
+        outcome = "updated" if existing else "created"
+
+        if dry_run:
+            verb = "update" if existing else "create"
+            logger.info(
+                "[dry-run] Would %s Garmin workout '%s' with %d step(s)",
+                verb, title, len(payload["workoutSegments"][0]["workoutSteps"]),
+            )
+            return {"outcome": outcome, "scheduled": 0}
+
+        # Content changed (or forced) — drop the stale Garmin workout(s) first: the
+        # DB-tracked id plus any same-named library entry carrying our provenance marker
+        # (an orphan from a crash or DB reset). Same-named entries without the marker are
+        # the user's own workouts and are left untouched.
+        stale_ids = set()
+        if existing and existing.get("garmin_workout_id"):
+            stale_ids.add(str(existing["garmin_workout_id"]))
+        for entry in library_by_name.get(payload["workoutName"], []):
+            if ROUTINE_DESC_MARKER in entry["description"]:
+                stale_ids.add(entry["id"])
+        for wid in stale_ids:
+            try:
+                delete_workout(garmin_client, wid)
+            except Exception:
+                logger.warning("  Could not delete stale/orphan workout %s", wid)
+
+        workout_id = create_workout(garmin_client, payload)
+        if workout_id is None:
+            logger.warning("  Garmin did not return a workoutId for '%s'", title)
+            return {"outcome": "failed", "scheduled": 0}
+
+        # Recreating the workout drops the calendar entries the old one had, so re-apply
+        # the prior schedule when this run doesn't set a new one. An explicit schedule_date
+        # overrides; otherwise restore every date the routine had booked (recurring), with
+        # a fallback to the single stored date for rows predating per-entry tracking. Only
+        # an explicit schedule_date counts toward the "scheduled" stat.
+        if schedule_date:
+            dates_to_book = [schedule_date]
+        else:
+            dates_to_book = store.get_routine_scheduled_dates(rid)
+            if not dates_to_book and (existing or {}).get("scheduled_date"):
+                dates_to_book = [existing["scheduled_date"]]
+        effective_schedule_date = min(dates_to_book) if dates_to_book else None
+
+        scheduled = 0
+        if dates_to_book:
+            # Persist the created workout before scheduling, marked 'schedule_pending', so
+            # a schedule failure leaves it tracked (recovered next sync) not orphaned.
+            store.mark_routine_synced(
+                rid, garmin_workout_id=str(workout_id), title=title,
+                hevy_updated_at=updated_at, scheduled_date=effective_schedule_date,
+                content_hash=content_hash, status="schedule_pending",
+            )
+            # The old workout (and its calendar entries) was just deleted, so its tracked
+            # ids are already gone — clear+rebook without a rate-limited unschedule per id.
+            _reschedule_routine(
+                garmin_client, store, rid, workout_id, dates_to_book, unschedule_prior=False
+            )
+            if schedule_date:
+                scheduled = 1
+
+        store.mark_routine_synced(
+            rid, garmin_workout_id=str(workout_id), title=title,
+            hevy_updated_at=updated_at, scheduled_date=effective_schedule_date,
+            content_hash=content_hash,
+        )
+        return {"outcome": outcome, "scheduled": scheduled}
+    except Exception:
+        logger.exception("Failed to sync routine %s (%s)", rid, title)
+        return {"outcome": "failed", "scheduled": 0}
+
+
 def sync_routines(
     config: dict[str, Any] | None = None,
     dry_run: bool = False,
@@ -872,30 +1002,12 @@ def sync_routines(
     _cache_routines_total(store, len(routines))
 
     garmin_client = None
-    # name -> [{"id", "description"}, ...] of the workouts already in the Garmin library.
-    # Built once per run so we can reconcile against Garmin's actual state before creating,
-    # not just the local DB row: a DB reset (ephemeral cloud storage, a migration) or a
-    # crash in the create->persist window would otherwise leave a workout on Garmin that
-    # we no longer track and recreate as a duplicate. We correlate by name (the routine
-    # title we set as workoutName) AND require our provenance marker in the description
-    # before deleting, so a workout the user hand-built in Garmin with the same title is
-    # never touched. Best-effort: if the listing fails we fall back to DB-only dedup; if
-    # Garmin omits the description the marker just won't match, so we create rather than
-    # delete — a possible duplicate, never destroyed user data.
     library_by_name: dict[str, list[dict]] = {}
     if not dry_run:
         logger.info("Authenticating with Garmin Connect...")
         garmin_client = get_client(garmin_email, garmin_password, garmin_token_dir)
         logger.info("Authenticated successfully")
-        try:
-            for w in list_workouts(garmin_client, limit=999):
-                name, wid = w.get("workoutName"), w.get("workoutId")
-                if name and wid is not None:
-                    library_by_name.setdefault(name, []).append(
-                        {"id": str(wid), "description": w.get("description") or ""}
-                    )
-        except Exception:
-            logger.warning("Could not list Garmin workouts; falling back to DB-only dedup")
+        library_by_name = _build_library_by_name(garmin_client)
 
     stats = {
         "created": 0,
@@ -907,125 +1019,71 @@ def sync_routines(
     }
 
     for routine in routines:
-        rid = routine.get("id", "unknown")
-        title = routine.get("title") or routine.get("name") or "Routine"
-        updated_at = routine.get("updated_at")
-
-        try:
-            payload = routine_to_garmin_workout(
-                routine, weight_unit=weight_unit, default_rest_seconds=default_rest_seconds
-            )
-            content_hash = workout_content_hash(payload)
-
-            # Skip when the generated payload is byte-for-byte what we last synced
-            # AND the workout is fully landed. A row left in 'schedule_pending' (the
-            # workout was created but a prior run's schedule call failed) is not done,
-            # so we don't skip it — the next sync retries the schedule below.
-            # Hashing the payload (not Hevy's updated_at) also re-syncs when this
-            # builder changes — e.g. after adding rest steps. --force overrides it.
-            existing = store.get_synced_routine(rid)
-            content_synced = bool(existing and existing.get("content_hash") == content_hash)
-            already_done = content_synced and (existing.get("status") or "success") == "success"
-            if not force and already_done:
-                logger.debug("Skipping routine %s (%s) — unchanged", rid, title)
-                stats["skipped"] += 1
-                continue
-
-            # A prior sync record means this run replaces it (an update), not a
-            # brand-new create — tracked separately for the summary.
-            outcome = "updated" if existing else "created"
-
-            if dry_run:
-                verb = "update" if existing else "create"
-                logger.info(
-                    "[dry-run] Would %s Garmin workout '%s' with %d step(s)",
-                    verb,
-                    title,
-                    len(payload["workoutSegments"][0]["workoutSteps"]),
-                )
-                stats[outcome] += 1
-                continue
-
-            # Content changed (or forced) — drop the stale Garmin workout(s) first.
-            # That's the DB-tracked id *plus* any same-named library entry that carries
-            # our provenance marker: an orphan from a prior crash or a DB reset that isn't
-            # tracked locally. A same-named entry *without* the marker is the user's own
-            # workout, so it's left untouched. Deleting the rest (deduped, so a tracked id
-            # that also shows up in the library isn't deleted twice) before recreating
-            # keeps sync idempotent instead of stacking a duplicate onto whatever survived.
-            stale_ids = set()
-            if existing and existing.get("garmin_workout_id"):
-                stale_ids.add(str(existing["garmin_workout_id"]))
-            for entry in library_by_name.get(payload["workoutName"], []):
-                if ROUTINE_DESC_MARKER in entry["description"]:
-                    stale_ids.add(entry["id"])
-            for wid in stale_ids:
-                try:
-                    delete_workout(garmin_client, wid)
-                except Exception:
-                    logger.warning("  Could not delete stale/orphan workout %s", wid)
-
-            workout_id = create_workout(garmin_client, payload)
-            if workout_id is None:
-                logger.warning("  Garmin did not return a workoutId for '%s'", title)
-                stats["failed"] += 1
-                continue
-
-            # Recreating the workout drops the calendar entries the old one had, so
-            # re-apply the prior schedule when this run doesn't set a new one. An
-            # explicit schedule_date overrides; otherwise restore *every* date the
-            # routine had booked (so a recurring routine keeps all its entries), falling
-            # back to the single stored date for rows created before per-entry tracking.
-            # Only an explicit schedule_date counts toward the "scheduled" stat.
-            if schedule_date:
-                dates_to_book = [schedule_date]
-            else:
-                dates_to_book = store.get_routine_scheduled_dates(rid)
-                if not dates_to_book and (existing or {}).get("scheduled_date"):
-                    dates_to_book = [existing["scheduled_date"]]
-            effective_schedule_date = min(dates_to_book) if dates_to_book else None
-
-            if dates_to_book:
-                # Persist the created workout *before* the schedule call, marked
-                # 'schedule_pending'. If scheduling then errors (Garmin 429/500), the
-                # workout is already tracked, so the next sync deletes+recreates it
-                # instead of orphaning it and creating a duplicate.
-                store.mark_routine_synced(
-                    rid,
-                    garmin_workout_id=str(workout_id),
-                    title=title,
-                    hevy_updated_at=updated_at,
-                    scheduled_date=effective_schedule_date,
-                    content_hash=content_hash,
-                    status="schedule_pending",
-                )
-                # The old workout (and its Garmin calendar entries) was just deleted,
-                # so its tracked ids are already gone — clear+rebook without spending a
-                # rate-limited unschedule call per stale id.
-                _reschedule_routine(
-                    garmin_client, store, rid, workout_id, dates_to_book, unschedule_prior=False
-                )
-                if schedule_date:
-                    stats["scheduled"] += 1
-
-            store.mark_routine_synced(
-                rid,
-                garmin_workout_id=str(workout_id),
-                title=title,
-                hevy_updated_at=updated_at,
-                scheduled_date=effective_schedule_date,
-                content_hash=content_hash,
-            )
-            stats[outcome] += 1
-        except Exception:
-            logger.exception("Failed to sync routine %s (%s)", rid, title)
-            stats["failed"] += 1
+        res = _sync_one_routine(
+            routine, store, garmin_client, library_by_name,
+            weight_unit=weight_unit, default_rest_seconds=default_rest_seconds,
+            schedule_date=schedule_date, force=force, dry_run=dry_run,
+        )
+        stats[res["outcome"]] += 1
+        stats["scheduled"] += res["scheduled"]
 
     logger.info(
         "Routine sync done — created=%d updated=%d skipped=%d failed=%d scheduled=%d",
         stats["created"], stats["updated"], stats["skipped"], stats["failed"], stats["scheduled"],
     )
     return stats
+
+
+def sync_routine(
+    hevy_routine_id: str,
+    *,
+    config: dict[str, Any] | None = None,
+    force: bool = False,
+    **overrides: Any,
+) -> dict:
+    """Sync a single Hevy routine to Garmin (the per-row "Sync" action).
+
+    Fetches the routine from Hevy, reconciles against the Garmin library, and runs the
+    same per-routine logic as :func:`sync_routines`. Returns
+    ``{"outcome": ..., "row": {id, title, exercise_count, synced, scheduled_date}}`` —
+    ``row`` is a render-ready dict for the routines table. Raises ``ValueError`` when the
+    routine isn't found in the Hevy account.
+    """
+    cfg = config or load_config()
+    store = _resolve_store()
+    hevy_api_key = overrides.get("hevy_api_key") or cfg.get("hevy_api_key")
+    garmin_email = overrides.get("garmin_email") or cfg.get("garmin_email")
+    garmin_password = overrides.get("garmin_password") or cfg.get("garmin_password", "")
+    garmin_token_dir = cfg.get("garmin_token_dir", "~/.garminconnect")
+    weight_unit = (cfg.get("sync") or {}).get("weight_unit", "kilogram")
+    default_rest_seconds = (cfg.get("timing") or {}).get("rest_between_sets_seconds", 75)
+
+    hevy = HevyClient(api_key=hevy_api_key)
+    routine = next(
+        (r for r in fetch_all_routines(hevy) if r.get("id") == hevy_routine_id), None
+    )
+    if routine is None:
+        raise ValueError("Routine not found in Hevy")
+
+    logger.info("Authenticating with Garmin Connect...")
+    garmin_client = get_client(garmin_email, garmin_password, garmin_token_dir)
+    library_by_name = _build_library_by_name(garmin_client)
+    res = _sync_one_routine(
+        routine, store, garmin_client, library_by_name,
+        weight_unit=weight_unit, default_rest_seconds=default_rest_seconds,
+        schedule_date=None, force=force, dry_run=False,
+    )
+
+    record = store.get_synced_routine(hevy_routine_id)
+    row = {
+        "id": hevy_routine_id,
+        "title": routine.get("title") or routine.get("name") or "Routine",
+        "exercise_count": len(routine.get("exercises") or []),
+        "synced": record is not None,
+        "scheduled_date": (record or {}).get("scheduled_date"),
+    }
+    logger.info("Synced routine %s — %s", hevy_routine_id, res["outcome"])
+    return {"outcome": res["outcome"], "row": row}
 
 
 # Cap on recurring occurrences, so a typo in "weeks" can't schedule years of entries.

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -826,6 +826,136 @@ def _reschedule_routine(
             store.add_routine_schedule(hevy_routine_id, str(schedule_id), day)
 
 
+def _build_library_by_name(garmin_client) -> dict[str, list[dict]]:
+    """Map ``workoutName`` -> ``[{"id", "description"}, ...]`` of the workouts already in
+    the Garmin library, so a sync can reconcile against Garmin's actual state before
+    creating (not just the local DB row) — a DB reset or a crash in the create->persist
+    window would otherwise leave an untracked workout that gets recreated as a duplicate.
+    Best-effort: if the listing fails we fall back to DB-only dedup.
+    """
+    library_by_name: dict[str, list[dict]] = {}
+    try:
+        for w in list_workouts(garmin_client, limit=999):
+            name, wid = w.get("workoutName"), w.get("workoutId")
+            if name and wid is not None:
+                library_by_name.setdefault(name, []).append(
+                    {"id": str(wid), "description": w.get("description") or ""}
+                )
+    except Exception:
+        logger.warning("Could not list Garmin workouts; falling back to DB-only dedup")
+    return library_by_name
+
+
+def _sync_one_routine(
+    routine: dict,
+    store,
+    garmin_client,
+    library_by_name: dict[str, list[dict]],
+    *,
+    weight_unit: str,
+    default_rest_seconds: int | None,
+    schedule_date: str | None = None,
+    force: bool = False,
+    dry_run: bool = False,
+) -> dict:
+    """Sync one Hevy routine to a Garmin planned workout.
+
+    Returns ``{"outcome": "created"|"updated"|"skipped"|"failed", "scheduled": 0|1}``.
+    Shared by :func:`sync_routines` (bulk) and :func:`sync_routine` (single) so both
+    paths behave identically. Catches its own errors and reports ``"failed"``.
+    """
+    rid = routine.get("id", "unknown")
+    title = routine.get("title") or routine.get("name") or "Routine"
+    updated_at = routine.get("updated_at")
+    try:
+        payload = routine_to_garmin_workout(
+            routine, weight_unit=weight_unit, default_rest_seconds=default_rest_seconds
+        )
+        content_hash = workout_content_hash(payload)
+
+        # Skip when the generated payload is byte-for-byte what we last synced AND the
+        # workout is fully landed. A row left in 'schedule_pending' isn't done, so we
+        # don't skip it — the next sync retries the schedule below. --force overrides.
+        existing = store.get_synced_routine(rid)
+        content_synced = bool(existing and existing.get("content_hash") == content_hash)
+        already_done = content_synced and (existing.get("status") or "success") == "success"
+        if not force and already_done:
+            logger.debug("Skipping routine %s (%s) — unchanged", rid, title)
+            return {"outcome": "skipped", "scheduled": 0}
+
+        # A prior sync record means this run replaces it (an update), not a new create.
+        outcome = "updated" if existing else "created"
+
+        if dry_run:
+            verb = "update" if existing else "create"
+            logger.info(
+                "[dry-run] Would %s Garmin workout '%s' with %d step(s)",
+                verb, title, len(payload["workoutSegments"][0]["workoutSteps"]),
+            )
+            return {"outcome": outcome, "scheduled": 0}
+
+        # Content changed (or forced) — drop the stale Garmin workout(s) first: the
+        # DB-tracked id plus any same-named library entry carrying our provenance marker
+        # (an orphan from a crash or DB reset). Same-named entries without the marker are
+        # the user's own workouts and are left untouched.
+        stale_ids = set()
+        if existing and existing.get("garmin_workout_id"):
+            stale_ids.add(str(existing["garmin_workout_id"]))
+        for entry in library_by_name.get(payload["workoutName"], []):
+            if ROUTINE_DESC_MARKER in entry["description"]:
+                stale_ids.add(entry["id"])
+        for wid in stale_ids:
+            try:
+                delete_workout(garmin_client, wid)
+            except Exception:
+                logger.warning("  Could not delete stale/orphan workout %s", wid)
+
+        workout_id = create_workout(garmin_client, payload)
+        if workout_id is None:
+            logger.warning("  Garmin did not return a workoutId for '%s'", title)
+            return {"outcome": "failed", "scheduled": 0}
+
+        # Recreating the workout drops the calendar entries the old one had, so re-apply
+        # the prior schedule when this run doesn't set a new one. An explicit schedule_date
+        # overrides; otherwise restore every date the routine had booked (recurring), with
+        # a fallback to the single stored date for rows predating per-entry tracking. Only
+        # an explicit schedule_date counts toward the "scheduled" stat.
+        if schedule_date:
+            dates_to_book = [schedule_date]
+        else:
+            dates_to_book = store.get_routine_scheduled_dates(rid)
+            if not dates_to_book and (existing or {}).get("scheduled_date"):
+                dates_to_book = [existing["scheduled_date"]]
+        effective_schedule_date = min(dates_to_book) if dates_to_book else None
+
+        scheduled = 0
+        if dates_to_book:
+            # Persist the created workout before scheduling, marked 'schedule_pending', so
+            # a schedule failure leaves it tracked (recovered next sync) not orphaned.
+            store.mark_routine_synced(
+                rid, garmin_workout_id=str(workout_id), title=title,
+                hevy_updated_at=updated_at, scheduled_date=effective_schedule_date,
+                content_hash=content_hash, status="schedule_pending",
+            )
+            # The old workout (and its calendar entries) was just deleted, so its tracked
+            # ids are already gone — clear+rebook without a rate-limited unschedule per id.
+            _reschedule_routine(
+                garmin_client, store, rid, workout_id, dates_to_book, unschedule_prior=False
+            )
+            if schedule_date:
+                scheduled = 1
+
+        store.mark_routine_synced(
+            rid, garmin_workout_id=str(workout_id), title=title,
+            hevy_updated_at=updated_at, scheduled_date=effective_schedule_date,
+            content_hash=content_hash,
+        )
+        return {"outcome": outcome, "scheduled": scheduled}
+    except Exception:
+        logger.exception("Failed to sync routine %s (%s)", rid, title)
+        return {"outcome": "failed", "scheduled": 0}
+
+
 def sync_routines(
     config: dict[str, Any] | None = None,
     dry_run: bool = False,
@@ -873,30 +1003,12 @@ def sync_routines(
     _cache_routines_total(store, len(routines))
 
     garmin_client = None
-    # name -> [{"id", "description"}, ...] of the workouts already in the Garmin library.
-    # Built once per run so we can reconcile against Garmin's actual state before creating,
-    # not just the local DB row: a DB reset (ephemeral cloud storage, a migration) or a
-    # crash in the create->persist window would otherwise leave a workout on Garmin that
-    # we no longer track and recreate as a duplicate. We correlate by name (the routine
-    # title we set as workoutName) AND require our provenance marker in the description
-    # before deleting, so a workout the user hand-built in Garmin with the same title is
-    # never touched. Best-effort: if the listing fails we fall back to DB-only dedup; if
-    # Garmin omits the description the marker just won't match, so we create rather than
-    # delete — a possible duplicate, never destroyed user data.
     library_by_name: dict[str, list[dict]] = {}
     if not dry_run:
         logger.info("Authenticating with Garmin Connect...")
         garmin_client = get_client(garmin_email, garmin_password, garmin_token_dir)
         logger.info("Authenticated successfully")
-        try:
-            for w in list_workouts(garmin_client, limit=999):
-                name, wid = w.get("workoutName"), w.get("workoutId")
-                if name and wid is not None:
-                    library_by_name.setdefault(name, []).append(
-                        {"id": str(wid), "description": w.get("description") or ""}
-                    )
-        except Exception:
-            logger.warning("Could not list Garmin workouts; falling back to DB-only dedup")
+        library_by_name = _build_library_by_name(garmin_client)
 
     stats = {
         "created": 0,
@@ -908,125 +1020,71 @@ def sync_routines(
     }
 
     for routine in routines:
-        rid = routine.get("id", "unknown")
-        title = routine.get("title") or routine.get("name") or "Routine"
-        updated_at = routine.get("updated_at")
-
-        try:
-            payload = routine_to_garmin_workout(
-                routine, weight_unit=weight_unit, default_rest_seconds=default_rest_seconds
-            )
-            content_hash = workout_content_hash(payload)
-
-            # Skip when the generated payload is byte-for-byte what we last synced
-            # AND the workout is fully landed. A row left in 'schedule_pending' (the
-            # workout was created but a prior run's schedule call failed) is not done,
-            # so we don't skip it — the next sync retries the schedule below.
-            # Hashing the payload (not Hevy's updated_at) also re-syncs when this
-            # builder changes — e.g. after adding rest steps. --force overrides it.
-            existing = store.get_synced_routine(rid)
-            content_synced = bool(existing and existing.get("content_hash") == content_hash)
-            already_done = content_synced and (existing.get("status") or "success") == "success"
-            if not force and already_done:
-                logger.debug("Skipping routine %s (%s) — unchanged", rid, title)
-                stats["skipped"] += 1
-                continue
-
-            # A prior sync record means this run replaces it (an update), not a
-            # brand-new create — tracked separately for the summary.
-            outcome = "updated" if existing else "created"
-
-            if dry_run:
-                verb = "update" if existing else "create"
-                logger.info(
-                    "[dry-run] Would %s Garmin workout '%s' with %d step(s)",
-                    verb,
-                    title,
-                    len(payload["workoutSegments"][0]["workoutSteps"]),
-                )
-                stats[outcome] += 1
-                continue
-
-            # Content changed (or forced) — drop the stale Garmin workout(s) first.
-            # That's the DB-tracked id *plus* any same-named library entry that carries
-            # our provenance marker: an orphan from a prior crash or a DB reset that isn't
-            # tracked locally. A same-named entry *without* the marker is the user's own
-            # workout, so it's left untouched. Deleting the rest (deduped, so a tracked id
-            # that also shows up in the library isn't deleted twice) before recreating
-            # keeps sync idempotent instead of stacking a duplicate onto whatever survived.
-            stale_ids = set()
-            if existing and existing.get("garmin_workout_id"):
-                stale_ids.add(str(existing["garmin_workout_id"]))
-            for entry in library_by_name.get(payload["workoutName"], []):
-                if ROUTINE_DESC_MARKER in entry["description"]:
-                    stale_ids.add(entry["id"])
-            for wid in stale_ids:
-                try:
-                    delete_workout(garmin_client, wid)
-                except Exception:
-                    logger.warning("  Could not delete stale/orphan workout %s", wid)
-
-            workout_id = create_workout(garmin_client, payload)
-            if workout_id is None:
-                logger.warning("  Garmin did not return a workoutId for '%s'", title)
-                stats["failed"] += 1
-                continue
-
-            # Recreating the workout drops the calendar entries the old one had, so
-            # re-apply the prior schedule when this run doesn't set a new one. An
-            # explicit schedule_date overrides; otherwise restore *every* date the
-            # routine had booked (so a recurring routine keeps all its entries), falling
-            # back to the single stored date for rows created before per-entry tracking.
-            # Only an explicit schedule_date counts toward the "scheduled" stat.
-            if schedule_date:
-                dates_to_book = [schedule_date]
-            else:
-                dates_to_book = store.get_routine_scheduled_dates(rid)
-                if not dates_to_book and (existing or {}).get("scheduled_date"):
-                    dates_to_book = [existing["scheduled_date"]]
-            effective_schedule_date = min(dates_to_book) if dates_to_book else None
-
-            if dates_to_book:
-                # Persist the created workout *before* the schedule call, marked
-                # 'schedule_pending'. If scheduling then errors (Garmin 429/500), the
-                # workout is already tracked, so the next sync deletes+recreates it
-                # instead of orphaning it and creating a duplicate.
-                store.mark_routine_synced(
-                    rid,
-                    garmin_workout_id=str(workout_id),
-                    title=title,
-                    hevy_updated_at=updated_at,
-                    scheduled_date=effective_schedule_date,
-                    content_hash=content_hash,
-                    status="schedule_pending",
-                )
-                # The old workout (and its Garmin calendar entries) was just deleted,
-                # so its tracked ids are already gone — clear+rebook without spending a
-                # rate-limited unschedule call per stale id.
-                _reschedule_routine(
-                    garmin_client, store, rid, workout_id, dates_to_book, unschedule_prior=False
-                )
-                if schedule_date:
-                    stats["scheduled"] += 1
-
-            store.mark_routine_synced(
-                rid,
-                garmin_workout_id=str(workout_id),
-                title=title,
-                hevy_updated_at=updated_at,
-                scheduled_date=effective_schedule_date,
-                content_hash=content_hash,
-            )
-            stats[outcome] += 1
-        except Exception:
-            logger.exception("Failed to sync routine %s (%s)", rid, title)
-            stats["failed"] += 1
+        res = _sync_one_routine(
+            routine, store, garmin_client, library_by_name,
+            weight_unit=weight_unit, default_rest_seconds=default_rest_seconds,
+            schedule_date=schedule_date, force=force, dry_run=dry_run,
+        )
+        stats[res["outcome"]] += 1
+        stats["scheduled"] += res["scheduled"]
 
     logger.info(
         "Routine sync done — created=%d updated=%d skipped=%d failed=%d scheduled=%d",
         stats["created"], stats["updated"], stats["skipped"], stats["failed"], stats["scheduled"],
     )
     return stats
+
+
+def sync_routine(
+    hevy_routine_id: str,
+    *,
+    config: dict[str, Any] | None = None,
+    force: bool = False,
+    **overrides: Any,
+) -> dict:
+    """Sync a single Hevy routine to Garmin (the per-row "Sync" action).
+
+    Fetches the routine from Hevy, reconciles against the Garmin library, and runs the
+    same per-routine logic as :func:`sync_routines`. Returns
+    ``{"outcome": ..., "row": {id, title, exercise_count, synced, scheduled_date}}`` —
+    ``row`` is a render-ready dict for the routines table. Raises ``ValueError`` when the
+    routine isn't found in the Hevy account.
+    """
+    cfg = config or load_config()
+    store = _resolve_store()
+    hevy_api_key = overrides.get("hevy_api_key") or cfg.get("hevy_api_key")
+    garmin_email = overrides.get("garmin_email") or cfg.get("garmin_email")
+    garmin_password = overrides.get("garmin_password") or cfg.get("garmin_password", "")
+    garmin_token_dir = cfg.get("garmin_token_dir", "~/.garminconnect")
+    weight_unit = (cfg.get("sync") or {}).get("weight_unit", "kilogram")
+    default_rest_seconds = (cfg.get("timing") or {}).get("rest_between_sets_seconds", 75)
+
+    hevy = HevyClient(api_key=hevy_api_key)
+    routine = next(
+        (r for r in fetch_all_routines(hevy) if r.get("id") == hevy_routine_id), None
+    )
+    if routine is None:
+        raise ValueError("Routine not found in Hevy")
+
+    logger.info("Authenticating with Garmin Connect...")
+    garmin_client = get_client(garmin_email, garmin_password, garmin_token_dir)
+    library_by_name = _build_library_by_name(garmin_client)
+    res = _sync_one_routine(
+        routine, store, garmin_client, library_by_name,
+        weight_unit=weight_unit, default_rest_seconds=default_rest_seconds,
+        schedule_date=None, force=force, dry_run=False,
+    )
+
+    record = store.get_synced_routine(hevy_routine_id)
+    row = {
+        "id": hevy_routine_id,
+        "title": routine.get("title") or routine.get("name") or "Routine",
+        "exercise_count": len(routine.get("exercises") or []),
+        "synced": record is not None,
+        "scheduled_date": (record or {}).get("scheduled_date"),
+    }
+    logger.info("Synced routine %s — %s", hevy_routine_id, res["outcome"])
+    return {"outcome": res["outcome"], "row": row}
 
 
 # Cap on recurring occurrences, so a typo in "weeks" can't schedule years of entries.

--- a/src/hevy2garmin/templates/routine_row.html
+++ b/src/hevy2garmin/templates/routine_row.html
@@ -1,0 +1,58 @@
+<tr id="routine-row-{{ r.id }}" class="routine-row {{ 'is-synced' if r.synced else 'is-unsynced' }}"
+    style="border-top:1px solid var(--border); vertical-align:top;"
+    {% if oob %}hx-swap-oob="true"{% endif %}>
+  <td style="padding:8px;">{{ r.title }}</td>
+  <td style="padding:8px;">{{ r.exercise_count }}</td>
+  <td style="padding:8px;">
+    {% if r.synced %}<span style="color:var(--green);">✓ synced</span>
+    {% else %}<span style="color:var(--text-muted);">not synced</span>{% endif %}
+    {% if r.scheduled_date %}<br><span style="color:var(--text-muted); font-size:12px;">📅 {{ r.scheduled_date }}</span>{% endif %}
+  </td>
+  <td style="padding:8px;">
+    <div style="display:flex; flex-direction:column; gap:8px; align-items:flex-start;">
+      <button type="button" class="btn btn-secondary"
+              hx-post="/api/routines/{{ r.id }}/sync" hx-target="#routines-result" hx-swap="innerHTML"
+              hx-disabled-elt="this" style="font-size:12px; padding:4px 10px;"
+              title="Sync this routine to Garmin">
+        {{ 'Re-sync' if r.synced else 'Sync' }}
+        <span class="htmx-indicator"><span class="spinner"></span></span>
+      </button>
+      {% if r.synced %}
+      <details>
+        <summary style="cursor:pointer; user-select:none;" title="Schedule on the Garmin calendar">📅 Schedule</summary>
+        <form hx-post="/api/routines/{{ r.id }}/schedule" hx-target="#routines-result" hx-swap="innerHTML" hx-disabled-elt="find button"
+              style="margin-top:8px; display:flex; flex-direction:column; gap:8px; font-size:13px; max-width:320px;">
+          <label style="display:flex; gap:6px; align-items:center;">
+            <input type="radio" name="mode" value="once" checked> One-off
+            <input type="date" name="date"
+                   style="background:var(--bg-primary); color:var(--text); border:1px solid var(--border); border-radius:var(--radius-sm); padding:4px 6px;">
+          </label>
+          <label style="display:flex; gap:6px; align-items:center; flex-wrap:wrap;">
+            <input type="radio" name="mode" value="recurring"> Weekly on
+            <select name="weekday" style="background:var(--bg-primary); color:var(--text); border:1px solid var(--border); border-radius:var(--radius-sm); padding:4px 6px;">
+              <option value="0">Monday</option>
+              <option value="1">Tuesday</option>
+              <option value="2">Wednesday</option>
+              <option value="3">Thursday</option>
+              <option value="4">Friday</option>
+              <option value="5">Saturday</option>
+              <option value="6">Sunday</option>
+            </select>
+          </label>
+          <label style="display:flex; gap:6px; align-items:center; flex-wrap:wrap; color:var(--text-muted);">
+            from <input type="date" name="start_date"
+                   style="background:var(--bg-primary); color:var(--text); border:1px solid var(--border); border-radius:var(--radius-sm); padding:4px 6px;">
+            for <input type="number" name="weeks" min="1" max="52" value="4" style="width:60px; background:var(--bg-primary); color:var(--text); border:1px solid var(--border); border-radius:var(--radius-sm); padding:4px 6px;"> weeks
+          </label>
+          <div style="display:flex; gap:8px; align-items:center;">
+            <button type="submit" class="btn btn-primary">Add to calendar</button>
+            <span class="htmx-indicator" style="align-items:center; gap:6px; color:var(--text-muted);">
+              <span class="spinner"></span> Scheduling…
+            </span>
+          </div>
+        </form>
+      </details>
+      {% endif %}
+    </div>
+  </td>
+</tr>

--- a/src/hevy2garmin/templates/routine_row.html
+++ b/src/hevy2garmin/templates/routine_row.html
@@ -1,58 +1,66 @@
-<tr id="routine-row-{{ r.id }}" class="routine-row {{ 'is-synced' if r.synced else 'is-unsynced' }}"
-    style="border-top:1px solid var(--border); vertical-align:top;"
-    {% if oob %}hx-swap-oob="true"{% endif %}>
-  <td style="padding:8px;">{{ r.title }}</td>
-  <td style="padding:8px;">{{ r.exercise_count }}</td>
-  <td style="padding:8px;">
-    {% if r.synced %}<span style="color:var(--green);">✓ synced</span>
-    {% else %}<span style="color:var(--text-muted);">not synced</span>{% endif %}
-    {% if r.scheduled_date %}<br><span style="color:var(--text-muted); font-size:12px;">📅 {{ r.scheduled_date }}</span>{% endif %}
-  </td>
-  <td style="padding:8px;">
-    <div style="display:flex; flex-direction:column; gap:8px; align-items:flex-start;">
-      <button type="button" class="btn btn-secondary"
-              hx-post="/api/routines/{{ r.id }}/sync" hx-target="#routines-result" hx-swap="innerHTML"
-              hx-disabled-elt="this" style="font-size:12px; padding:4px 10px;"
-              title="Sync this routine to Garmin">
-        {{ 'Re-sync' if r.synced else 'Sync' }}
-        <span class="htmx-indicator"><span class="spinner"></span></span>
-      </button>
+<div id="routine-row-{{ r.id }}" class="routine-card {% if r.synced %}is-synced{% endif %}"
+     data-title="{{ r.title|lower }}" data-synced="{{ 1 if r.synced else 0 }}"
+     {% if oob %}hx-swap-oob="true"{% endif %}>
+  <div class="routine-row">
+    <div class="routine-main">
+      <div class="routine-name">{{ r.title }}</div>
+      <button type="button" class="ex-toggle" aria-label="Toggle exercises">{{ r.exercise_count }} exercises <span class="chev">▾</span></button>
+    </div>
+    {% if r.synced %}<span class="badge badge-success">✓ Synced</span>{% else %}<span class="badge badge-pending">Not synced</span>{% endif %}
+    {% if r.scheduled_date %}<span class="sched-date">📅 {{ r.scheduled_date }}</span>{% endif %}
+    <div class="routine-actions">
+      <form hx-post="/api/routines/{{ r.id }}/sync" hx-target="#routines-result" hx-disabled-elt="find button" style="display:inline-flex;">
+        {% if r.synced %}<input type="hidden" name="force" value="1">{% endif %}
+        <button type="submit" class="btn btn-primary btn-sm" title="{% if r.synced %}Re-create this planned workout on Garmin{% else %}Create this planned workout on Garmin{% endif %}">
+          <span class="htmx-hide">{% if r.synced %}Re-sync{% else %}Sync{% endif %}</span>
+          <span class="htmx-indicator"><span class="spinner"></span></span>
+        </button>
+      </form>
       {% if r.synced %}
-      <details>
-        <summary style="cursor:pointer; user-select:none;" title="Schedule on the Garmin calendar">📅 Schedule</summary>
-        <form hx-post="/api/routines/{{ r.id }}/schedule" hx-target="#routines-result" hx-swap="innerHTML" hx-disabled-elt="find button"
-              style="margin-top:8px; display:flex; flex-direction:column; gap:8px; font-size:13px; max-width:320px;">
-          <label style="display:flex; gap:6px; align-items:center;">
-            <input type="radio" name="mode" value="once" checked> One-off
-            <input type="date" name="date"
-                   style="background:var(--bg-primary); color:var(--text); border:1px solid var(--border); border-radius:var(--radius-sm); padding:4px 6px;">
-          </label>
-          <label style="display:flex; gap:6px; align-items:center; flex-wrap:wrap;">
-            <input type="radio" name="mode" value="recurring"> Weekly on
-            <select name="weekday" style="background:var(--bg-primary); color:var(--text); border:1px solid var(--border); border-radius:var(--radius-sm); padding:4px 6px;">
-              <option value="0">Monday</option>
-              <option value="1">Tuesday</option>
-              <option value="2">Wednesday</option>
-              <option value="3">Thursday</option>
-              <option value="4">Friday</option>
-              <option value="5">Saturday</option>
-              <option value="6">Sunday</option>
-            </select>
-          </label>
-          <label style="display:flex; gap:6px; align-items:center; flex-wrap:wrap; color:var(--text-muted);">
-            from <input type="date" name="start_date"
-                   style="background:var(--bg-primary); color:var(--text); border:1px solid var(--border); border-radius:var(--radius-sm); padding:4px 6px;">
-            for <input type="number" name="weeks" min="1" max="52" value="4" style="width:60px; background:var(--bg-primary); color:var(--text); border:1px solid var(--border); border-radius:var(--radius-sm); padding:4px 6px;"> weeks
-          </label>
-          <div style="display:flex; gap:8px; align-items:center;">
-            <button type="submit" class="btn btn-primary">Add to calendar</button>
-            <span class="htmx-indicator" style="align-items:center; gap:6px; color:var(--text-muted);">
-              <span class="spinner"></span> Scheduling…
-            </span>
-          </div>
-        </form>
-      </details>
+      <button type="button" class="icon-btn sched-toggle" title="Schedule on the Garmin calendar">📅 Schedule</button>
+      {% else %}
+      <button type="button" class="icon-btn" disabled title="Sync this routine first">📅 Schedule</button>
       {% endif %}
     </div>
-  </td>
-</tr>
+  </div>
+
+  {% if r.exercises %}
+  <div class="ex-list">
+    {% for ex in r.exercises %}
+    <span class="ex-chip"><span>{{ ex.name }}</span>{% if ex.sets %}<span class="sets">{{ ex.sets }}×</span>{% endif %}</span>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  {% if r.synced %}
+  <div class="sched-panel">
+    <form hx-post="/api/routines/{{ r.id }}/schedule" hx-target="#routines-result" hx-swap="innerHTML" hx-disabled-elt="find button"
+          style="display:flex; flex-direction:column; gap:8px; font-size:13px; max-width:360px;">
+      <label style="display:flex; gap:6px; align-items:center;">
+        <input type="radio" name="mode" value="once" checked> One-off
+        <input type="date" name="date" class="form-input" style="min-height:auto; padding:4px 6px; width:auto;">
+      </label>
+      <label style="display:flex; gap:6px; align-items:center; flex-wrap:wrap;">
+        <input type="radio" name="mode" value="recurring"> Weekly on
+        <select name="weekday" class="form-select" style="min-height:auto; padding:4px 6px; width:auto;">
+          <option value="0">Monday</option>
+          <option value="1">Tuesday</option>
+          <option value="2">Wednesday</option>
+          <option value="3">Thursday</option>
+          <option value="4">Friday</option>
+          <option value="5">Saturday</option>
+          <option value="6">Sunday</option>
+        </select>
+      </label>
+      <label style="display:flex; gap:6px; align-items:center; flex-wrap:wrap; color:var(--text-muted);">
+        from <input type="date" name="start_date" class="form-input" style="min-height:auto; padding:4px 6px; width:auto;">
+        for <input type="number" name="weeks" min="1" max="52" value="4" class="form-input" style="min-height:auto; padding:4px 6px; width:60px;"> weeks
+      </label>
+      <div style="display:flex; gap:8px; align-items:center;">
+        <button type="submit" class="btn btn-primary btn-sm">Add to calendar</button>
+        <span class="htmx-indicator" style="align-items:center; gap:6px; color:var(--text-muted);"><span class="spinner"></span> Scheduling…</span>
+      </div>
+    </form>
+  </div>
+  {% endif %}
+</div>

--- a/src/hevy2garmin/templates/routine_schedules.html
+++ b/src/hevy2garmin/templates/routine_schedules.html
@@ -4,44 +4,36 @@
      hx-target="#scheduled-table"
      hx-swap="outerHTML">
   {% if scheduled_workouts %}
-  <table style="width:100%; border-collapse:collapse;">
-    <thead>
-      <tr style="text-align:left; color:var(--text-muted); font-size:13px;">
-        <th style="padding:8px;">Date</th>
-        <th style="padding:8px;">Routine</th>
-        <th style="padding:8px; width:1px;"></th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for s in scheduled_workouts %}
-      <tr style="border-top:1px solid var(--border-subtle);">
-        <td style="padding:8px; font-variant-numeric:tabular-nums; color:var(--text-secondary);">📅 {{ s.scheduled_date }}</td>
-        <td style="padding:8px;">{{ s.title or 'Routine' }}</td>
-        <td style="padding:8px; text-align:right; white-space:nowrap;">
-          {% if not demo_mode %}
-          <button type="button" class="btn btn-secondary"
-                  hx-post="/api/routines/{{ s.hevy_routine_id }}/schedule/{{ s.schedule_id }}/unschedule?page={{ page }}&start={{ start_date }}&q={{ title_query|urlencode }}&size={{ page_size }}"
-                  hx-target="#scheduled-table" hx-swap="outerHTML"
-                  hx-confirm="Remove this scheduled workout from your Garmin calendar?"
-                  hx-disabled-elt="this" style="font-size:12px; padding:4px 10px;">
-            Remove <span class="htmx-indicator"><span class="spinner"></span></span>
-          </button>
-          {% endif %}
-        </td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+  <div class="timeline">
+    {% for s in scheduled_workouts %}
+    {% set p = sched_parts(s.scheduled_date) %}
+    <div class="timeline-row">
+      <span class="timeline-date">{{ p.short }}</span>
+      <span class="timeline-dot"></span>
+      <span class="timeline-name">{{ s.title or 'Routine' }}</span>
+      <span class="timeline-wd">{{ p.weekday }}</span>
+      {% if not demo_mode %}
+      <button type="button" class="btn btn-secondary btn-sm"
+              hx-post="/api/routines/{{ s.hevy_routine_id }}/schedule/{{ s.schedule_id }}/unschedule?page={{ page }}&start={{ start_date }}&q={{ title_query|urlencode }}&size={{ page_size }}"
+              hx-target="#scheduled-table" hx-swap="outerHTML"
+              hx-confirm="Remove this scheduled workout from your Garmin calendar?"
+              hx-disabled-elt="this" style="font-size:12px; padding:5px 12px; min-height:auto;">
+        Remove <span class="htmx-indicator"><span class="spinner"></span></span>
+      </button>
+      {% endif %}
+    </div>
+    {% endfor %}
+  </div>
   {% if total_pages > 1 %}
-  <div style="display:flex; gap:12px; align-items:center; justify-content:flex-end; margin-top:12px; font-size:13px; color:var(--text-muted);">
-    <button type="button" class="btn btn-secondary"
-            style="font-size:12px; padding:4px 10px;{% if page <= 1 %} opacity:0.4; cursor:not-allowed;{% endif %}"
+  <div style="display:flex; gap:12px; align-items:center; justify-content:flex-end; margin-top:14px; font-size:13px; color:var(--text-muted);">
+    <button type="button" class="btn btn-secondary btn-sm"
+            style="font-size:12px; padding:4px 10px; min-height:auto;{% if page <= 1 %} opacity:0.4; cursor:not-allowed;{% endif %}"
             hx-get="/api/routines/schedules?page={{ page - 1 }}&start={{ start_date }}&q={{ title_query|urlencode }}&size={{ page_size }}"
             hx-target="#scheduled-table" hx-swap="outerHTML"
             {% if page <= 1 %}disabled{% endif %}>Prev</button>
     <span>Page {{ page }} of {{ total_pages }}</span>
-    <button type="button" class="btn btn-secondary"
-            style="font-size:12px; padding:4px 10px;{% if page >= total_pages %} opacity:0.4; cursor:not-allowed;{% endif %}"
+    <button type="button" class="btn btn-secondary btn-sm"
+            style="font-size:12px; padding:4px 10px; min-height:auto;{% if page >= total_pages %} opacity:0.4; cursor:not-allowed;{% endif %}"
             hx-get="/api/routines/schedules?page={{ page + 1 }}&start={{ start_date }}&q={{ title_query|urlencode }}&size={{ page_size }}"
             hx-target="#scheduled-table" hx-swap="outerHTML"
             {% if page >= total_pages %}disabled{% endif %}>Next</button>
@@ -52,7 +44,7 @@
     <select name="size"
             hx-get="/api/routines/schedules?start={{ start_date }}&q={{ title_query|urlencode }}"
             hx-target="#scheduled-table" hx-swap="outerHTML" hx-trigger="change"
-            style="background:var(--bg-primary); color:var(--text); border:1px solid var(--border); border-radius:var(--radius-sm); padding:4px 6px;">
+            class="form-select" style="min-height:auto; padding:4px 6px; width:auto;">
       {% for sz in page_sizes %}
       <option value="{{ sz }}" {% if sz == page_size %}selected{% endif %}>{{ sz }}</option>
       {% endfor %}

--- a/src/hevy2garmin/templates/routines.html
+++ b/src/hevy2garmin/templates/routines.html
@@ -22,68 +22,26 @@
 {% if fetch_error %}
 <div class="toast toast-error">Could not load routines: {{ fetch_error }}</div>
 {% else %}
+<style>#routines-tbody.only-unsynced tr.is-synced { display: none; }</style>
 <div class="card">
   {% if routines %}
+  <label style="display:flex; gap:6px; align-items:center; color:var(--text-muted); font-size:13px; margin-bottom:12px;">
+    <input type="checkbox"
+           onchange="document.getElementById('routines-tbody').classList.toggle('only-unsynced', this.checked)">
+    Show only unsynced
+  </label>
   <table style="width:100%; border-collapse:collapse;">
     <thead>
       <tr style="text-align:left; color:var(--text-muted); font-size:13px;">
         <th style="padding:8px;">Routine</th>
         <th style="padding:8px;">Exercises</th>
         <th style="padding:8px;">Status</th>
-        <th style="padding:8px;">Schedule</th>
+        <th style="padding:8px;">Actions</th>
       </tr>
     </thead>
-    <tbody>
+    <tbody id="routines-tbody">
       {% for r in routines %}
-      <tr style="border-top:1px solid var(--border); vertical-align:top;">
-        <td style="padding:8px;">{{ r.title }}</td>
-        <td style="padding:8px;">{{ r.exercise_count }}</td>
-        <td style="padding:8px;">
-          {% if r.synced %}<span style="color:var(--green);">✓ synced</span>
-          {% else %}<span style="color:var(--text-muted);">not synced</span>{% endif %}
-          {% if r.scheduled_date %}<br><span style="color:var(--text-muted); font-size:12px;">📅 {{ r.scheduled_date }}</span>{% endif %}
-        </td>
-        <td style="padding:8px;">
-          {% if r.synced %}
-          <details>
-            <summary style="cursor:pointer; user-select:none;" title="Schedule on the Garmin calendar">📅 Schedule</summary>
-            <form hx-post="/api/routines/{{ r.id }}/schedule" hx-target="#routines-result" hx-swap="innerHTML" hx-disabled-elt="find button"
-                  style="margin-top:8px; display:flex; flex-direction:column; gap:8px; font-size:13px; max-width:320px;">
-              <label style="display:flex; gap:6px; align-items:center;">
-                <input type="radio" name="mode" value="once" checked> One-off
-                <input type="date" name="date"
-                       style="background:var(--bg-primary); color:var(--text); border:1px solid var(--border); border-radius:var(--radius-sm); padding:4px 6px;">
-              </label>
-              <label style="display:flex; gap:6px; align-items:center; flex-wrap:wrap;">
-                <input type="radio" name="mode" value="recurring"> Weekly on
-                <select name="weekday" style="background:var(--bg-primary); color:var(--text); border:1px solid var(--border); border-radius:var(--radius-sm); padding:4px 6px;">
-                  <option value="0">Monday</option>
-                  <option value="1">Tuesday</option>
-                  <option value="2">Wednesday</option>
-                  <option value="3">Thursday</option>
-                  <option value="4">Friday</option>
-                  <option value="5">Saturday</option>
-                  <option value="6">Sunday</option>
-                </select>
-              </label>
-              <label style="display:flex; gap:6px; align-items:center; flex-wrap:wrap; color:var(--text-muted);">
-                from <input type="date" name="start_date"
-                       style="background:var(--bg-primary); color:var(--text); border:1px solid var(--border); border-radius:var(--radius-sm); padding:4px 6px;">
-                for <input type="number" name="weeks" min="1" max="52" value="4" style="width:60px; background:var(--bg-primary); color:var(--text); border:1px solid var(--border); border-radius:var(--radius-sm); padding:4px 6px;"> weeks
-              </label>
-              <div style="display:flex; gap:8px; align-items:center;">
-                <button type="submit" class="btn btn-primary">Add to calendar</button>
-                <span class="htmx-indicator" style="align-items:center; gap:6px; color:var(--text-muted);">
-                  <span class="spinner"></span> Scheduling…
-                </span>
-              </div>
-            </form>
-          </details>
-          {% else %}
-          <span style="color:var(--text-muted); font-size:12px;">sync first</span>
-          {% endif %}
-        </td>
-      </tr>
+      {% include "routine_row.html" %}
       {% endfor %}
     </tbody>
   </table>

--- a/src/hevy2garmin/templates/routines.html
+++ b/src/hevy2garmin/templates/routines.html
@@ -1,71 +1,172 @@
 {% extends "base.html" %}
+{% block head %}
+<style>
+  .routines-summary { display:flex; align-items:flex-end; justify-content:space-between; gap:16px; flex-wrap:wrap; margin-bottom:20px; }
+  .stat-pod { display:flex; align-items:center; gap:14px; background:var(--bg-card); border:1px solid var(--border-subtle); border-radius:var(--radius); padding:12px 18px; }
+  .stat-pod .n { font-size:22px; font-weight:700; line-height:1; }
+  .stat-pod .l { font-size:11px; color:var(--text-muted); margin-top:4px; }
+  .stat-pod .sep { width:1px; height:30px; background:var(--border); }
+
+  .sync-bar { background:var(--bg-card); border:1px solid var(--border-subtle); border-radius:var(--radius); padding:18px; margin-bottom:20px; }
+  .sync-bar-row { display:flex; align-items:center; gap:16px; flex-wrap:wrap; }
+  .progress-track { height:8px; border-radius:100px; background:var(--bg-secondary); margin-top:14px; overflow:hidden; }
+  .progress-fill { height:100%; background:linear-gradient(90deg, var(--accent), #34d399); transition:width .3s; }
+
+  .routine-toolbar { display:flex; align-items:center; gap:12px; flex-wrap:wrap; margin-bottom:16px; }
+  .seg { display:inline-flex; background:var(--bg-secondary); border:1px solid var(--border); border-radius:10px; padding:3px; }
+  .seg-btn { border:none; cursor:pointer; font-family:var(--font); font-size:13px; font-weight:600; padding:6px 14px; border-radius:8px; background:transparent; color:var(--text-secondary); }
+  .seg-btn.active { background:var(--accent); color:#04120b; }
+  .routine-search { flex:1; min-width:180px; background:var(--bg-card); color:var(--text-primary); border:1px solid var(--border); border-radius:10px; padding:9px 14px; font-family:var(--font); font-size:14px; }
+  .routine-search:focus { outline:none; border-color:var(--accent); box-shadow:0 0 0 3px var(--accent-glow); }
+
+  .routine-list { display:flex; flex-direction:column; gap:10px; }
+  .routine-card { background:var(--bg-card); border:1px solid var(--border-subtle); border-left:3px solid var(--border); border-radius:var(--radius); overflow:hidden; }
+  .routine-card.is-synced { border-left-color:var(--accent); }
+  .routine-row { display:flex; align-items:center; gap:14px; padding:14px 16px; }
+  .routine-main { margin-right:auto; min-width:0; }
+  .routine-name { font-weight:600; font-size:15px; }
+  .ex-toggle { margin-top:4px; display:inline-flex; align-items:center; gap:6px; background:transparent; border:none; color:var(--text-muted); font-family:var(--font); font-size:12px; font-weight:500; cursor:pointer; padding:0; }
+  .ex-toggle .chev { display:inline-block; transition:transform .15s; }
+  .routine-card.ex-open .ex-toggle .chev { transform:rotate(180deg); }
+  .ex-list { display:none; padding:2px 16px 16px; flex-wrap:wrap; gap:8px; }
+  .routine-card.ex-open .ex-list { display:flex; }
+  .ex-chip { display:inline-flex; align-items:center; gap:8px; background:var(--bg-secondary); border:1px solid var(--border); border-radius:var(--radius-sm); padding:6px 12px; font-size:13px; }
+  .ex-chip .sets { color:var(--text-muted); font-variant-numeric:tabular-nums; }
+  .sched-date { display:inline-flex; align-items:center; gap:4px; color:var(--text-muted); font-size:12px; white-space:nowrap; }
+  .routine-actions { display:flex; gap:8px; align-items:center; }
+  .icon-btn { background:transparent; color:var(--text-secondary); border:1px solid var(--border); border-radius:var(--radius-sm); padding:7px 12px; font-size:12px; font-weight:600; cursor:pointer; font-family:var(--font); }
+  .icon-btn:hover:not(:disabled) { color:var(--text-primary); border-color:var(--text-muted); }
+  .icon-btn:disabled { opacity:.4; cursor:not-allowed; }
+  .sched-panel { display:none; padding:0 16px 16px; }
+  .routine-card.sched-open .sched-panel { display:block; }
+
+  .empty-state { background:var(--bg-card); border:1px solid var(--border-subtle); border-radius:var(--radius); padding:28px; text-align:center; color:var(--text-muted); font-size:14px; }
+
+  .timeline { display:flex; flex-direction:column; }
+  .timeline-row { display:flex; align-items:center; gap:16px; padding:10px 0; border-top:1px solid var(--border-subtle); }
+  .timeline-date { width:64px; font-size:12px; color:var(--text-muted); font-variant-numeric:tabular-nums; }
+  .timeline-dot { width:8px; height:8px; border-radius:50%; background:var(--accent); flex:none; }
+  .timeline-name { margin-right:auto; font-weight:600; font-size:14px; }
+  .timeline-wd { color:var(--text-muted); font-size:12px; }
+</style>
+{% endblock %}
 {% block content %}
-<div class="page-header">
-  <h1>Routines</h1>
-  <p class="subtitle">Create Garmin planned workouts from your Hevy routines.</p>
-</div>
+<div id="routines-page">
+  <div class="routines-summary">
+    <div>
+      <h1 style="font-size:26px; font-weight:700; letter-spacing:-0.02em;">Routines</h1>
+      <p style="color:var(--text-secondary); margin-top:4px; font-size:14px;">Create Garmin planned workouts from your Hevy routines.</p>
+    </div>
+    <div class="stat-pod">
+      <div style="text-align:center;"><div class="n" style="color:var(--accent);">{{ stats.synced }}</div><div class="l">On Garmin</div></div>
+      <div class="sep"></div>
+      <div style="text-align:center;"><div class="n">{{ stats.total }}</div><div class="l">In Hevy</div></div>
+      <div class="sep"></div>
+      <div style="text-align:center;"><div class="n" style="color:var(--amber);">{{ stats.pending }}</div><div class="l">Pending</div></div>
+    </div>
+  </div>
 
-<div class="card" style="margin-bottom:16px;">
-  <form hx-post="/api/routines/sync" hx-target="#routines-result" hx-disabled-elt="find button"
-        style="display:flex; gap:12px; align-items:center; flex-wrap:wrap;">
-    <button type="submit" class="btn btn-primary">Sync all routines</button>
-    <label style="display:flex; gap:6px; align-items:center; color:var(--text-muted); font-size:14px;" title="Re-create even routines already synced">
-      <input type="checkbox" name="force" value="1"> Force re-create
-    </label>
-    <span class="htmx-indicator" style="align-items:center; gap:6px; color:var(--text-muted); font-size:14px;">
-      <span class="spinner"></span> Syncing…
-    </span>
-  </form>
-  <div id="routines-result" style="margin-top:12px;"></div>
-</div>
+  {% if not fetch_error %}
+  <div class="sync-bar">
+    <form hx-post="/api/routines/sync" hx-target="#routines-result" hx-disabled-elt="find button" class="sync-bar-row">
+      <div style="margin-right:auto;">
+        <div style="font-size:14px; font-weight:600; display:flex; align-items:center; gap:8px;"><span style="color:var(--accent);">⚡</span> {{ stats.synced }} of {{ stats.total }} routines on Garmin</div>
+        <div style="font-size:12px; color:var(--text-muted); margin-top:4px;">
+          {% if stats.pending %}{{ stats.pending }} still pending — sync them in one go.{% else %}Everything is on your Garmin calendar.{% endif %}
+        </div>
+      </div>
+      <label style="display:flex; gap:6px; align-items:center; color:var(--text-muted); font-size:13px;" title="Re-create even routines already synced">
+        <input type="checkbox" name="force" value="1"> Force re-create
+      </label>
+      <button type="submit" class="btn btn-primary">
+        <span class="htmx-hide">Sync all</span>
+        <span class="htmx-indicator"><span class="spinner"></span> Syncing…</span>
+      </button>
+    </form>
+    <div class="progress-track"><div class="progress-fill" style="width:{{ stats.pct }}%;"></div></div>
+    <div id="routines-result" style="margin-top:12px;"></div>
+  </div>
 
-{% if fetch_error %}
-<div class="toast toast-error">Could not load routines: {{ fetch_error }}</div>
-{% else %}
-<style>#routines-tbody.only-unsynced tr.is-synced { display: none; }</style>
-<div class="card">
   {% if routines %}
-  <label style="display:flex; gap:6px; align-items:center; color:var(--text-muted); font-size:13px; margin-bottom:12px;">
-    <input type="checkbox"
-           onchange="document.getElementById('routines-tbody').classList.toggle('only-unsynced', this.checked)">
-    Show only unsynced
-  </label>
-  <table style="width:100%; border-collapse:collapse;">
-    <thead>
-      <tr style="text-align:left; color:var(--text-muted); font-size:13px;">
-        <th style="padding:8px;">Routine</th>
-        <th style="padding:8px;">Exercises</th>
-        <th style="padding:8px;">Status</th>
-        <th style="padding:8px;">Actions</th>
-      </tr>
-    </thead>
-    <tbody id="routines-tbody">
-      {% for r in routines %}
-      {% include "routine_row.html" %}
-      {% endfor %}
-    </tbody>
-  </table>
-  {% else %}
-  <p style="color:var(--text-muted);">No routines found in your Hevy account.</p>
-  {% endif %}
-</div>
-{% endif %}
+  <div class="routine-toolbar">
+    <div class="seg" role="tablist">
+      <button type="button" class="seg-btn active" data-filter="all">All</button>
+      <button type="button" class="seg-btn" data-filter="synced">On Garmin</button>
+      <button type="button" class="seg-btn" data-filter="pending">Pending</button>
+    </div>
+    <input type="text" id="routine-search" class="routine-search" placeholder="Search routines…" autocomplete="off">
+  </div>
 
-<div class="card" style="margin-top:16px;">
-  <div class="card-header" style="margin-bottom:12px;"><span class="card-title">Scheduled workouts</span></div>
-  <form hx-get="/api/routines/schedules" hx-target="#scheduled-table" hx-swap="outerHTML"
-        hx-trigger="submit, change, keyup changed delay:400ms"
-        style="display:flex; gap:12px; flex-wrap:wrap; align-items:center; margin-bottom:12px; font-size:13px; color:var(--text-muted);"
-        onsubmit="return false;">
-    <label style="display:flex; gap:6px; align-items:center;">
-      From <input type="date" name="start" value="{{ start_date }}"
-             style="background:var(--bg-primary); color:var(--text); border:1px solid var(--border); border-radius:var(--radius-sm); padding:4px 6px;">
-    </label>
-    <label style="display:flex; gap:6px; align-items:center;">
-      Routine <input type="text" name="q" value="{{ title_query }}" placeholder="filter by name"
-             style="background:var(--bg-primary); color:var(--text); border:1px solid var(--border); border-radius:var(--radius-sm); padding:4px 6px;">
-    </label>
-  </form>
-  {% include "routine_schedules.html" %}
+  <div class="routine-list" id="routines-list">
+    {% for r in routines %}
+    {% include "routine_row.html" %}
+    {% endfor %}
+    <div id="filter-empty" class="empty-state" style="display:none;">No routines match this filter.</div>
+  </div>
+  {% else %}
+  <div class="empty-state">No routines found in your Hevy account.</div>
+  {% endif %}
+  {% else %}
+  <div class="toast toast-error">Could not load routines: {{ fetch_error }}</div>
+  {% endif %}
+
+  <div class="card" style="margin-top:20px;">
+    <div class="card-header" style="margin-bottom:12px;"><span class="card-title">Upcoming schedule</span>
+      <form hx-get="/api/routines/schedules" hx-target="#scheduled-table" hx-swap="outerHTML"
+            hx-trigger="submit, change, keyup changed delay:400ms"
+            style="display:flex; gap:12px; flex-wrap:wrap; align-items:center; font-size:13px; color:var(--text-muted);"
+            onsubmit="return false;">
+        <label style="display:flex; gap:6px; align-items:center;">From
+          <input type="date" name="start" value="{{ start_date }}" class="form-input" style="min-height:auto; padding:5px 8px; width:auto;"></label>
+        <label style="display:flex; gap:6px; align-items:center;">
+          <input type="text" name="q" value="{{ title_query }}" placeholder="filter by name" class="form-input" style="min-height:auto; padding:5px 10px; width:auto;"></label>
+      </form>
+    </div>
+    {% include "routine_schedules.html" %}
+  </div>
 </div>
+
+<script>
+(function () {
+  var page = document.getElementById('routines-page');
+  if (!page) return;
+  var search = page.querySelector('#routine-search');
+  var segBtns = page.querySelectorAll('.seg-btn');
+  var filterEmpty = page.querySelector('#filter-empty');
+  var filter = 'all', q = '';
+
+  function apply() {
+    var visible = 0;
+    page.querySelectorAll('.routine-card').forEach(function (c) {
+      var synced = c.dataset.synced === '1';
+      var okF = filter === 'all' || (filter === 'synced' && synced) || (filter === 'pending' && !synced);
+      var okQ = !q || c.dataset.title.indexOf(q) !== -1;
+      var show = okF && okQ;
+      c.style.display = show ? '' : 'none';
+      if (show) visible++;
+    });
+    if (filterEmpty) filterEmpty.style.display = visible ? 'none' : '';
+  }
+
+  segBtns.forEach(function (b) {
+    b.addEventListener('click', function () {
+      filter = b.dataset.filter;
+      segBtns.forEach(function (x) { x.classList.toggle('active', x === b); });
+      apply();
+    });
+  });
+  if (search) search.addEventListener('input', function (e) { q = e.target.value.trim().toLowerCase(); apply(); });
+
+  page.addEventListener('click', function (e) {
+    var ex = e.target.closest('.ex-toggle');
+    if (ex) { ex.closest('.routine-card').classList.toggle('ex-open'); return; }
+    var sc = e.target.closest('.sched-toggle');
+    if (sc) { sc.closest('.routine-card').classList.toggle('sched-open'); }
+  });
+
+  // A per-routine sync swaps its card in via hx-swap-oob; re-apply the active
+  // filter/search so the refreshed card respects the current view.
+  document.body.addEventListener('htmx:afterSwap', apply);
+})();
+</script>
 {% endblock %}

--- a/src/hevy2garmin/templates/routines.html
+++ b/src/hevy2garmin/templates/routines.html
@@ -48,6 +48,35 @@
   .timeline-dot { width:8px; height:8px; border-radius:50%; background:var(--accent); flex:none; }
   .timeline-name { margin-right:auto; font-weight:600; font-size:14px; }
   .timeline-wd { color:var(--text-muted); font-size:12px; }
+
+  /* ── Mobile (matches the app-wide 640px breakpoint in base.html) ── */
+  @media (max-width: 640px) {
+    /* Stat pod spans the row and spreads its three figures edge-to-edge. */
+    #routines-page .routines-summary { align-items:stretch; }
+    #routines-page .stat-pod { width:100%; justify-content:space-between; }
+
+    /* Full-width sync button instead of squeezing next to the checkbox. */
+    #routines-page .sync-bar-row { align-items:stretch; }
+    #routines-page .sync-bar-row > button[type="submit"] { width:100%; justify-content:center; }
+
+    /* Segmented filter fills the row; search drops to its own full-width line. */
+    #routines-page .seg { width:100%; }
+    #routines-page .seg-btn { flex:1; }
+    #routines-page .routine-search { min-width:0; width:100%; }
+
+    /* Card row wraps: name on line 1, badge+date on line 2, action buttons
+       right-aligned on their own line 3 (two buttons won't fit beside the date). */
+    #routines-page .routine-row { flex-wrap:wrap; }
+    #routines-page .routine-main { flex-basis:100%; }
+    #routines-page .routine-actions { flex:0 0 100%; justify-content:flex-end; }
+
+    /* Timeline row wraps so the Remove button stays reachable. */
+    #routines-page .timeline-row { flex-wrap:wrap; }
+    #routines-page .timeline-row .btn { margin-left:auto; }
+
+    /* "Upcoming schedule" header stacks its title above the filter form. */
+    #routines-page .card-header { flex-wrap:wrap; gap:12px; }
+  }
 </style>
 {% endblock %}
 {% block content %}

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -291,7 +291,9 @@ class TestSyncRoutines:
             result = sync_module.sync_routine("r1")
         assert result["outcome"] == "created"
         assert result["row"] == {
-            "id": "r1", "title": "Push", "exercise_count": 1, "synced": True, "scheduled_date": None}
+            "id": "r1", "title": "Push",
+            "exercises": [{"name": "Bench Press (Barbell)", "sets": 1}],
+            "exercise_count": 1, "synced": True, "scheduled_date": None}
         create_mock.assert_called_once()
         assert store.get_synced_routine("r1")["garmin_workout_id"] == "777"
 
@@ -725,8 +727,9 @@ class TestScheduledWorkoutsUI:
             page2 = client.get("/api/routines/schedules?page=2").text
             clamped = client.get("/api/routines/schedules?page=99").text
         assert "Page 1 of 2" in page1
-        assert "2999-01-11" not in page1  # the 11th entry is on page 2
-        assert "Page 2 of 2" in page2 and "2999-01-11" in page2
+        # The timeline humanizes dates ("Jan 11"); the 11th entry sits on page 2.
+        assert "Jan 11" not in page1
+        assert "Page 2 of 2" in page2 and "Jan 11" in page2
         # Out-of-range page clamps to the last page rather than erroring.
         assert "Page 2 of 2" in clamped
 

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -282,6 +282,26 @@ class TestSyncRoutines:
         create_mock.assert_called_once()
         assert store.get_synced_routine("r1")["garmin_workout_id"] == "777"
 
+    def test_sync_single_routine_creates_and_returns_row(self, tmp_path: Path) -> None:
+        routines = [{"id": "r1", "title": "Push", "updated_at": "2026-01-01T00:00:00Z",
+                     "exercises": [{"title": "Bench Press (Barbell)",
+                                    "sets": [{"type": "normal", "reps": 5, "weight_kg": 60}]}]}]
+        store, create_mock, _, patches = self._patched(tmp_path, routines)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6], patches[7]:
+            result = sync_module.sync_routine("r1")
+        assert result["outcome"] == "created"
+        assert result["row"] == {
+            "id": "r1", "title": "Push", "exercise_count": 1, "synced": True, "scheduled_date": None}
+        create_mock.assert_called_once()
+        assert store.get_synced_routine("r1")["garmin_workout_id"] == "777"
+
+    def test_sync_single_routine_not_found_raises(self, tmp_path: Path) -> None:
+        routines = [{"id": "r1", "title": "Push", "exercises": []}]
+        store, _, _, patches = self._patched(tmp_path, routines)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6], patches[7]:
+            with pytest.raises(ValueError, match="not found"):
+                sync_module.sync_routine("missing")
+
     def _hash_for(self, routine: dict) -> str:
         # Mirror how sync_routines builds the payload (no timing config → 75s default).
         payload = routine_to_garmin_workout(routine, weight_unit="kilogram", default_rest_seconds=75)
@@ -781,6 +801,45 @@ class TestScheduledWorkoutsUI:
         # Transient failure surfaces an error toast and keeps the entry tracked.
         assert "toast-error" in resp.text
         assert set(store.get_routine_schedule_ids("r1")) == {"s0", "s1"}
+
+
+class TestRoutineSyncUI:
+    def _client(self, store: SQLiteDatabase):
+        srv._is_configured_cache = True  # skip the "not configured → /setup" redirect
+        return patch.object(srv.db, "get_db", return_value=store), TestClient(srv.app)
+
+    def test_sync_route_swaps_row_and_toasts(self, tmp_path: Path) -> None:
+        store = SQLiteDatabase(tmp_path / "ui.db")
+        db_patch, client = self._client(store)
+        row = {"id": "r1", "title": "Push", "exercise_count": 3, "synced": True, "scheduled_date": None}
+        with db_patch, client, patch.object(
+            srv, "sync_routine", return_value={"outcome": "created", "row": row}
+        ):
+            resp = client.post("/api/routines/r1/sync")
+        assert resp.status_code == 200
+        assert "toast-success" in resp.text
+        # The updated row is returned as an out-of-band swap so it flips to synced.
+        assert 'id="routine-row-r1"' in resp.text and 'hx-swap-oob="true"' in resp.text
+        assert "Re-sync" in resp.text  # synced rows offer re-sync
+        assert resp.headers.get("HX-Trigger") == "refreshSchedules"
+
+    def test_sync_route_reports_failure(self, tmp_path: Path) -> None:
+        store = SQLiteDatabase(tmp_path / "ui.db")
+        db_patch, client = self._client(store)
+        row = {"id": "r1", "title": "Push", "exercise_count": 3, "synced": False, "scheduled_date": None}
+        with db_patch, client, patch.object(
+            srv, "sync_routine", return_value={"outcome": "failed", "row": row}
+        ):
+            resp = client.post("/api/routines/r1/sync")
+        assert "toast-error" in resp.text
+        assert "hx-swap-oob" not in resp.text  # no row swap on failure
+
+    def test_sync_route_demo_mode(self, tmp_path: Path) -> None:
+        store = SQLiteDatabase(tmp_path / "ui.db")
+        db_patch, client = self._client(store)
+        with db_patch, client, patch.object(srv, "is_demo_mode", return_value=True):
+            resp = client.post("/api/routines/r1/sync")
+        assert "demo mode" in resp.text
 
 
 class TestDbFacade:

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -282,6 +282,26 @@ class TestSyncRoutines:
         create_mock.assert_called_once()
         assert store.get_synced_routine("r1")["garmin_workout_id"] == "777"
 
+    def test_sync_single_routine_creates_and_returns_row(self, tmp_path: Path) -> None:
+        routines = [{"id": "r1", "title": "Push", "updated_at": "2026-01-01T00:00:00Z",
+                     "exercises": [{"title": "Bench Press (Barbell)",
+                                    "sets": [{"type": "normal", "reps": 5, "weight_kg": 60}]}]}]
+        store, create_mock, _, patches = self._patched(tmp_path, routines)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6], patches[7]:
+            result = sync_module.sync_routine("r1")
+        assert result["outcome"] == "created"
+        assert result["row"] == {
+            "id": "r1", "title": "Push", "exercise_count": 1, "synced": True, "scheduled_date": None}
+        create_mock.assert_called_once()
+        assert store.get_synced_routine("r1")["garmin_workout_id"] == "777"
+
+    def test_sync_single_routine_not_found_raises(self, tmp_path: Path) -> None:
+        routines = [{"id": "r1", "title": "Push", "exercises": []}]
+        store, _, _, patches = self._patched(tmp_path, routines)
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6], patches[7]:
+            with pytest.raises(ValueError, match="not found"):
+                sync_module.sync_routine("missing")
+
     def _hash_for(self, routine: dict) -> str:
         # Mirror how sync_routines builds the payload (no timing config → 75s default).
         payload = routine_to_garmin_workout(routine, weight_unit="kilogram", default_rest_seconds=75)
@@ -794,6 +814,45 @@ class TestScheduledWorkoutsUI:
         # Transient failure surfaces an error toast and keeps the entry tracked.
         assert "toast-error" in resp.text
         assert set(store.get_routine_schedule_ids("r1")) == {"s0", "s1"}
+
+
+class TestRoutineSyncUI:
+    def _client(self, store: SQLiteDatabase):
+        srv._is_configured_cache = True  # skip the "not configured → /setup" redirect
+        return patch.object(srv.db, "get_db", return_value=store), TestClient(srv.app)
+
+    def test_sync_route_swaps_row_and_toasts(self, tmp_path: Path) -> None:
+        store = SQLiteDatabase(tmp_path / "ui.db")
+        db_patch, client = self._client(store)
+        row = {"id": "r1", "title": "Push", "exercise_count": 3, "synced": True, "scheduled_date": None}
+        with db_patch, client, patch.object(
+            srv, "sync_routine", return_value={"outcome": "created", "row": row}
+        ):
+            resp = client.post("/api/routines/r1/sync")
+        assert resp.status_code == 200
+        assert "toast-success" in resp.text
+        # The updated row is returned as an out-of-band swap so it flips to synced.
+        assert 'id="routine-row-r1"' in resp.text and 'hx-swap-oob="true"' in resp.text
+        assert "Re-sync" in resp.text  # synced rows offer re-sync
+        assert resp.headers.get("HX-Trigger") == "refreshSchedules"
+
+    def test_sync_route_reports_failure(self, tmp_path: Path) -> None:
+        store = SQLiteDatabase(tmp_path / "ui.db")
+        db_patch, client = self._client(store)
+        row = {"id": "r1", "title": "Push", "exercise_count": 3, "synced": False, "scheduled_date": None}
+        with db_patch, client, patch.object(
+            srv, "sync_routine", return_value={"outcome": "failed", "row": row}
+        ):
+            resp = client.post("/api/routines/r1/sync")
+        assert "toast-error" in resp.text
+        assert "hx-swap-oob" not in resp.text  # no row swap on failure
+
+    def test_sync_route_demo_mode(self, tmp_path: Path) -> None:
+        store = SQLiteDatabase(tmp_path / "ui.db")
+        db_patch, client = self._client(store)
+        with db_patch, client, patch.object(srv, "is_demo_mode", return_value=True):
+            resp = client.post("/api/routines/r1/sync")
+        assert "demo mode" in resp.text
 
 
 class TestDbFacade:


### PR DESCRIPTION
## What changed and why

Today the `/routines` page only offers **"Sync all routines"**. This PR adds two things to the routines list:
1. **Per-routine Sync button** — syncs a single routine and swaps its row in place (via an HTMX out-of-band swap), flipping it to "✓ synced" and revealing the Schedule form, without a full page reload.
2. **"Show only unsynced" filter** — a client-side toggle that hides routines already on Garmin, so you can find and sync only the pending ones.

> ✅ **#254 merged — branch synced with upstream `main`:** this PR was originally stacked on `fix/routines-unschedule-before-reschedule` (PR #254). Now that #254 has landed on `main`, this branch has been merged with the latest upstream `main`, so the diff is narrowed to **only** the per-routine sync + "show only unsynced" filter (plus the card/timeline redesign). No longer blocked.

## Technical details

### Files changed
- `src/hevy2garmin/sync.py` — extracted the `sync_routines` loop body into `_sync_one_routine(...)` and the Garmin-library reconciliation into `_build_library_by_name(...)` (both reused by `sync_routines`, identical behavior/stats); new `sync_routine(hevy_routine_id, *, force=False)` that fetches the routine from Hevy (via `fetch_all_routines` + id filter), syncs it, and returns a render-ready row dict (`{"outcome", "row"}`), raising `ValueError` if the routine doesn't exist.
- `src/hevy2garmin/server.py` — new route `POST /api/routines/{id}/sync` (demo-mode and sync-lock guards, like `api_routines_sync`): on success it returns the toast (into `#routines-result`) **plus** an out-of-band re-render of the row, and `HX-Trigger: refreshSchedules`; on failure/error, only the error toast. The routine title (user-controlled data from Hevy) is escaped with `html.escape` before being interpolated into the success/error toasts — those f-strings bypass Jinja's autoescape. `routines_page` now renders rows through the new partial.
- `src/hevy2garmin/templates/routine_row.html` (new) — the routine row (with `id`/class `is-synced`/`is-unsynced` and a conditional `hx-swap-oob`), the **Sync/Re-sync** button, and the existing Schedule form.
- `src/hevy2garmin/templates/routines.html` — the loop now includes the partial; card-based redesign with stats and a schedule timeline; a **Show only unsynced** filter plus a client-side search over routines.
- `tests/test_routine.py` / `tests/test_db.py` — coverage for `sync_routine` (creates + returns row; `ValueError` when not found) and the route (swap/toast, failure, demo mode), plus the DB-layer schedule tracking.

### Approach and trade-offs
The per-routine logic is reused by extracting it from `sync_routines`, so bulk and individual sync behave identically and the existing `sync_routines` tests stay green. The filter is client-side (class toggle) so it's instant and doesn't re-fetch Hevy; a freshly synced row drops out of the filter on its own because the OOB swap flips `is-unsynced`→`is-synced`. Fetching a single routine is done via `fetch_all_routines` + filter (Hevy exposes no single-routine endpoint) — an acceptable cost for a manual action.

### How to test
```bash
PYTHONPATH=src pytest tests/test_routine.py tests/test_db.py -q
PYTHONPATH=src pytest tests/ -q
```
Manual: `PYTHONPATH=src python -m hevy2garmin.cli serve --port 8123`, open `/routines`, click **Sync** on an unsynced routine and watch the row turn into "✓ synced" with the Schedule form; toggle **Show only unsynced** and confirm the synced ones disappear; confirm the "Scheduled workouts" table refreshes.

### Breaking changes
None. No schema changes, no contract changes. Only a new route, a new template, and internal refactoring of `sync.py`. (The `routine_schedules` table introduced by #254 is created idempotently with `CREATE TABLE IF NOT EXISTS`.)

## Security notes
The toasts for `POST /api/routines/{id}/sync` are built with f-strings (outside Jinja's autoescape) and interpolate the routine title, which is user-controlled (Hevy account data). Without escaping, a title like `<img src=x onerror=...>` would be reflected untreated into `#routines-result` (reflected XSS, even if over the user's own data). The title is now escaped with `html.escape` in both branches (success and failure), restoring the autoescape invariant the rest of the UI (Jinja render in `routine_row.html`) already guarantees. The `api_routines_sync` toast stays safe because it only interpolates integer counts.

### Checklist
- [x] Tests added or updated
- [x] No sensitive data in logs or responses
- [x] Migrations are backward-compatible (`CREATE TABLE IF NOT EXISTS`)
- [ ] Feature flag (not applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

