### PR TITLE
release: 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-07-24
+
+### Added
+- Per-routine sync on the Routines page ([#255](https://github.com/drkostas/hevy2garmin/pull/255), thanks @bcandido). Each routine now has its own Sync / Re-sync button, so you can create or re-create a single planned workout on Garmin without running a full sync. A single sync uses the same safe reconciliation as the bulk path: it only ever replaces a Garmin workout carrying hevy2garmin's provenance marker (never one you built by hand), persists the workout before scheduling so a mid-sync failure can't orphan or duplicate it, and restores the routine's existing scheduled dates.
+- Redesigned Routines page ([#255](https://github.com/drkostas/hevy2garmin/pull/255), thanks @bcandido). Routines are shown as cards with a clear on-Garmin / pending status, an expandable exercise list, and a per-routine schedule panel. A toolbar adds All / On Garmin / Pending filters (a "show only unsynced" view) and a name search, and a summary strip shows how many routines are on Garmin with a progress bar.
+
 ## [0.7.0] - 2026-07-24
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hevy2garmin"
-version = "0.7.0"
+version = "0.8.0"
 description = "Sync Hevy gym workouts to Garmin Connect — exercise mapping, FIT file generation, and automatic upload"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## 0.8.0: per-routine sync + Routines page redesign

Ships #255 (thanks @bcandido).

### Added
- Per-routine Sync / Re-sync on the Routines page: create or re-create a single planned workout on Garmin without a full sync, using the same safe reconciliation as the bulk path (marker-only replace so hand-built Garmin workouts are never touched, persist-before-schedule, and existing scheduled dates restored).
- Redesigned Routines page: routine cards with on-Garmin / pending status, expandable exercise lists, a per-routine schedule panel, All / On Garmin / Pending filters (a "show only unsynced" view) plus name search, and a summary strip with a progress bar.

Reviewed the sync refactor (all three hardened routine-sync invariants preserved, 448 tests green) and UI-validated the redesign on desktop and mobile before merging #255.

Merging bumps `pyproject` 0.7.0 to 0.8.0, which triggers `publish.yml` to tag `v0.8.0` and publish to PyPI.
