### PR TITLE
feat(auth): dashboard security layer (login rate limiting + hardening)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,17 @@ GARMIN_PASSWORD=
 # Optional: dashboard password. When set, all routes require login.
 H2G_PASSWORD=
 
+# Optional: argon2 hash of the dashboard password — use INSTEAD of H2G_PASSWORD so the
+# plaintext never lives in the environment. Generate: hevy2garmin hash-password
+H2G_PASSWORD_HASH=
+
+# Optional: dedicated session-signing secret. Decouples cookie signing from the password
+# (rotating the password no longer logs everyone out). Falls back to the password when unset.
+H2G_SECRET=
+
+# Optional: how long a login lasts, in days, before re-auth is required (default: 30).
+H2G_SESSION_TTL_DAYS=
+
 # Optional: set to 'true' to run in demo mode (disables sync, shows banner)
 DEMO_MODE=
 

--- a/.env.example
+++ b/.env.example
@@ -19,8 +19,9 @@ H2G_PASSWORD=
 # plaintext never lives in the environment. Generate: hevy2garmin hash-password
 H2G_PASSWORD_HASH=
 
-# Optional: dedicated session-signing secret. Decouples cookie signing from the password
-# (rotating the password no longer logs everyone out). Falls back to the password when unset.
+# Optional but recommended (especially with H2G_PASSWORD_HASH): dedicated session-signing
+# secret. Decouples cookie signing from the password (rotating it no longer logs everyone
+# out). Without it, the signing key derives from the password (or its hash).
 H2G_SECRET=
 
 # Optional: how long a login lasts, in days, before re-auth is required (default: 30).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- Hardened dashboard authentication. Failed logins are now rate-limited per client IP with exponential backoff and a global cap (HTTP 429 on lockout), so the login can't be brute-forced. The dashboard password can be supplied pre-hashed via `H2G_PASSWORD_HASH` (argon2, generated with `hevy2garmin hash-password`) so the plaintext never sits in the environment; session cookies gain the `Secure` flag over HTTPS and are signed with an optional dedicated `H2G_SECRET` (session lifetime configurable via `H2G_SESSION_TTL_DAYS`, default 30 days); a "Sign out everywhere" action invalidates every active session; and standard security headers (HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, a baseline CSP) are sent on every response. Existing password-only deployments keep working unchanged.
+
 ## [0.6.4] - 2026-07-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -320,6 +320,17 @@ See [`.env.example`](.env.example) for all available env vars.
 
 > **Cloud deploys (Vercel):** Garmin blocks automated logins from cloud servers, so hevy2garmin routes the login through a Cloudflare Worker (`hevy2garmin-exchange-di.gkos.workers.dev`) that runs on Cloudflare's edge network. The Worker accepts your email + password from the setup page, completes the login (including 2FA if enabled), and returns a DI OAuth token that hevy2garmin stores in your Postgres database. This happens in a single click from the setup wizard. On the rare occasion Garmin rejects the direct login, the setup page automatically falls back to a "sign in via browser, paste the URL back" flow.
 
