### PR TITLE
feat(routines): show updated-on-hevy badge for drifted routines

### DIFF
--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -1513,7 +1513,7 @@ async def routines_page(request: Request):
         schedules = {"scheduled_workouts": [], "page": 1, "total_pages": 1, "sched_total": 0}
     try:
         from hevy2garmin.hevy import HevyClient
-        from hevy2garmin.sync import fetch_all_routines, _cache_routines_total
+        from hevy2garmin.sync import fetch_all_routines, _cache_routines_total, routine_payload_hash
 
         _db = db.get_db()
         hevy = HevyClient(api_key=config.get("hevy_api_key"))
@@ -1528,12 +1528,22 @@ async def routines_page(request: Request):
                 }
                 for ex in (r.get("exercises") or [])
             ]
+            # The routine drifted on Hevy since the last sync when the payload it
+            # would produce now no longer hashes to what we synced. Legacy rows with
+            # no stored hash count as drifted — a sync would recreate them too.
+            needs_update = False
+            if record is not None:
+                try:
+                    needs_update = record.get("content_hash") != routine_payload_hash(r, config)
+                except Exception:
+                    logger.debug("Could not hash routine %s", r.get("id"), exc_info=True)
             routines.append({
                 "id": r.get("id", ""),
                 "title": r.get("title") or r.get("name") or "Routine",
                 "exercises": exercises,
                 "exercise_count": len(exercises),
                 "synced": record is not None,
+                "needs_update": needs_update,
                 "scheduled_date": (record or {}).get("scheduled_date"),
             })
     except Exception:
@@ -1546,6 +1556,7 @@ async def routines_page(request: Request):
         "total": total,
         "synced": synced,
         "pending": max(0, total - synced),
+        "needs_update": sum(1 for r in routines if r["needs_update"]),
         "scheduled": sum(1 for r in routines if r["scheduled_date"]),
         "pct": round(synced / total * 100) if total else 0,
     }

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -846,6 +846,22 @@ def _build_library_by_name(garmin_client) -> dict[str, list[dict]]:
     return library_by_name
 
 
