### PR TITLE
fix(hr): extract all watch-activity HR without the strict window (#244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-07-24
+
+### Fixed
+- The Replace watch strategy now extracts heart rate from the watch activity's own recording without an over-strict time window ([#244](https://github.com/drkostas/hevy2garmin/issues/244)). Previously it only kept HR samples that fell inside the Hevy workout window (plus a 3-minute buffer), so a watch activity whose clock differed from the Hevy log by more than a few minutes lost all of its HR and fell back to keeping the watch copy, with exercise names then showing as "unknown". It now takes every heart-rate record from the activity's own file, since that file is a single recording of the workout. When no HR can be extracted, the reason is now logged instead of silently swallowed, so genuine device-specific extraction failures can be diagnosed.
+
 ## [0.6.2] - 2026-07-23
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hevy2garmin"
-version = "0.6.2"
+version = "0.6.3"
 description = "Sync Hevy gym workouts to Garmin Connect — exercise mapping, FIT file generation, and automatic upload"
 readme = "README.md"
 license = "MIT"

--- a/src/hevy2garmin/hr.py
+++ b/src/hevy2garmin/hr.py
@@ -124,7 +124,6 @@ def fetch_activity_hr(
     if not start_dt or not end_dt:
         return []
     start_ms = int(start_dt.timestamp() * 1000)
-    end_ms = int(end_dt.timestamp() * 1000)
 
     try:
         call = (limiter.call if limiter is not None else (lambda f, *a: f(*a)))
@@ -134,6 +133,7 @@ def fetch_activity_hr(
             Garmin.ActivityDownloadFormat.ORIGINAL,
         )
         if not isinstance(downloaded, bytes) or not downloaded:
+            logger.warning("activity %s: HR download returned no bytes", activity_id)
             return []
 
         fit_bytes = downloaded
@@ -145,6 +145,7 @@ def fetch_activity_hr(
                     None,
                 )
                 if fit_member is None:
+                    logger.warning("activity %s: no .fit member in downloaded zip", activity_id)
                     return []
                 fit_bytes = archive.read(fit_member)
 
@@ -159,19 +160,22 @@ def fetch_activity_hr(
         finally:
             fit_logger.setLevel(previous_level)
     except Exception as exc:
-        logger.debug("activity HR fetch failed for %s: %s", activity_id, exc)
+        logger.warning("activity %s: HR download/parse failed: %s", activity_id, exc)
         return []
 
-    # Tolerate a small offset between the Hevy workout window and the watch's
-    # own recording clock (#244): a strict in-window match dropped every sample
-    # when the two differed even slightly, which then hard-failed Replace. The
-    # graceful merge fallback in sync_one_workout covers larger gaps.
-    window_buffer_ms = 180_000  # 3 minutes
+    # The downloaded FIT is the watch's own single recording of this workout, so
+    # every heart-rate record in it belongs to the workout. Take them all and
+    # rebase to the Hevy start for embedding, rather than intersecting with the
+    # Hevy workout window (#244): a watch activity whose clock differs from the
+    # Hevy log by more than a few minutes would otherwise lose all its samples.
     samples: list[dict] = []
+    record_count = 0
+    hr_record_count = 0
     for record in fit_file.records:
         message = record.message
         if not isinstance(message, RecordMessage):
             continue
+        record_count += 1
         timestamp = getattr(message, "timestamp", None)
         bpm = getattr(message, "heart_rate", None)
         if timestamp is None or bpm is None:
@@ -185,12 +189,20 @@ def fetch_activity_hr(
             bpm_int = int(bpm)
         except (TypeError, ValueError):
             continue
-        if (start_ms - window_buffer_ms) <= timestamp_ms <= (end_ms + window_buffer_ms) and 0 < bpm_int < 256:
-            samples.append({
-                "time": max(0.0, (timestamp_ms - start_ms) / 1000.0),
-                "hr": bpm_int,
-            })
+        if not 0 < bpm_int < 256:
+            continue
+        hr_record_count += 1
+        samples.append({
+            "time": max(0.0, (timestamp_ms - start_ms) / 1000.0),
+            "hr": bpm_int,
+        })
 
+    if not samples:
+        logger.warning(
+            "activity %s: no heart-rate samples extracted (%d record messages, "
+            "%d with valid HR); replacement will fall back to keeping the watch copy",
+            activity_id, record_count, hr_record_count,
+        )
     samples.sort(key=lambda sample: sample["time"])
     return samples
 

--- a/tests/test_hr.py
+++ b/tests/test_hr.py
@@ -148,6 +148,35 @@ class TestFetchActivityHR:
             {"time": 480.0, "hr": 150},
         ]
 
+    def test_extracts_hr_even_when_outside_hevy_window(self, tmp_path: Path):
+        # Regression #244: the watch activity's clock can differ from the Hevy
+        # log by more than a few minutes. The downloaded FIT is the watch's own
+        # single recording of this workout, so every HR record must be extracted
+        # regardless of the Hevy window (the old strict-window filter dropped
+        # them all, breaking Replace).
+        shifted = {
+            **self.WORKOUT,
+            "start_time": "2026-03-15T18:30:00+00:00",  # 30 min after the fetch window
+            "end_time": "2026-03-15T18:40:00+00:00",
+        }
+        fit_path = tmp_path / "activity.fit"
+        generate_fit(
+            shifted,
+            hr_samples=[{"time": 0, "hr": 111}, {"time": 300, "hr": 145}],
+            output_path=str(fit_path),
+        )
+        output = io.BytesIO()
+        with zipfile.ZipFile(output, "w") as archive:
+            archive.writestr("123_ACTIVITY.fit", fit_path.read_bytes())
+        client = MagicMock()
+        client.download_activity.return_value = output.getvalue()
+
+        # Fetch with the ORIGINAL window, 30 min earlier than the FIT's HR.
+        samples = fetch_activity_hr(client, 123, self.WORKOUT)
+
+        assert [s["hr"] for s in samples] == [111, 145]
+        assert all(s["time"] >= 0 for s in samples)
+
     def test_falls_back_to_daily_hr_when_original_download_fails(self):
         client = MagicMock()
         client.download_activity.side_effect = RuntimeError("not downloadable")


### PR DESCRIPTION
Addresses #244 (still confirming the reporter's specific device, so not auto-closing).

`fetch_activity_hr` filtered watch-activity HR to the Hevy workout window (±3 min). But the downloaded FIT is the watch's own single recording of that one workout, so intersecting with the Hevy window buys nothing and drops all HR when the two clocks differ by more than the buffer. It now takes every HR record from the file.

It also replaces the silent `except ... return []` with logging (download size / parse error / record + HR counts), so a genuine device-specific extraction failure surfaces the reason instead of vanishing.

Regression test: `test_extracts_hr_even_when_outside_hevy_window`. Full suite: 414 passed, 7 skipped.

Refs #244
