### PR TITLE
fix(config): strip whitespace from credentials (#257)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-07-23
+
+### Fixed
+- Credentials with leading or trailing whitespace (a pasted newline is the classic case) no longer break sync ([#257](https://github.com/drkostas/hevy2garmin/issues/257)). The Hevy API key, Garmin email and password are normalized on read, so a stray newline can't break the API call and an existing bad value already stored in the database is cleaned automatically on the next load. On the Vercel deploy the stored value takes precedence over the environment variable, so this also fixes the case where a bad key couldn't be cleared by editing the env var.
+
 ## [0.6.1] - 2026-07-23
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hevy2garmin"
-version = "0.6.1"
+version = "0.6.2"
 description = "Sync Hevy gym workouts to Garmin Connect — exercise mapping, FIT file generation, and automatic upload"
 readme = "README.md"
 license = "MIT"

--- a/src/hevy2garmin/config.py
+++ b/src/hevy2garmin/config.py
@@ -118,6 +118,14 @@ def load_config() -> dict[str, Any]:
     if not config.get("garmin_password") and os.environ.get("GARMIN_PASSWORD"):
         config["garmin_password"] = os.environ["GARMIN_PASSWORD"]
 
+    # Normalize credential whitespace. A stray leading/trailing newline (the classic
+    # copy-paste mistake) breaks the API call, and on the Vercel deploy the stored DB
+    # value takes precedence over the env var, so the user can't clear it by editing
+    # the variable. Stripping on read fixes new and existing values alike. (#257)
+    for _cred in ("hevy_api_key", "garmin_email", "garmin_password"):
+        if isinstance(config.get(_cred), str):
+            config[_cred] = config[_cred].strip()
+
     return config
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -72,6 +72,22 @@ class TestLoadConfig:
             config = load_config()
             assert config["user_profile"]["weight_kg"] == 80.0
 
+    def test_strips_whitespace_from_credentials(self, tmp_path: Path) -> None:
+        # A stray leading/trailing newline on a pasted credential (#257) is
+        # normalized on read, so it can't break the API call and an existing bad
+        # value self-heals on the next load.
+        config_file = tmp_path / "config.json"
+        config_file.write_text(json.dumps({
+            "hevy_api_key": "  abc123\n",
+            "garmin_email": "\tuser@example.com ",
+            "garmin_password": " pw ",
+        }))
+        with patch("hevy2garmin.config.CONFIG_FILE", config_file):
+            config = load_config()
+            assert config["hevy_api_key"] == "abc123"
+            assert config["garmin_email"] == "user@example.com"
+            assert config["garmin_password"] == "pw"
+
 
 class TestIsConfigured:
     def test_false_without_api_key(self, tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #257 (reported on r/Hevy).

A Hevy API key pasted with a trailing newline broke the Hevy API call and couldn't be cleared: the key is never stripped, and on the Vercel deploy the stored DB value takes precedence over the `HEVY_API_KEY` env var, so editing the variable did nothing.

`load_config` now strips leading/trailing whitespace off the Hevy API key and Garmin email/password on read. One place covers every path, and an existing bad value already in the database self-heals on the next load, so affected users do not re-enter anything.

Also bumps to 0.6.2 so the fix ships. Regression test: `test_strips_whitespace_from_credentials`. Full suite: 413 passed, 7 skipped.

Closes #257
