### PR TITLE
chore(release): v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-07-23
+
+### Added
+- A Scheduled Workouts table on the Routines page ([#254](https://github.com/drkostas/hevy2garmin/pull/254), thanks @bcandido). See every upcoming scheduled routine (date and routine name) in one place, filter by start date or name, choose the page size, and remove an entry with one click, which also unschedules it on Garmin. The table reads from the local database, so it still renders even if the Hevy fetch is unavailable.
+
 ### Fixed
+- Re-scheduling a routine no longer stacks duplicate entries on the Garmin calendar ([#254](https://github.com/drkostas/hevy2garmin/pull/254), thanks @bcandido). Garmin appends a fresh calendar entry on every schedule call with no server-side dedup, so the tool now tracks the schedule id Garmin returns and unschedules the prior entries before booking new dates, making re-scheduling idempotent.
 - Routine sync now reconciles against the actual Garmin workout library before creating, so a database reset (ephemeral cloud storage, a migration) or a crash in the create→persist window no longer duplicates planned workouts. Before creating a routine's workout, a same-named workout already in the Garmin library is deleted and recreated instead of stacking a second copy — making routine sync self-healing across DB loss and mid-run failures. To stay safe, reconciliation only ever deletes a workout carrying hevy2garmin's provenance marker (now embedded in every synced routine's description), so a workout you built by hand in Garmin that happens to share a routine's title is never touched. The listing is best-effort: if it fails, sync falls back to the previous DB-only dedup.
 
 ## [0.6.0] - 2026-07-20

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hevy2garmin"
-version = "0.6.0"
+version = "0.6.1"
 description = "Sync Hevy gym workouts to Garmin Connect — exercise mapping, FIT file generation, and automatic upload"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Release 0.6.1.

Ships @bcandido's routine-scheduling work:
- **#253** — reconcile against the actual Garmin workout library before creating, so a DB reset or a mid-run crash no longer duplicates planned workouts (marker-guarded, so a hand-built same-named workout is never touched).
- **#254** — idempotent re-scheduling (track the Garmin schedule id and unschedule prior entries before booking new dates, no more stacked calendar duplicates), plus a Scheduled Workouts table on the Routines page (filter, paginate, remove).

Version bump 0.6.0 → 0.6.1 + CHANGELOG. Merging to `main` triggers the PyPI publish.