+def routine_payload_hash(routine: dict, cfg: dict[str, Any]) -> str:
+    """Hash of the Garmin payload ``routine`` would sync as (pure/local, no network).
+
+    Single source of truth for "has this routine changed since last sync" — the
+    /routines page badge and :func:`_sync_one_routine`'s skip check must agree, so
+    this resolves weight_unit and the rest default exactly like :func:`sync_routines`.
+    """
+    weight_unit = (cfg.get("sync") or {}).get("weight_unit", "kilogram")
+    default_rest_seconds = (cfg.get("timing") or {}).get("rest_between_sets_seconds", 75)
+    return workout_content_hash(
+        routine_to_garmin_workout(
+            routine, weight_unit=weight_unit, default_rest_seconds=default_rest_seconds
+        )
+    )
+
+
 def _sync_one_routine(
     routine: dict,
     store,

--- a/src/hevy2garmin/templates/routine_row.html
+++ b/src/hevy2garmin/templates/routine_row.html
@@ -7,12 +7,13 @@
       <button type="button" class="ex-toggle" aria-label="Toggle exercises">{{ r.exercise_count }} exercises <span class="chev">▾</span></button>
     </div>
     {% if r.synced %}<span class="badge badge-success">✓ Synced</span>{% else %}<span class="badge badge-pending">Not synced</span>{% endif %}
+    {% if r.synced and r.needs_update and not r.missing %}<span class="badge" style="background: rgba(251,191,36,0.15); color: #fbbf24;">Updated on Hevy</span>{% endif %}
     {% if r.scheduled_date %}<span class="sched-date">📅 {{ r.scheduled_date }}</span>{% endif %}
     <div class="routine-actions">
       <form hx-post="/api/routines/{{ r.id }}/sync" hx-target="#routines-result" hx-disabled-elt="find button" style="display:inline-flex;">
         {% if r.synced %}<input type="hidden" name="force" value="1">{% endif %}
-        <button type="submit" class="btn btn-primary btn-sm" title="{% if r.synced %}Re-create this planned workout on Garmin{% else %}Create this planned workout on Garmin{% endif %}">
-          <span class="htmx-hide">{% if r.synced %}Re-sync{% else %}Sync{% endif %}</span>
+        <button type="submit" class="btn btn-primary btn-sm" title="{% if r.synced and r.needs_update %}The routine changed on Hevy — sync to update the Garmin workout{% elif r.synced %}Re-create this planned workout on Garmin{% else %}Create this planned workout on Garmin{% endif %}">
+          <span class="htmx-hide">{% if r.synced %}{% if r.needs_update %}Update{% else %}Re-sync{% endif %}{% else %}Sync{% endif %}</span>
           <span class="htmx-indicator"><span class="spinner"></span></span>
         </button>
       </form>

--- a/src/hevy2garmin/templates/routines.html
+++ b/src/hevy2garmin/templates/routines.html
@@ -101,7 +101,8 @@
       <div style="margin-right:auto;">
         <div style="font-size:14px; font-weight:600; display:flex; align-items:center; gap:8px;"><span style="color:var(--accent);">⚡</span> {{ stats.synced }} of {{ stats.total }} routines on Garmin</div>
         <div style="font-size:12px; color:var(--text-muted); margin-top:4px;">
-          {% if stats.pending %}{{ stats.pending }} still pending — sync them in one go.{% else %}Everything is on your Garmin calendar.{% endif %}
+          {% if stats.pending %}{{ stats.pending }} still pending — sync them in one go.{% elif stats.needs_update %}{{ stats.needs_update }} changed on Hevy — sync to update.{% else %}Everything is on your Garmin calendar.{% endif %}
+          {% if stats.pending and stats.needs_update %}{{ stats.needs_update }} changed on Hevy since the last sync.{% endif %}
         </div>
       </div>
       <label style="display:flex; gap:6px; align-items:center; color:var(--text-muted); font-size:13px;" title="Re-create even routines already synced">

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -858,6 +858,82 @@ class TestRoutineSyncUI:
         assert "demo mode" in resp.text
 
 
+class TestRoutinesPageUI:
+    """GET /routines — the 'Updated on Hevy' drift badge."""
+
+    def _client(self, store: SQLiteDatabase):
+        srv._is_configured_cache = True  # skip the "not configured → /setup" redirect
+        return patch.object(srv.db, "get_db", return_value=store), TestClient(srv.app)
+
+    _ROUTINE = {"id": "r1", "title": "Push", "updated_at": "2026-01-01T00:00:00Z",
+                "exercises": [{"title": "Bench Press (Barbell)",
+                               "sets": [{"type": "normal", "reps": 5, "weight_kg": 60}]}]}
+
+    def _get_routines_page(self, store: SQLiteDatabase, routine: dict) -> str:
+        db_patch, client = self._client(store)
+        hevy = MagicMock()
+        hevy.get_routines.return_value = {"routines": [routine], "page_count": 1}
+        with db_patch, client, \
+                patch.object(srv, "load_config", return_value={"hevy_api_key": "k"}), \
+                patch("hevy2garmin.hevy.HevyClient", return_value=hevy):
+            return client.get("/routines").text
+
+    def test_badge_shown_when_routine_drifted(self, tmp_path: Path) -> None:
+        store = SQLiteDatabase(tmp_path / "ui.db")
+        store.mark_routine_synced("r1", garmin_workout_id="555", content_hash="stale-hash")
+        html = self._get_routines_page(store, dict(self._ROUTINE))
+        assert "Updated on Hevy" in html
+        assert ">Update<" in html  # the sync button relabels
+        assert "changed on Hevy" in html  # sync-bar subtitle counts it
+
+    def test_badge_absent_when_hash_matches(self, tmp_path: Path) -> None:
+        store = SQLiteDatabase(tmp_path / "ui.db")
+        current = sync_module.routine_payload_hash(dict(self._ROUTINE), {"hevy_api_key": "k"})
+        store.mark_routine_synced("r1", garmin_workout_id="555", content_hash=current)
+        html = self._get_routines_page(store, dict(self._ROUTINE))
+        assert "Updated on Hevy" not in html
+        assert ">Re-sync<" in html
+
+    def test_badge_absent_when_never_synced(self, tmp_path: Path) -> None:
+        store = SQLiteDatabase(tmp_path / "ui.db")
+        html = self._get_routines_page(store, dict(self._ROUTINE))
+        assert "Updated on Hevy" not in html
+        assert "Not synced" in html
+
+    def test_legacy_row_without_hash_counts_as_drifted(self, tmp_path: Path) -> None:
+        # Rows synced before content hashing have no stored hash; a sync would
+        # recreate them, so the badge must agree and show.
+        store = SQLiteDatabase(tmp_path / "ui.db")
+        store.mark_routine_synced("r1", garmin_workout_id="555")
+        html = self._get_routines_page(store, dict(self._ROUTINE))
+        assert "Updated on Hevy" in html
+
+    def test_hash_failure_degrades_to_no_badge(self, tmp_path: Path) -> None:
+        # A routine the payload builder can't process must not break the page.
+        store = SQLiteDatabase(tmp_path / "ui.db")
+        store.mark_routine_synced("r1", garmin_workout_id="555", content_hash="stale-hash")
+        db_patch, client = self._client(store)
+        hevy = MagicMock()
+        hevy.get_routines.return_value = {"routines": [dict(self._ROUTINE)], "page_count": 1}
+        with db_patch, client, \
+                patch.object(srv, "load_config", return_value={"hevy_api_key": "k"}), \
+                patch("hevy2garmin.hevy.HevyClient", return_value=hevy), \
+                patch("hevy2garmin.sync.routine_to_garmin_workout",
+                      side_effect=RuntimeError("bad routine")):
+            html = client.get("/routines").text
+        assert "Updated on Hevy" not in html
+        assert "✓ Synced" in html
+
+    def test_payload_hash_matches_sync_internal_hash(self) -> None:
+        # The page badge and _sync_one_routine's skip check must never disagree:
+        # same routine + default config → identical hash string.
+        routine = dict(self._ROUTINE)
+        expected = workout_content_hash(
+            routine_to_garmin_workout(routine, weight_unit="kilogram", default_rest_seconds=75)
+        )
+        assert sync_module.routine_payload_hash(routine, {}) == expected
+
+
 class TestDbFacade:
     def test_get_synced_routine_facade_delegates(self) -> None:
         # Regression: the `db` module facade must expose get_synced_routine, else


### PR DESCRIPTION
### What changed and why

The `/routines` page only knew "synced or not": a routine edited on Hevy after its sync looked identical to an up-to-date one, giving users no cue that the Garmin planned workout was stale. The page now locally computes the hash of the payload each routine would sync as and, when it no longer matches the last synced hash, shows an amber **"Updated on Hevy"** badge, relabels the button to **"Update"**, and counts drifted routines in the sync-bar subtitle.

---

### Technical details

#### Files changed
- `src/hevy2garmin/sync.py` — new `routine_payload_hash(routine, cfg)` helper, the single source of truth for the hash (the same one `_sync_one_routine`'s skip check uses).
- `src/hevy2garmin/server.py` — `routines_page` computes `needs_update` per routine and adds `stats.needs_update`.
- `src/hevy2garmin/templates/routine_row.html` — amber badge (same style as the workouts page's "Edited on Hevy") and button label.
- `src/hevy2garmin/templates/routines.html` — sync-bar subtitle with the drifted count.
- `tests/test_routine.py` — new `TestRoutinesPageUI` class (6 tests).

#### Approach and trade-offs
The hash covers the generated payload (not Hevy's `updated_at`), so the badge and the sync skip check can never disagree — including when the payload builder itself changes. Computation is purely local (no network beyond the Hevy fetch the page already made); a hash failure degrades to "no badge" instead of breaking the page. Legacy rows without a stored `content_hash` count as drifted, consistent with what a sync would do. No `force` flag is needed: a differing hash already defeats the skip.

#### How to test
```bash
PYTHONPATH=src pytest tests/test_routine.py::TestRoutinesPageUI -q
PYTHONPATH=src pytest tests/ -q
```
Manual: `hevy2garmin serve` → edit a synced routine on Hevy → reload `/routines` → amber badge + "Update" button; click it → the badge clears via the OOB row swap.

#### Breaking changes
None

#### Checklist
- [x] Tests added or updated
- [x] No sensitive data in logs or responses
- [ ] Migrations backward-compatible (n/a)
- [ ] Feature flag (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
