### PR TITLE
fix(hr): tolerate non-UTF-8 bytes in FIT string fields (#244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.6.4] - 2026-07-24
+
+### Fixed
+- Replace now works on watch activities whose FIT file contains a non-UTF-8 byte in a string field ([#244](https://github.com/drkostas/hevy2garmin/issues/244)). Some devices (a Garmin Fenix 7 Pro was the first confirmed) write a manufacturer or product name with a byte that isn't valid UTF-8, and fit-tool decoded FIT strings strictly, so a single bad byte raised an error that aborted the entire heart-rate extraction. HR extraction now decodes FIT strings leniently, so the file parses and the heart rate comes through, letting Replace upload a named activity instead of falling back to keeping the watch copy (which showed exercise names as "unknown").
+
 ## [0.6.3] - 2026-07-24
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hevy2garmin"
-version = "0.6.3"
+version = "0.6.4"
 description = "Sync Hevy gym workouts to Garmin Connect — exercise mapping, FIT file generation, and automatic upload"
 readme = "README.md"
 license = "MIT"

--- a/src/hevy2garmin/hr.py
+++ b/src/hevy2garmin/hr.py
@@ -28,6 +28,32 @@ from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
 
+
+def _patch_fit_tool_lenient_strings() -> None:
+    """Make fit-tool tolerate non-UTF-8 bytes in FIT string fields.
+
+    Some device FITs (a Garmin Fenix 7 Pro was the first confirmed, #244) carry a
+    non-UTF-8 byte in a string field such as a manufacturer or product name.
+    fit-tool decodes string containers with strict UTF-8, so a single bad byte
+    raised UnicodeDecodeError and aborted the whole parse, losing all heart rate
+    and silently dropping Replace to the merge fallback (names then "unknown").
+    Decode leniently instead: the bad byte becomes the Unicode replacement
+    character and the rest of the file, including the HR records, still parses.
+    Idempotent, and safe because hevy2garmin only ever reads these FITs.
+    """
+    from fit_tool.field import Field
+
+    if getattr(Field.read_strings_from_bytes, "_h2g_lenient", False):
+        return
+
+    def read_strings_from_bytes(self, bytes_buffer: bytes) -> None:
+        string_container = bytes_buffer.decode("utf-8", errors="replace")
+        strings = [s for s in string_container.split(chr(0))[:-1] if s]
+        self.encoded_values = list(strings)
+
+    read_strings_from_bytes._h2g_lenient = True  # type: ignore[attr-defined]
+    Field.read_strings_from_bytes = read_strings_from_bytes  # type: ignore[method-assign]
+
 _HR_BACKUP_PREFIX = "hr_backup_"
 
 
@@ -155,6 +181,7 @@ def fetch_activity_hr(
         fit_logger = logging.getLogger("fit_tool")
         previous_level = fit_logger.level
         fit_logger.setLevel(logging.ERROR)
+        _patch_fit_tool_lenient_strings()
         try:
             fit_file = FitFile.from_bytes(fit_bytes, check_crc=False)
         finally:

--- a/tests/test_hr.py
+++ b/tests/test_hr.py
@@ -177,6 +177,23 @@ class TestFetchActivityHR:
         assert [s["hr"] for s in samples] == [111, 145]
         assert all(s["time"] >= 0 for s in samples)
 
+    def test_fit_string_decode_tolerates_non_utf8_bytes(self):
+        # Regression #244: a device FIT (first seen on a Fenix 7 Pro) carried a
+        # non-UTF-8 byte in a string field, and fit-tool's strict UTF-8 decode
+        # raised UnicodeDecodeError, aborting the whole parse and losing all HR.
+        # The lenient shim must let the parse through.
+        from fit_tool.base_type import BaseType
+        from fit_tool.field import Field
+
+        from hevy2garmin.hr import _patch_fit_tool_lenient_strings
+
+        _patch_fit_tool_lenient_strings()
+        field = Field(name="product", field_id=0, base_type=BaseType.STRING)
+        # "Garmin" <0x9f> NUL "Fenix" NUL — the 0x9f is the invalid start byte.
+        buf = b"Garmin" + bytes([0x9F, 0]) + b"Fenix" + bytes([0])
+        field.read_strings_from_bytes(buf)  # must not raise
+        assert any("Fenix" in v for v in field.encoded_values)
+
     def test_falls_back_to_daily_hr_when_original_download_fails(self):
         client = MagicMock()
         client.download_activity.side_effect = RuntimeError("not downloadable")


### PR DESCRIPTION
Fixes the confirmed root cause of #244.

The reporter's sync log (visible thanks to 0.6.3's diagnostics) showed:
`HR download/parse failed: 'utf-8' codec can't decode byte 0x9f in position 36: invalid start byte`

His Fenix 7 Pro's FIT carries a non-UTF-8 byte in a string field, and fit-tool decodes FIT string containers with strict UTF-8, so one bad byte aborted the entire parse and lost all HR. I reproduced the exact error against fit-tool's `read_strings_from_bytes` and verified a lenient decode (`errors='replace'`) fixes it.

This installs a small, idempotent shim making fit-tool's FIT string decode lenient before parsing. Safe because hevy2garmin only ever reads these FITs.

Regression test: `test_fit_string_decode_tolerates_non_utf8_bytes`. Full suite: 415 passed, 7 skipped.

Refs #244
