### PR TITLE
release: 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-07-24
+
 ### Added
 - Hardened dashboard authentication. Failed logins are now rate-limited per client IP with exponential backoff and a global cap (HTTP 429 on lockout), so the login can't be brute-forced. The dashboard password can be supplied pre-hashed via `H2G_PASSWORD_HASH` (argon2, generated with `hevy2garmin hash-password`) so the plaintext never sits in the environment; session cookies gain the `Secure` flag over HTTPS and are signed with an optional dedicated `H2G_SECRET` (session lifetime configurable via `H2G_SESSION_TTL_DAYS`, default 30 days); a "Sign out everywhere" action invalidates every active session; and standard security headers (HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, a baseline CSP) are sent on every response. Existing password-only deployments keep working unchanged.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hevy2garmin"
-version = "0.6.4"
+version = "0.7.0"
 description = "Sync Hevy gym workouts to Garmin Connect — exercise mapping, FIT file generation, and automatic upload"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## 0.7.0: dashboard authentication hardening

Ships the hardened dashboard authentication layer merged in #261 (thanks @bcandido).

### Added
- Per-IP login rate limiting with exponential backoff and a global cap (HTTP 429 on lockout), so the login can't be brute-forced.
- `H2G_PASSWORD_HASH` (argon2, generated with `hevy2garmin hash-password`) so the plaintext password never sits in the environment.
- `Secure`-flagged, HMAC-signed session cookies with an optional dedicated `H2G_SECRET`; session lifetime configurable via `H2G_SESSION_TTL_DAYS` (default 30 days).
- "Sign out everywhere" that invalidates every active session, including legacy v1 cookies.
- Standard security headers on every response (HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, a baseline CSP).

Opt-in and backward compatible: existing password-only deployments keep working unchanged.

Merging bumps `pyproject` 0.6.4 to 0.7.0, which triggers `publish.yml` to tag `v0.7.0` and publish to PyPI.