+## Securing the dashboard
+
+The dashboard has no login by default (fine for a private local install). **If you deploy it to a public URL, protect it** — otherwise anyone who finds the URL can see your data.
+
+- **Set a password.** Set `H2G_PASSWORD` to require login on every page and API route. Without it the dashboard is open, so **always set a password before putting it on a public URL**.
+- **Avoid plaintext (optional).** Run `hevy2garmin hash-password` to generate an argon2 hash and set it as `H2G_PASSWORD_HASH` instead of `H2G_PASSWORD`, so the plaintext password never lives in your environment.
+- **Brute-force protection.** Failed logins are rate-limited per IP with exponential backoff and a global cap; repeated attempts get HTTP 429 with a cooldown.
+- **Sessions.** Login sets a signed, `HttpOnly`, `SameSite=Strict` cookie (30-day TTL by default, configurable via `H2G_SESSION_TTL_DAYS`), marked `Secure` over HTTPS. Set an optional `H2G_SECRET` to sign sessions with a dedicated key (so rotating the password doesn't sign everyone out). Use **Sign out all** in the nav to invalidate every active session at once.
+
+See [`.env.example`](.env.example) for all the related variables.
+
 ## Updating
 
 ### Vercel (fork-based deploy)

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ The dashboard has no login by default (fine for a private local install). **If y
 - **Set a password.** Set `H2G_PASSWORD` to require login on every page and API route. Without it the dashboard is open, so **always set a password before putting it on a public URL**.
 - **Avoid plaintext (optional).** Run `hevy2garmin hash-password` to generate an argon2 hash and set it as `H2G_PASSWORD_HASH` instead of `H2G_PASSWORD`, so the plaintext password never lives in your environment.
 - **Brute-force protection.** Failed logins are rate-limited per IP with exponential backoff and a global cap; repeated attempts get HTTP 429 with a cooldown.
-- **Sessions.** Login sets a signed, `HttpOnly`, `SameSite=Strict` cookie (30-day TTL by default, configurable via `H2G_SESSION_TTL_DAYS`), marked `Secure` over HTTPS. Set an optional `H2G_SECRET` to sign sessions with a dedicated key (so rotating the password doesn't sign everyone out). Use **Sign out all** in the nav to invalidate every active session at once.
+- **Sessions.** Login sets a signed, `HttpOnly`, `SameSite=Strict` cookie (30-day TTL by default, configurable via `H2G_SESSION_TTL_DAYS`), marked `Secure` over HTTPS. Setting `H2G_SECRET` (recommended, especially with `H2G_PASSWORD_HASH`) signs sessions with a dedicated key, so rotating the password doesn't sign everyone out. **Sign out all devices** (Settings → Sessions &amp; Security) invalidates every active session at once.
 
 See [`.env.example`](.env.example) for all the related variables.
 

--- a/src/hevy2garmin/auth.py
+++ b/src/hevy2garmin/auth.py
@@ -1,8 +1,17 @@
-"""Simple shared-password auth for the hevy2garmin dashboard.
+"""Shared-password auth for the hevy2garmin dashboard.
 
-When H2G_PASSWORD is set, all page/API routes require a valid session cookie.
-When unset, auth is disabled (backward-compatible with existing deployments).
+When ``H2G_PASSWORD`` (or a pre-hashed ``H2G_PASSWORD_HASH``) is set, all
+page/API routes require a valid session cookie. When neither is set, auth is
+disabled (backward-compatible with existing local deployments).
+
+Sessions are stateless, signed HMAC cookies (``v2.<ts>.<epoch>.<sig>``). The
+``epoch`` is folded into the signature so bumping a server-side counter
+("sign out everywhere") invalidates every outstanding cookie without needing a
+session store. Legacy ``v1.<ts>.<sig>`` cookies are still accepted until they
+expire, so an upgrade never force-logs-out the admin.
 """
+
+from __future__ import annotations
 
 import hashlib
 import hmac
@@ -10,53 +19,112 @@ import os
 import time
 
 SESSION_COOKIE = "h2g_session"
-SESSION_TTL = 30 * 24 * 3600  # 30 days
+DEFAULT_SESSION_TTL_DAYS = 30
+
+
+def session_ttl() -> int:
+    """Session lifetime in seconds (absolute, measured from login).
+
+    Configurable via ``H2G_SESSION_TTL_DAYS`` (integer days; default 30). An
+    invalid or non-positive value falls back to the default.
+    """
+    raw = os.environ.get("H2G_SESSION_TTL_DAYS")
+    if raw:
+        try:
+            days = int(raw)
+            if days > 0:
+                return days * 24 * 3600
+        except ValueError:
+            pass
+    return DEFAULT_SESSION_TTL_DAYS * 24 * 3600
 
 
 def get_password() -> str | None:
-    """Return the shared password, or None if auth is disabled."""
+    """Return the plaintext shared password, or None if not set."""
     return os.environ.get("H2G_PASSWORD") or None
 
 
+def _password_hash() -> str | None:
+    """Return the pre-hashed (argon2) password, or None if not set."""
+    return os.environ.get("H2G_PASSWORD_HASH") or None
+
+
 def auth_enabled() -> bool:
-    """True when H2G_PASSWORD is set (non-empty)."""
-    return bool(get_password())
+    """True when a password (plaintext or hashed) is configured."""
+    return bool(get_password() or _password_hash())
 
 
 def _secret() -> bytes:
-    """Derive a signing key from the password itself (no separate secret needed)."""
-    pw = get_password()
-    if not pw:
-        raise RuntimeError("H2G_PASSWORD not set")
-    return hashlib.sha256(f"h2g-session-{pw}".encode()).digest()
+    """Derive the cookie-signing key.
+
+    Prefers a dedicated ``H2G_SECRET`` (decouples signing from the password, so
+    rotating the password no longer invalidates sessions). Falls back to the
+    password, then the password hash, so existing deployments keep working and
+    their current cookies stay valid.
+    """
+    seed = os.environ.get("H2G_SECRET") or get_password() or _password_hash()
+    if not seed:
+        raise RuntimeError("no signing seed: set H2G_PASSWORD, H2G_PASSWORD_HASH, or H2G_SECRET")
+    return hashlib.sha256(("h2g-session-" + seed).encode()).digest()
 
 
-def sign_session() -> str:
-    """Create a signed session cookie value: 'v1.<timestamp>.<hmac>'."""
+def sign_session(epoch: int = 0) -> str:
+    """Create a signed session cookie value: ``v2.<timestamp>.<epoch>.<hmac>``."""
     ts = str(int(time.time()))
-    sig = hmac.new(_secret(), f"v1.{ts}".encode(), hashlib.sha256).hexdigest()[:32]
-    return f"v1.{ts}.{sig}"
+    payload = f"v2.{ts}.{int(epoch)}"
+    sig = hmac.new(_secret(), payload.encode(), hashlib.sha256).hexdigest()[:32]
+    return f"{payload}.{sig}"
 
 
-def verify_session(cookie: str | None) -> bool:
-    """Verify a session cookie is valid and not expired."""
-    if not cookie or not auth_enabled():
-        return not auth_enabled()
+def verify_session(cookie: str | None, current_epoch: int = 0) -> bool:
+    """Verify a session cookie: valid signature, not expired, current epoch.
+
+    Accepts both ``v2`` (with epoch) and legacy ``v1`` (epoch-less) cookies so
+    sessions issued before an upgrade survive until their TTL. Returns True when
+    auth is disabled (backward-compatible).
+    """
+    if not auth_enabled():
+        return True
+    if not cookie:
+        return False
     try:
         parts = cookie.split(".")
-        if len(parts) != 3 or parts[0] != "v1":
+        if parts[0] == "v2" and len(parts) == 4:
+            if int(parts[2]) != int(current_epoch):
+                return False
+            ts = int(parts[1])
+            payload = f"v2.{parts[1]}.{parts[2]}"
+            sig = parts[3]
+        elif parts[0] == "v1" and len(parts) == 3:
+            ts = int(parts[1])
+            payload = f"v1.{parts[1]}"
+            sig = parts[2]
+        else:
             return False
-        ts = int(parts[1])
-        if time.time() - ts > SESSION_TTL:
+        if time.time() - ts > session_ttl():
             return False
-        expected = hmac.new(_secret(), f"v1.{parts[1]}".encode(), hashlib.sha256).hexdigest()[:32]
-        return hmac.compare_digest(parts[2], expected)
+        expected = hmac.new(_secret(), payload.encode(), hashlib.sha256).hexdigest()[:32]
+        return hmac.compare_digest(sig, expected)
     except (ValueError, TypeError):
         return False
 
 
 def check_password(candidate: str) -> bool:
-    """Constant-time comparison of candidate against H2G_PASSWORD."""
+    """Verify a candidate against ``H2G_PASSWORD_HASH`` (argon2) or the plaintext
+    ``H2G_PASSWORD``. Constant-time in both paths."""
+    h = _password_hash()
+    if h:
+        try:
+            import nacl.exceptions
+            import nacl.pwhash
+        except Exception:  # pragma: no cover - pynacl is a hard dependency
+            return False
+        try:
+            return nacl.pwhash.verify(h.encode(), candidate.encode())
+        except nacl.exceptions.InvalidkeyError:
+            return False
+        except Exception:
+            return False
     pw = get_password()
     if not pw:
         return False

--- a/src/hevy2garmin/auth.py
+++ b/src/hevy2garmin/auth.py
@@ -79,9 +79,10 @@ def sign_session(epoch: int = 0) -> str:
 def verify_session(cookie: str | None, current_epoch: int = 0) -> bool:
     """Verify a session cookie: valid signature, not expired, current epoch.
 
-    Accepts both ``v2`` (with epoch) and legacy ``v1`` (epoch-less) cookies so
-    sessions issued before an upgrade survive until their TTL. Returns True when
-    auth is disabled (backward-compatible).
+    Accepts both ``v2`` (with epoch) and legacy ``v1`` cookies. ``v1`` cookies
+    carry no epoch, so they are treated as epoch 0: accepted before any
+    "sign out everywhere" bump and revoked by it (same as ``v2``). Returns True
+    when auth is disabled (backward-compatible).
     """
     if not auth_enabled():
         return True
@@ -96,6 +97,8 @@ def verify_session(cookie: str | None, current_epoch: int = 0) -> bool:
             payload = f"v2.{parts[1]}.{parts[2]}"
             sig = parts[3]
         elif parts[0] == "v1" and len(parts) == 3:
+            if int(current_epoch) != 0:  # v1 has an implicit epoch of 0 → any bump revokes it
+                return False
             ts = int(parts[1])
             payload = f"v1.{parts[1]}"
             sig = parts[2]

--- a/src/hevy2garmin/cli.py
+++ b/src/hevy2garmin/cli.py
@@ -348,6 +348,27 @@ def cmd_skip(args: argparse.Namespace) -> None:
     print(f"✓ Skipped {args.hevy_id}")
 
 
+def cmd_hash_password(args: argparse.Namespace) -> None:
+    """Generate an argon2 hash for the H2G_PASSWORD_HASH dashboard secret."""
+    import nacl.pwhash
+
+    pw = args.password
+    if not pw:
+        pw = getpass.getpass("Dashboard password: ")
+        if pw != getpass.getpass("Confirm password: "):
+            print("✗ Passwords do not match", file=sys.stderr)
+            sys.exit(1)
+    if not pw:
+        print("✗ Empty password", file=sys.stderr)
+        sys.exit(1)
+    print(nacl.pwhash.argon2id.str(pw.encode()).decode())
+    print(
+        "\nSet this value as H2G_PASSWORD_HASH (and leave H2G_PASSWORD unset) so the "
+        "plaintext password never lives in your environment.",
+        file=sys.stderr,
+    )
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog="hevy2garmin",
@@ -422,6 +443,11 @@ def main() -> None:
     serve_parser.add_argument("-p", "--port", type=int, default=8123, help="Port (default: 8123)")
     serve_parser.add_argument("--host", default="0.0.0.0", help="Host (default: 0.0.0.0)")
 
+    # hash-password
+    hashpw_parser = subparsers.add_parser(
+        "hash-password", help="Generate an argon2 hash for H2G_PASSWORD_HASH")
+    hashpw_parser.add_argument("password", nargs="?", help="Password (omit to be prompted securely)")
+
     args = parser.parse_args()
 
     if not args.command:
@@ -452,6 +478,7 @@ def main() -> None:
             "abandon-pending": cmd_abandon_pending,
             "mark-synced": cmd_mark_synced,
             "skip": cmd_skip,
+            "hash-password": cmd_hash_password,
         }
         commands[args.command](args)
     except RuntimeError as e:

--- a/src/hevy2garmin/login_ratelimit.py
+++ b/src/hevy2garmin/login_ratelimit.py
@@ -1,0 +1,120 @@
+"""Dashboard login rate-limiting with exponential backoff.
+
+Protects ``POST /login`` from brute-force guessing. Tracks failed attempts per
+client IP (plus a global counter that blunts distributed guessing from many
+spoofed IPs) and enforces a short lockout that backs off exponentially. State
+lives in the ``app_config`` key-value store so it survives serverless restarts,
+mirroring :mod:`hevy2garmin.ratelimit`.
+
+Tuned for a single human admin: the legit admin knows the password, so 5 tries
+is plenty and lockouts are minutes (not the hours of the Garmin limiter, which
+guards a third-party account). Short caps avoid self-DoS if the admin fumbles.
+
+All functions take a ``db`` (a Database exposing ``get_app_config`` /
+``set_app_config``) and are **best-effort: a storage failure NEVER raises and
+NEVER locks the admin out** — same guarantee as ``ratelimit.py``.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from hevy2garmin._isotime import parse_iso
+
+logger = logging.getLogger("hevy2garmin")
+
+_PREFIX = "login_fail:"
+_GLOBAL_KEY = _PREFIX + "__global__"
+
+_MAX_FAILS = 5             # per-IP failures before the first lockout
+_BASE_SECONDS = 60        # first lockout: 1 minute
+_MAX_SECONDS = 15 * 60    # cap per-IP lockout at 15 minutes
+_GLOBAL_MAX_FAILS = 50    # aggregate failures (all IPs) before a soft global lockout
+_GLOBAL_SECONDS = 15 * 60  # global soft lockout window
+_WINDOW_SECONDS = 15 * 60  # counters reset if the last failure is older than this
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _remaining(db, key: str) -> int:
+    """Seconds left in ``key``'s lockout, or 0. Best-effort → 0 on any error."""
+    try:
+        state = db.get_app_config(key)
+    except Exception:
+        return 0
+    if not state or not state.get("until"):
+        return 0
+    try:
+        until = parse_iso(state["until"])
+    except Exception:
+        return 0
+    remaining = (until - _now()).total_seconds()
+    return int(remaining) if remaining > 0 else 0
+
+
+def _bump(db, key: str, max_fails: int, base: int, cap: int) -> int:
+    """Record one failure against ``key`` with a rolling window and exponential
+    backoff. Returns the resulting lockout length in seconds (0 if not locked)."""
+    now = _now()
+    try:
+        state = db.get_app_config(key) or {}
+    except Exception:
+        state = {}
+
+    fails = int(state.get("fails", 0))
+    ts = state.get("ts")
+    if ts:
+        try:
+            if (now - parse_iso(ts)).total_seconds() > _WINDOW_SECONDS:
+                fails = 0  # rolling window elapsed since last failure → start over
+        except Exception:
+            pass
+    fails += 1
+
+    lock_secs = 0
+    until_iso = None
+    if fails >= max_fails:
+        over = fails - max_fails  # 0 on the first lockout, grows on repeats
+        lock_secs = min(base * (2 ** over), cap)
+        until_iso = (now + timedelta(seconds=lock_secs)).isoformat()
+
+    try:
+        db.set_app_config(key, {"fails": fails, "until": until_iso, "ts": now.isoformat()})
+    except Exception:
+        logger.debug("could not persist login-failure state for %s", key, exc_info=True)
+    return lock_secs
+
+
+def lockout_remaining(db, client_key: str) -> int:
+    """Seconds the given client must wait before another login attempt.
+
+    The effective lockout is the longer of the per-IP and global windows.
+    Best-effort → 0 on any error (never blocks the admin on a DB failure).
+    """
+    return max(_remaining(db, _PREFIX + client_key), _remaining(db, _GLOBAL_KEY))
+
+
+def record_failure(db, client_key: str) -> int:
+    """Record a failed login for ``client_key`` (and the global counter).
+
+    Returns the per-IP lockout seconds that just applied (0 if not yet locked).
+    Callers that want the effective wait should call :func:`lockout_remaining`
+    afterwards, since the global counter may trip independently.
+    """
+    per_ip = _bump(db, _PREFIX + client_key, _MAX_FAILS, _BASE_SECONDS, _MAX_SECONDS)
+    _bump(db, _GLOBAL_KEY, _GLOBAL_MAX_FAILS, _GLOBAL_SECONDS, _GLOBAL_SECONDS)
+    return per_ip
+
+
+def clear_failures(db, client_key: str) -> None:
+    """Reset the per-IP counter after a successful login (resets the backoff).
+
+    The global counter is intentionally left as-is: one correct login from the
+    admin should not wipe an in-progress distributed-attack signal.
+    """
+    try:
+        db.set_app_config(_PREFIX + client_key, {"fails": 0, "until": None, "ts": None})
+    except Exception:
+        logger.debug("could not clear login failures for %s", client_key, exc_info=True)

--- a/src/hevy2garmin/login_ratelimit.py
+++ b/src/hevy2garmin/login_ratelimit.py
@@ -104,6 +104,9 @@ def record_failure(db, client_key: str) -> int:
     afterwards, since the global counter may trip independently.
     """
     per_ip = _bump(db, _PREFIX + client_key, _MAX_FAILS, _BASE_SECONDS, _MAX_SECONDS)
+    # Tradeoff: the global counter can, via a spoofed X-Forwarded-For, briefly lock
+    # out the legit admin too (availability DoS). Acceptable for a single-admin tool
+    # — it only delays login by minutes and never persists past the rolling window.
     _bump(db, _GLOBAL_KEY, _GLOBAL_MAX_FAILS, _GLOBAL_SECONDS, _GLOBAL_SECONDS)
     return per_ip
 

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -17,9 +17,11 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from jinja2 import Environment, FileSystemLoader
 
-from hevy2garmin import db, __version__
+from hevy2garmin import db, login_ratelimit, __version__
 from hevy2garmin.db_interface import NoWritableDatabaseError
-from hevy2garmin.auth import auth_enabled, verify_session, sign_session, check_password, SESSION_COOKIE
+from hevy2garmin.auth import (
+    auth_enabled, verify_session, sign_session, check_password, SESSION_COOKIE, session_ttl,
+)
 from hevy2garmin.config import is_configured, load_config, save_config
 from hevy2garmin.demo import is_demo_mode
 from hevy2garmin.ratelimit import record_rate_limit, cooldown_remaining, clear_rate_limit, format_cooldown
@@ -330,6 +332,53 @@ async def _startup_autosync() -> None:
         _schedule_autosync(interval)
 
 
+def client_ip(request: Request) -> str:
+    """Best-effort real client IP.
+
+    Behind Vercel/Cloudflare the edge populates ``X-Forwarded-For`` and the
+    leftmost entry is the original client (proxies append their hops on the
+    right). Falls back to ``X-Real-IP``, then the socket peer, and finally the
+    literal ``"unknown"`` bucket for header-less clients (so a missing header
+    can't create unbounded rate-limit buckets).
+    """
+    xff = request.headers.get("x-forwarded-for")
+    if xff:
+        return xff.split(",")[0].strip()
+    xrip = request.headers.get("x-real-ip")
+    if xrip:
+        return xrip.strip()
+    return request.client.host if request.client else "unknown"
+
+
+def is_https(request: Request) -> bool:
+    """True when the original request was HTTPS.
+
+    On Vercel, TLS terminates at the edge and the app sees ``http`` plus an
+    ``X-Forwarded-Proto: https`` header, so we check both.
+    """
+    if request.url.scheme == "https":
+        return True
+    return request.headers.get("x-forwarded-proto", "").split(",")[0].strip() == "https"
+
+
+_epoch_cache = 0
+
+
+def _session_epoch() -> int:
+    """Current 'sign out everywhere' epoch from app_config.
+
+    Best-effort: on a DB error, return the last value we successfully read
+    (default 0) so a transient outage never spuriously invalidates sessions.
+    """
+    global _epoch_cache
+    try:
+        v = db.get_db().get_app_config("session_epoch")
+        _epoch_cache = int(v.get("n", 0)) if isinstance(v, dict) else 0
+    except Exception:
+        return _epoch_cache
+    return _epoch_cache
+
+
 _is_configured_cache: bool | None = None
 
 @app.middleware("http")
@@ -343,11 +392,11 @@ async def check_setup(request: Request, call_next):
         return await call_next(request)
 
     # ── Dashboard auth gate ──────────────────────────────────────────────
-    # When H2G_PASSWORD is set, all routes except /login and /api/cron/*
+    # When a password is set, all routes except /login and /api/cron/*
     # require a valid session cookie. Without it, redirect to /login.
     if auth_enabled() and path not in ("/login",) and not path.startswith("/api/cron/"):
         session_cookie = request.cookies.get(SESSION_COOKIE)
-        if not verify_session(session_cookie):
+        if not verify_session(session_cookie, _session_epoch()):
             if path.startswith("/api/"):
                 from starlette.responses import Response
                 return Response("Unauthorized", status_code=401)
@@ -377,8 +426,33 @@ async def check_setup(request: Request, call_next):
     # Auto-set auth cookie on every GET so it survives cookie clears and new devices.
     # SameSite=strict prevents cross-origin POSTs from using it (CSRF protection).
     if secret and request.method == "GET" and not request.cookies.get("h2g_auth"):
-        response.set_cookie("h2g_auth", secret, httponly=True, samesite="strict", max_age=365 * 86400)
+        response.set_cookie("h2g_auth", secret, httponly=True, samesite="strict",
+                            secure=is_https(request), max_age=365 * 86400)
 
+    return response
+
+
+@app.middleware("http")
+async def security_headers(request: Request, call_next):
+    """Defense-in-depth response headers. Registered after check_setup so it is
+    the outermost middleware and stamps every response — including redirects and
+    the lock/DB pages."""
+    response = await call_next(request)
+    response.headers.setdefault("X-Content-Type-Options", "nosniff")
+    response.headers.setdefault("X-Frame-Options", "DENY")
+    response.headers.setdefault("Referrer-Policy", "no-referrer")
+    response.headers.setdefault("Cross-Origin-Opener-Policy", "same-origin")
+    # Pragmatic CSP: only the high-value, no-cost directives. A strict
+    # script/style policy is deferred because the templates use inline JS and
+    # load scripts from CDNs (would need 'unsafe-inline').
+    response.headers.setdefault(
+        "Content-Security-Policy",
+        "frame-ancestors 'none'; form-action 'self'; base-uri 'self'",
+    )
+    if is_https(request):
+        response.headers.setdefault(
+            "Strict-Transport-Security", "max-age=31536000; includeSubDomains"
+        )
     return response
 
 
@@ -387,7 +461,7 @@ async def check_setup(request: Request, call_next):
 @app.get("/login", response_class=HTMLResponse)
 async def login_page(request: Request):
     """Show login form. Redirects to dashboard if already authenticated or auth disabled."""
-    if not auth_enabled() or verify_session(request.cookies.get(SESSION_COOKIE)):
+    if not auth_enabled() or verify_session(request.cookies.get(SESSION_COOKIE), _session_epoch()):
         return RedirectResponse("/")
     error = request.query_params.get("error")
     return HTMLResponse(_jinja_env.get_template("login.html").render(error=error))
@@ -395,20 +469,44 @@ async def login_page(request: Request):
 
 @app.post("/login")
 async def login_submit(request: Request, password: str = Form(...)):
-    """Verify password, set session cookie, redirect to dashboard."""
+    """Verify password (rate-limited), set session cookie, redirect to dashboard."""
     next_url = request.query_params.get("next", "/")
     # Prevent open redirect: only allow relative paths
     if not next_url.startswith("/") or next_url.startswith("//"):
         next_url = "/"
-    if not check_password(password):
+
+    key = client_ip(request)
+    try:
+        store = db.get_db()
+    except Exception:
+        store = None  # DB unavailable → skip the limiter (never lock the admin out on an outage)
+
+    def _error(msg: str, status: int) -> HTMLResponse:
         return HTMLResponse(
-            _jinja_env.get_template("login.html").render(error="Wrong password."),
-            status_code=401,
+            _jinja_env.get_template("login.html").render(error=msg),
+            status_code=status,
         )
+
+    # Rate limit: check the lockout BEFORE comparing credentials.
+    remaining = login_ratelimit.lockout_remaining(store, key) if store else 0
+    if remaining > 0:
+        return _error(f"Too many attempts. Try again in {format_cooldown(remaining)}.", 429)
+
+    if not check_password(password):
+        remaining = 0
+        if store:
+            login_ratelimit.record_failure(store, key)
+            remaining = login_ratelimit.lockout_remaining(store, key)
+        if remaining > 0:
+            return _error(f"Too many attempts. Try again in {format_cooldown(remaining)}.", 429)
+        return _error("Wrong password.", 401)
+
+    if store:
+        login_ratelimit.clear_failures(store, key)
     response = RedirectResponse(next_url, status_code=303)
     response.set_cookie(
-        SESSION_COOKIE, sign_session(),
-        httponly=True, samesite="strict", max_age=30 * 24 * 3600,
+        SESSION_COOKIE, sign_session(_session_epoch()),
+        httponly=True, samesite="strict", secure=is_https(request), max_age=session_ttl(),
     )
     return response
 
@@ -416,6 +514,24 @@ async def login_submit(request: Request, password: str = Form(...)):
 @app.post("/logout")
 async def logout():
     """Clear session cookie and redirect to login."""
+    response = RedirectResponse("/login", status_code=303)
+    response.delete_cookie(SESSION_COOKIE)
+    return response
+
+
+@app.post("/logout-all")
+async def logout_all():
+    """Sign out everywhere: bump the server-side epoch so every outstanding
+    session cookie (on all devices) stops validating."""
+    global _epoch_cache
+    try:
+        store = db.get_db()
+        cur = store.get_app_config("session_epoch")
+        n = int(cur.get("n", 0)) if isinstance(cur, dict) else 0
+        store.set_app_config("session_epoch", {"n": n + 1})
+        _epoch_cache = n + 1
+    except Exception:
+        logger.warning("could not bump session epoch for /logout-all", exc_info=True)
     response = RedirectResponse("/login", status_code=303)
     response.delete_cookie(SESSION_COOKIE)
     return response
@@ -533,6 +649,7 @@ async def setup_page(request: Request):
 
 @app.post("/setup")
 async def setup_save(
+    request: Request,
     hevy_api_key: str = Form(""),
     garmin_email: str = Form(""),
     garmin_password: str = Form(""),
@@ -668,7 +785,8 @@ async def setup_save(
     # Set auth cookie if HEVY2GARMIN_SECRET is configured (cloud deployments)
     secret = os.environ.get("HEVY2GARMIN_SECRET")
     if secret:
-        response.set_cookie("h2g_auth", secret, httponly=True, samesite="strict", max_age=365 * 86400)
+        response.set_cookie("h2g_auth", secret, httponly=True, samesite="strict",
+                            secure=is_https(request), max_age=365 * 86400)
     return response
 
 

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -531,7 +531,11 @@ async def logout_all():
         store.set_app_config("session_epoch", {"n": n + 1})
         _epoch_cache = n + 1
     except Exception:
+        # Don't pretend success: the epoch never advanced, so other devices are
+        # still signed in. Keep this session and surface the error so the admin
+        # can retry, instead of redirecting to /login as if it worked.
         logger.warning("could not bump session epoch for /logout-all", exc_info=True)
+        return RedirectResponse("/settings?err=logout_all", status_code=303)
     response = RedirectResponse("/login", status_code=303)
     response.delete_cookie(SESSION_COOKIE)
     return response
@@ -1121,7 +1125,7 @@ async def settings_page(request: Request):
     merge_extra_types = ", ".join(
         t for t in config.get("merge_activity_types", ["strength_training"]) if t != "strength_training"
     )
-    return _render("settings.html", config=config, unmapped=sorted(unmapped.items(), key=lambda x: -x[1]), merge_extra_types=merge_extra_types)
+    return _render("settings.html", config=config, unmapped=sorted(unmapped.items(), key=lambda x: -x[1]), merge_extra_types=merge_extra_types, err=request.query_params.get("err"))
 
 
 @app.post("/settings")

--- a/src/hevy2garmin/templates/base.html
+++ b/src/hevy2garmin/templates/base.html
@@ -227,11 +227,49 @@
             <a href="/routines" {% if request and request.url.path == '/routines' %}class="active"{% endif %}>Routines</a>
             <a href="/history" {% if request and request.url.path == '/history' %}class="active"{% endif %}>History</a>
             <a href="/mappings" {% if request and request.url.path == '/mappings' %}class="active"{% endif %}>Mappings</a>
+            {% if not auth_enabled %}
             <a href="/settings" {% if request and request.url.path == '/settings' %}class="active"{% endif %}>Settings</a>
+            {% endif %}
             {% if auth_enabled %}
-            <form method="post" action="/logout" style="display:inline; margin-left: 4px;">
-                <button type="submit" style="background:none; border:none; color:var(--text-muted); font:inherit; font-size:13px; padding:8px 12px; cursor:pointer; border-radius:var(--radius-sm);" onmouseover="this.style.color='var(--red)'" onmouseout="this.style.color='var(--text-muted)'">&times; Sign out</button>
-            </form>
+            <div class="account-menu" style="position:relative; margin-left:8px;">
+                <button type="button" id="accountMenuBtn" aria-haspopup="menu" aria-expanded="false"
+                        onclick="var m=document.getElementById('accountMenu'),o=this.getAttribute('aria-expanded')==='true';this.setAttribute('aria-expanded',(!o).toString());m.style.display=o?'none':'block';"
+                        style="display:flex; align-items:center; gap:8px; padding:5px 8px 5px 5px; border:1px solid var(--border); background:transparent; border-radius:999px; cursor:pointer;">
+                    <span style="width:30px; height:30px; border-radius:50%; background:linear-gradient(135deg,var(--accent),var(--blue)); display:grid; place-items:center; color:#fff; font-size:13px; font-weight:700;">{{ user_initials or 'ME' }}</span>
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--text-secondary)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+                </button>
+                <div id="accountMenu" role="menu" style="display:none; position:absolute; right:0; top:calc(100% + 10px); width:264px; background:var(--bg-card); border:1px solid var(--border); border-radius:var(--radius); box-shadow:0 16px 40px rgba(0,0,0,0.5); overflow:hidden; z-index:60;">
+                    <div style="display:flex; align-items:center; gap:12px; padding:16px;">
+                        <span style="width:40px; height:40px; border-radius:50%; background:linear-gradient(135deg,var(--accent),var(--blue)); display:grid; place-items:center; color:#fff; font-size:15px; font-weight:700; flex-shrink:0;">{{ user_initials or 'ME' }}</span>
+                        <div style="min-width:0;">
+                            <div style="font-size:14px; font-weight:600; color:var(--text-primary);">Signed in</div>
+                            <div style="font-size:12px; color:var(--text-muted); display:flex; align-items:center; gap:5px; margin-top:1px;">
+                                <span style="width:6px; height:6px; border-radius:50%; background:var(--accent); box-shadow:0 0 6px var(--accent);"></span>
+                                This device &middot; active now
+                            </div>
+                        </div>
+                    </div>
+                    <div style="height:1px; background:var(--border-subtle);"></div>
+                    <a href="/settings" role="menuitem" style="display:flex; align-items:center; gap:10px; padding:11px 16px; font-size:14px; font-weight:500; color:var(--text-secondary);">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+                        Settings &amp; sessions
+                    </a>
+                    <form method="post" action="/logout" style="padding:6px 10px 10px; margin:0;">
+                        <button type="submit" style="width:100%; display:flex; align-items:center; justify-content:center; gap:8px; padding:10px; border-radius:var(--radius-sm); border:1px solid rgba(239,68,68,0.25); background:rgba(239,68,68,0.08); color:#f87171; font:inherit; font-size:14px; font-weight:600; cursor:pointer;">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+                            Sign out
+                        </button>
+                        <div style="font-size:11px; color:var(--text-muted); text-align:center; margin-top:8px;">Signs out this device only.</div>
+                    </form>
+                </div>
+            </div>
+            <script>
+            document.addEventListener('click', function (e) {
+                var b = document.getElementById('accountMenuBtn'), m = document.getElementById('accountMenu');
+                if (!b || !m) return;
+                if (!b.contains(e.target) && !m.contains(e.target)) { m.style.display = 'none'; b.setAttribute('aria-expanded', 'false'); }
+            });
+            </script>
             {% endif %}
         </div>
     </nav>

--- a/src/hevy2garmin/templates/settings.html
+++ b/src/hevy2garmin/templates/settings.html
@@ -274,6 +274,40 @@
     </button>
 </form>
 
+{% if auth_enabled %}
+<!-- Sessions & Security -->
+<div class="card section" style="border-color: rgba(239,68,68,0.18); margin-top: 28px;">
+    <div style="display:flex; align-items:center; gap:8px; margin-bottom:8px;">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#f87171" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+        <span class="card-title">Sessions &amp; Security</span>
+    </div>
+    <p class="section-description">Manage where you're signed in. Signing out everywhere invalidates every active session cookie on all devices &mdash; you'll need to sign in again on each one.</p>
+    <div class="list-item" style="background: var(--bg-secondary); border:1px solid var(--border); border-radius: var(--radius-sm); padding:14px 16px;">
+        <div style="display:flex; align-items:center; gap:12px;">
+            <span style="width:36px; height:36px; border-radius:8px; background:rgba(16,185,129,0.12); display:grid; place-items:center;">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#34d399" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+            </span>
+            <div>
+                <div style="font-size:14px; font-weight:600; color:var(--text-primary);">This device</div>
+                <div style="font-size:12px; color:var(--text-muted);">Current session &middot; active now</div>
+            </div>
+        </div>
+        <span class="badge badge-success">Active</span>
+    </div>
+    <div style="display:flex; align-items:center; justify-content:space-between; gap:16px; flex-wrap:wrap; margin-top:16px;">
+        <div style="font-size:13px; color:var(--text-secondary); max-width:460px;">
+            <strong style="color:var(--text-primary);">Sign out of all devices.</strong> Ends every session, including this one. Use this if you think a session may be compromised.
+        </div>
+        <form method="post" action="/logout-all" style="margin:0;" onsubmit="return confirm('Sign out of ALL devices? Every active session will be invalidated.');">
+            <button type="submit" class="btn" style="background:rgba(239,68,68,0.1); color:#f87171; border:1px solid rgba(239,68,68,0.3);">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+                Sign out all devices
+            </button>
+        </form>
+    </div>
+</div>
+{% endif %}
+
 {% if unmapped %}
 <div class="card" style="margin-top: 28px;">
     <div class="card-header">

--- a/src/hevy2garmin/templates/settings.html
+++ b/src/hevy2garmin/templates/settings.html
@@ -282,6 +282,11 @@
         <span class="card-title">Sessions &amp; Security</span>
     </div>
     <p class="section-description">Manage where you're signed in. Signing out everywhere invalidates every active session cookie on all devices &mdash; you'll need to sign in again on each one.</p>
+    {% if err == 'logout_all' %}
+    <div style="background: rgba(239,68,68,0.1); border:1px solid rgba(239,68,68,0.3); color:#f87171; border-radius: var(--radius-sm); padding:10px 14px; font-size:13px; margin-bottom:14px;">
+        Couldn't sign out all devices &mdash; the database write failed. Please try again.
+    </div>
+    {% endif %}
     <div class="list-item" style="background: var(--bg-secondary); border:1px solid var(--border); border-radius: var(--radius-sm); padding:14px 16px;">
         <div style="display:flex; align-items:center; gap:12px;">
             <span style="width:36px; height:36px; border-radius:8px; background:rgba(16,185,129,0.12); display:grid; place-items:center;">

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -7,7 +7,9 @@ from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
-from hevy2garmin.auth import sign_session, verify_session, check_password, auth_enabled
+from hevy2garmin.auth import sign_session, verify_session, check_password, auth_enabled, session_ttl
+from hevy2garmin.server import client_ip, is_https
+from starlette.requests import Request
 
 
 @pytest.fixture
@@ -100,7 +102,7 @@ class TestPasswordAuthHelpers:
     def test_sign_verify_round_trip(self) -> None:
         with patch.dict(os.environ, {"H2G_PASSWORD": "secret123"}):
             cookie = sign_session()
-            assert cookie.startswith("v1.")
+            assert cookie.startswith("v2.")
             assert verify_session(cookie) is True
 
     def test_reject_none(self) -> None:
@@ -111,7 +113,7 @@ class TestPasswordAuthHelpers:
         with patch.dict(os.environ, {"H2G_PASSWORD": "secret123"}):
             cookie = sign_session()
             parts = cookie.split(".")
-            parts[2] = "0" * len(parts[2])
+            parts[-1] = "0" * len(parts[-1])  # tamper the signature
             assert verify_session(".".join(parts)) is False
 
     def test_check_password_correct(self) -> None:
@@ -171,3 +173,182 @@ class TestPasswordAuthRoutes:
         resp = client_with_password.get("/api/sync-one")
         # API routes should get 401, not a redirect
         assert resp.status_code == 401
+
+
+def _make_request(headers=None, client=("9.9.9.9", 12345), scheme="http") -> Request:
+    raw = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    scope = {
+        "type": "http", "method": "GET", "path": "/", "raw_path": b"/",
+        "query_string": b"", "headers": raw, "client": client,
+        "scheme": scheme, "server": ("testserver", 80),
+    }
+    return Request(scope)
+
+
+class TestClientIp:
+    """Unit tests for the proxy-aware client IP / HTTPS helpers."""
+
+    def test_xff_leftmost(self) -> None:
+        r = _make_request({"x-forwarded-for": "1.2.3.4, 10.0.0.1"})
+        assert client_ip(r) == "1.2.3.4"
+
+    def test_x_real_ip_fallback(self) -> None:
+        r = _make_request({"x-real-ip": "5.6.7.8"})
+        assert client_ip(r) == "5.6.7.8"
+
+    def test_socket_peer_fallback(self) -> None:
+        assert client_ip(_make_request(client=("7.7.7.7", 1))) == "7.7.7.7"
+
+    def test_is_https_scheme(self) -> None:
+        assert is_https(_make_request(scheme="https")) is True
+
+    def test_is_https_forwarded_proto(self) -> None:
+        assert is_https(_make_request({"x-forwarded-proto": "https"})) is True
+
+    def test_is_https_false_for_plain_http(self) -> None:
+        assert is_https(_make_request()) is False
+
+
+class TestHardenedHelpers:
+    """Hashed password, dedicated secret, and session revocation."""
+
+    def test_hashed_password_login(self) -> None:
+        import nacl.pwhash
+        h = nacl.pwhash.argon2id.str(b"argon-pw").decode()
+        with patch.dict(os.environ, {"H2G_PASSWORD_HASH": h}, clear=False):
+            os.environ.pop("H2G_PASSWORD", None)
+            assert auth_enabled() is True
+            assert check_password("argon-pw") is True
+            assert check_password("nope") is False
+
+    def test_session_epoch_revocation(self) -> None:
+        with patch.dict(os.environ, {"H2G_PASSWORD": "secret123"}):
+            cookie = sign_session(epoch=0)
+            assert verify_session(cookie, current_epoch=0) is True
+            # bumping the epoch invalidates every outstanding cookie
+            assert verify_session(cookie, current_epoch=1) is False
+            # a cookie signed at the new epoch validates again
+            assert verify_session(sign_session(epoch=1), current_epoch=1) is True
+
+    def test_legacy_v1_cookie_still_accepted(self) -> None:
+        import hashlib
+        import hmac
+        import time
+        with patch.dict(os.environ, {"H2G_PASSWORD": "secret123"}):
+            from hevy2garmin.auth import _secret
+            ts = str(int(time.time()))
+            sig = hmac.new(_secret(), f"v1.{ts}".encode(), hashlib.sha256).hexdigest()[:32]
+            assert verify_session(f"v1.{ts}.{sig}") is True
+
+    def test_session_ttl_default(self) -> None:
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("H2G_SESSION_TTL_DAYS", None)
+            assert session_ttl() == 30 * 24 * 3600
+
+    def test_session_ttl_from_env(self) -> None:
+        with patch.dict(os.environ, {"H2G_SESSION_TTL_DAYS": "3"}):
+            assert session_ttl() == 3 * 24 * 3600
+
+    def test_session_ttl_invalid_falls_back(self) -> None:
+        with patch.dict(os.environ, {"H2G_SESSION_TTL_DAYS": "abc"}):
+            assert session_ttl() == 30 * 24 * 3600
+
+    def test_verify_respects_configured_ttl(self) -> None:
+        import hashlib
+        import hmac
+        import time
+        with patch.dict(os.environ, {"H2G_PASSWORD": "secret123", "H2G_SESSION_TTL_DAYS": "1"}):
+            from hevy2garmin.auth import _secret
+            old_ts = int(time.time()) - 2 * 24 * 3600  # 2 days old, TTL is 1 day
+            payload = f"v2.{old_ts}.0"
+            sig = hmac.new(_secret(), payload.encode(), hashlib.sha256).hexdigest()[:32]
+            assert verify_session(f"{payload}.{sig}", 0) is False   # expired
+            assert verify_session(sign_session(0), 0) is True        # fresh still valid
+
+
+class TestLoginRateLimit:
+    """Integration: brute-force protection on POST /login."""
+
+    PW = "rl-test-pw"
+
+    @pytest.fixture
+    def client(self):
+        with patch.dict(os.environ, {"H2G_PASSWORD": self.PW}):
+            os.environ.pop("HEVY2GARMIN_SECRET", None)
+            from hevy2garmin.server import app
+            yield TestClient(app, follow_redirects=False)
+
+    @staticmethod
+    def _reset(ip: str) -> None:
+        from hevy2garmin import db as _db, login_ratelimit
+        store = _db.get_db()
+        login_ratelimit.clear_failures(store, ip)
+        store.set_app_config("login_fail:__global__", {"fails": 0, "until": None, "ts": None})
+
+    def test_lockout_after_attempts_returns_429(self, client) -> None:
+        ip = "203.0.113.21"
+        self._reset(ip)
+        last = None
+        for _ in range(6):
+            last = client.post("/login", data={"password": "wrong"},
+                               headers={"X-Forwarded-For": ip})
+        assert last.status_code == 429
+        assert "Too many attempts" in last.text
+
+    def test_correct_password_within_limit_succeeds(self, client) -> None:
+        ip = "203.0.113.22"
+        self._reset(ip)
+        client.post("/login", data={"password": "wrong"}, headers={"X-Forwarded-For": ip})
+        resp = client.post("/login", data={"password": self.PW},
+                           headers={"X-Forwarded-For": ip})
+        assert resp.status_code == 303
+        assert "h2g_session" in resp.cookies
+
+    def test_lockout_expiry_allows_login(self, client) -> None:
+        from datetime import datetime, timedelta, timezone
+        from hevy2garmin import db as _db
+        ip = "203.0.113.23"
+        store = _db.get_db()
+        store.set_app_config("login_fail:__global__", {"fails": 0, "until": None, "ts": None})
+        past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        store.set_app_config("login_fail:" + ip, {"fails": 9, "until": past, "ts": past})
+        resp = client.post("/login", data={"password": self.PW},
+                           headers={"X-Forwarded-For": ip})
+        assert resp.status_code == 303
+
+    def test_secure_cookie_only_on_https(self, client) -> None:
+        ip = "203.0.113.24"
+        self._reset(ip)
+        https = client.post("/login", data={"password": self.PW},
+                            headers={"X-Forwarded-For": ip, "X-Forwarded-Proto": "https"})
+        set_https = " ".join(v for k, v in https.headers.multi_items() if k.lower() == "set-cookie")
+        assert "h2g_session" in set_https and "Secure" in set_https
+
+        self._reset(ip)
+        http = client.post("/login", data={"password": self.PW},
+                           headers={"X-Forwarded-For": ip})
+        set_http = " ".join(v for k, v in http.headers.multi_items() if k.lower() == "set-cookie")
+        assert "h2g_session" in set_http and "Secure" not in set_http
+
+
+class TestSecurityHeaders:
+    """Defense-in-depth headers on every response."""
+
+    @pytest.fixture
+    def client(self):
+        with patch.dict(os.environ, {"H2G_PASSWORD": "x"}):
+            from hevy2garmin.server import app
+            yield TestClient(app, follow_redirects=False)
+
+    def test_baseline_headers_present(self, client) -> None:
+        resp = client.get("/login")
+        assert resp.headers.get("x-frame-options") == "DENY"
+        assert resp.headers.get("x-content-type-options") == "nosniff"
+        assert resp.headers.get("referrer-policy") == "no-referrer"
+        assert "frame-ancestors 'none'" in resp.headers.get("content-security-policy", "")
+
+    def test_hsts_only_on_https(self, client) -> None:
+        plain = client.get("/login")
+        assert "strict-transport-security" not in {k.lower() for k in plain.headers.keys()}
+        secure = client.get("/login", headers={"X-Forwarded-Proto": "https"})
+        assert secure.headers.get("strict-transport-security")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -240,6 +240,18 @@ class TestHardenedHelpers:
             sig = hmac.new(_secret(), f"v1.{ts}".encode(), hashlib.sha256).hexdigest()[:32]
             assert verify_session(f"v1.{ts}.{sig}") is True
 
+    def test_v1_cookie_revoked_by_epoch_bump(self) -> None:
+        import hashlib
+        import hmac
+        import time
+        with patch.dict(os.environ, {"H2G_PASSWORD": "secret123"}):
+            from hevy2garmin.auth import _secret
+            ts = str(int(time.time()))
+            sig = hmac.new(_secret(), f"v1.{ts}".encode(), hashlib.sha256).hexdigest()[:32]
+            cookie = f"v1.{ts}.{sig}"
+            assert verify_session(cookie, 0) is True    # accepted before any sign-out-everywhere
+            assert verify_session(cookie, 1) is False   # revoked once the epoch is bumped
+
     def test_session_ttl_default(self) -> None:
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("H2G_SESSION_TTL_DAYS", None)

--- a/tests/test_login_ratelimit.py
+++ b/tests/test_login_ratelimit.py
@@ -1,0 +1,105 @@
+"""Tests for the dashboard login rate-limiter (per-IP + global backoff)."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from hevy2garmin.login_ratelimit import (
+    lockout_remaining,
+    record_failure,
+    clear_failures,
+    _PREFIX,
+    _GLOBAL_KEY,
+    _MAX_FAILS,
+    _BASE_SECONDS,
+    _MAX_SECONDS,
+    _GLOBAL_MAX_FAILS,
+    _WINDOW_SECONDS,
+)
+
+
+class FakeDB:
+    """In-memory app_config store (same shape as tests/test_ratelimit.py)."""
+
+    def __init__(self):
+        self._c = {}
+
+    def get_app_config(self, key):
+        return self._c.get(key)
+
+    def set_app_config(self, key, value):
+        self._c[key] = value
+
+
+def test_under_threshold_no_lockout():
+    db = FakeDB()
+    for _ in range(_MAX_FAILS - 1):  # 4 failures
+        assert record_failure(db, "ip") == 0
+    assert lockout_remaining(db, "ip") == 0
+
+
+def test_lockout_after_threshold():
+    db = FakeDB()
+    secs = 0
+    for _ in range(_MAX_FAILS):  # 5th failure trips it
+        secs = record_failure(db, "ip")
+    assert secs == _BASE_SECONDS
+    assert lockout_remaining(db, "ip") > 0
+
+
+def test_backoff_grows_and_caps():
+    db = FakeDB()
+    seqs = [record_failure(db, "ip") for _ in range(12)]
+    assert seqs[_MAX_FAILS - 1] == _BASE_SECONDS       # first lockout = base
+    assert seqs[_MAX_FAILS] == _BASE_SECONDS * 2        # next doubles
+    assert seqs[-1] == _MAX_SECONDS                     # capped
+
+
+def test_clear_on_success_resets():
+    db = FakeDB()
+    for _ in range(_MAX_FAILS):
+        record_failure(db, "ip")
+    assert lockout_remaining(db, "ip") > 0
+    clear_failures(db, "ip")
+    assert lockout_remaining(db, "ip") == 0
+    # counter starts fresh: one failure is well below the threshold again
+    assert record_failure(db, "ip") == 0
+
+
+def test_expired_lockout_reports_zero():
+    db = FakeDB()
+    past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+    db.set_app_config(_PREFIX + "ip", {"fails": 9, "until": past, "ts": past})
+    assert lockout_remaining(db, "ip") == 0
+
+
+def test_window_resets_stale_counter():
+    db = FakeDB()
+    stale = (datetime.now(timezone.utc) - timedelta(seconds=_WINDOW_SECONDS + 30)).isoformat()
+    db.set_app_config(_PREFIX + "ip", {"fails": _MAX_FAILS - 1, "until": None, "ts": stale})
+    # last failure is older than the window → counter restarts at 1, no lockout
+    assert record_failure(db, "ip") == 0
+    assert db.get_app_config(_PREFIX + "ip")["fails"] == 1
+
+
+def test_global_counter_trips_for_fresh_ip():
+    db = FakeDB()
+    for i in range(_GLOBAL_MAX_FAILS):  # each a different IP → per-IP never locks
+        record_failure(db, f"ip-{i}")
+    assert db.get_app_config(_GLOBAL_KEY)["until"] is not None
+    # a brand-new IP is still throttled by the global soft lockout
+    assert lockout_remaining(db, "brand-new") > 0
+
+
+def test_storage_failure_never_raises():
+    class BrokenDB:
+        def get_app_config(self, key):
+            raise RuntimeError("db down")
+
+        def set_app_config(self, key, value):
+            raise RuntimeError("db down")
+
+    db = BrokenDB()
+    # must not raise, and must never lock the admin out on a storage failure
+    assert record_failure(db, "ip") == 0
+    assert lockout_remaining(db, "ip") == 0
+    clear_failures(db, "ip")


### PR DESCRIPTION
## What changed and why

Adds a security layer to the dashboard login so it can be safely exposed on a public URL, while keeping the system simple (single admin). The dashboard already had shared-password auth, but no brute-force protection and no session/cookie hardening. This PR rate-limits the login, lets the password be stored hashed (never plaintext), hardens the session cookie, sends security headers on every response, and reworks the logout UI. Backward compatible: password-only (`H2G_PASSWORD`) deployments keep working, and with no password set the dashboard stays open (auth is opt-in).

## Screenshots

Account menu in the nav — the `Settings` link moved into the profile menu:

<img width="1000" alt="account menu dropdown" src="https://github.com/user-attachments/assets/1a118df4-05e2-45b5-9d8c-7788906ac615" />

"Sessions & Security" card on the Settings page ("Sign out all devices"):

<img width="1000" alt="sessions and security card" src="https://github.com/user-attachments/assets/ee01a1c1-a737-4974-b2aa-b956e7a33c18" />

Nav bar — account avatar, no `Settings` link:

<img width="1000" alt="nav bar" src="https://github.com/user-attachments/assets/bba4be97-f0a5-4cb6-835b-0c3e3ee388cf" />

<details><summary>Full Settings page</summary>

<img width="1000" alt="full settings page" src="https://github.com/user-attachments/assets/052e50e2-d289-471b-9274-313f2fd4d7ba" />

</details>

## Technical details

### Files changed
- `src/hevy2garmin/login_ratelimit.py` (new) — login rate limiter (per-IP + global counter, exponential backoff, best-effort on `app_cache`).
- `src/hevy2garmin/auth.py` — argon2 hash (`H2G_PASSWORD_HASH`), dedicated signing secret (`H2G_SECRET`), `v2` session cookie with an epoch for revocation (still accepts `v1`), TTL configurable via `H2G_SESSION_TTL_DAYS` (default 30 days).
- `src/hevy2garmin/server.py` — `client_ip`/`is_https` helpers; rate limiting + `Secure` cookie in `login_submit`; a second security-headers middleware; `POST /logout-all` route.
- `src/hevy2garmin/cli.py` — `hash-password` subcommand.
- `src/hevy2garmin/templates/base.html` — account menu (avatar + dropdown) in the nav; the Settings link moves into the profile menu (kept in the bar only when auth is disabled).
- `src/hevy2garmin/templates/settings.html` — "Sessions & Security" card (current session + "Sign out all devices").
- `tests/test_login_ratelimit.py` (new), `tests/test_auth.py` (extended).
- `.env.example`, `README.md`, `CHANGELOG.md` — docs.

### Approach and trade-offs
Keeps the stateless HMAC-cookie model (a good fit for serverless) — no JWT, Redis, session store, or multi-user tables. All persistent state (rate-limit counters, session epoch) uses the existing `app_cache` key-value store, which works on both SQLite and Postgres and survives serverless restarts. The CSP ships only the zero-cost, high-value directives (`frame-ancestors`, `form-action`, `base-uri`); a strict `script-src` policy is deliberately deferred because the templates use inline JS + CDN scripts.

### How to test
- `PYTHONPATH=src pytest tests/ -q` → 442 passed, 7 skipped.
- `PYTHONPATH=src pytest tests/test_login_ratelimit.py tests/test_auth.py -q`
- Manual:
  - `H2G_PASSWORD='...' PYTHONPATH=src python -m hevy2garmin.cli serve --port 8123`, then fail the password 5+ times → HTTP 429 with a cooldown.
  - `PYTHONPATH=src python -m hevy2garmin.cli hash-password` → set the output as `H2G_PASSWORD_HASH` (unset `H2G_PASSWORD`) and log in.
  - `curl -sI` shows `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: no-referrer`.

### Breaking changes
None. The session cookie format changed from `v1` to `v2` (to support revocation), but `v1` cookies are still accepted until they expire — no forced logout. No migrations, no removed env vars.

### Checklist
- [x] Tests added or updated
- [x] No sensitive data in logs or responses
- [x] Migrations are backward-compatible (N/A — no migrations)
- [ ] Feature flag added (N/A)

## Security notes
- Constant-time password comparison: plaintext via `hmac.compare_digest`, hash via libsodium `nacl.pwhash.verify`.
- Login rate limiting is best-effort: a storage failure never locks the admin out or raises; the error message is generic ("Wrong password.") to avoid user enumeration.
- Session cookie: `HttpOnly`, `SameSite=Strict`, `Secure` over HTTPS, signed with HMAC-SHA256; absolute TTL of 30 days by default, configurable via `H2G_SESSION_TTL_DAYS`.
- Client IP is taken from `X-Forwarded-For` (leftmost, Vercel's convention); since XFF is spoofable, the global counter caps distributed guessing from forged IPs.
- Auth is opt-in: with no `H2G_PASSWORD`/`H2G_PASSWORD_HASH` the dashboard stays open — set a password before exposing it on a public URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
