### PR TITLE
fix(routines): detect planned workouts deleted on garmin

### DIFF
--- a/src/hevy2garmin/db_interface.py
+++ b/src/hevy2garmin/db_interface.py
@@ -139,6 +139,19 @@ class Database(ABC):
         """Return the sync record for a Hevy routine, or None if never synced."""
 
     @abstractmethod
+    def list_synced_routines(self) -> list[dict]:
+        """Return every routine sync record (same keys as :meth:`get_synced_routine`)."""
+
+    @abstractmethod
+    def set_routine_status(self, hevy_routine_id: str, status: str) -> None:
+        """Update only the status of a routine sync record.
+
+        Leaves every other field (including ``synced_at``) untouched — used by
+        reconciliation to flag ``missing_on_garmin`` / restore ``success`` without
+        clobbering the recorded hash or sync time. No-op for unknown ids.
+        """
+
+    @abstractmethod
     def is_routine_synced(self, hevy_routine_id: str, hevy_updated_at: str | None = None) -> bool:
         """True if the routine was synced and (if given) not edited on Hevy since."""
 
@@ -158,6 +171,9 @@ class Database(ABC):
         ``status="schedule_pending"`` marks a workout that was created on Garmin
         but whose calendar scheduling hasn't been confirmed yet, so the next sync
         retries it instead of skipping the routine as already done.
+        ``status="missing_on_garmin"`` (set via :meth:`set_routine_status`) marks a
+        workout that no longer exists on Garmin (deleted by the user there); any
+        non-``success`` status defeats the unchanged-hash skip, so a sync recreates it.
         """
 
     @abstractmethod

--- a/src/hevy2garmin/db_postgres.py
+++ b/src/hevy2garmin/db_postgres.py
@@ -190,6 +190,24 @@ class PostgresDatabase(Database):
                 row = cur.fetchone()
                 return dict(row) if row else None
 
+    def list_synced_routines(self) -> list[dict]:
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT hevy_routine_id, garmin_workout_id, title, hevy_updated_at, "
+                    "scheduled_date, content_hash, synced_at, status FROM synced_routines"
+                )
+                return [dict(row) for row in cur.fetchall()]
+
+    def set_routine_status(self, hevy_routine_id: str, status: str) -> None:
+        with self._get_conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE synced_routines SET status = %s WHERE hevy_routine_id = %s",
+                    (status, hevy_routine_id),
+                )
+            conn.commit()
+
     def is_routine_synced(self, hevy_routine_id: str, hevy_updated_at: str | None = None) -> bool:
         record = self.get_synced_routine(hevy_routine_id)
         if record is None:

--- a/src/hevy2garmin/db_sqlite.py
+++ b/src/hevy2garmin/db_sqlite.py
@@ -183,6 +183,26 @@ class SQLiteDatabase(Database):
                 "scheduled_date", "content_hash", "synced_at", "status")
         return dict(zip(keys, row))
 
+    def list_synced_routines(self) -> list[dict]:
+        conn = self._get_conn()
+        rows = conn.execute(
+            "SELECT hevy_routine_id, garmin_workout_id, title, hevy_updated_at, "
+            "scheduled_date, content_hash, synced_at, status FROM synced_routines"
+        ).fetchall()
+        conn.close()
+        keys = ("hevy_routine_id", "garmin_workout_id", "title", "hevy_updated_at",
+                "scheduled_date", "content_hash", "synced_at", "status")
+        return [dict(zip(keys, row)) for row in rows]
+
+    def set_routine_status(self, hevy_routine_id: str, status: str) -> None:
+        conn = self._get_conn()
+        conn.execute(
+            "UPDATE synced_routines SET status = ? WHERE hevy_routine_id = ?",
+            (status, hevy_routine_id),
+        )
+        conn.commit()
+        conn.close()
+
     def is_routine_synced(self, hevy_routine_id: str, hevy_updated_at: str | None = None) -> bool:
         record = self.get_synced_routine(hevy_routine_id)
         if record is None:

--- a/src/hevy2garmin/reconcile.py
+++ b/src/hevy2garmin/reconcile.py
@@ -1,9 +1,13 @@
-"""Detect (log-only) duplicate Garmin activities left by past sync races.
+"""Reconcile local sync state against Garmin's actual state.
 
-When hevy2garmin syncs a workout before its Garmin watch activity has landed, it
-uploads a fresh activity; the watch copy appears later and the user has two
-activities for one workout. This module finds those pairs and logs them. It does
-NOT delete anything — deletion is a separate, opt-in feature.
+Two concerns live here:
+
+- :func:`detect_duplicates` — detect (log-only) duplicate Garmin activities left
+  by past sync races: hevy2garmin uploaded a fresh activity before the watch copy
+  landed, leaving two activities for one workout. Nothing is deleted — deletion
+  is a separate, opt-in feature.
+- :func:`reconcile_missing_routine_workouts` — flag routine planned workouts the
+  user deleted on Garmin, so the dashboard stops showing them as synced.
 """
 from __future__ import annotations
 
@@ -63,3 +67,43 @@ def detect_duplicates(client, workouts: list[dict], limiter=None) -> list[dict]:
             logger.debug("duplicate detection skipped for a workout", exc_info=True)
             continue
     return dups
+
+
+def reconcile_missing_routine_workouts(store, garmin_workouts: list[dict] | None) -> list[str]:
+    """Flag synced routines whose Garmin planned workout no longer exists.
+
+    ``garmin_workouts`` is a full ``list_workouts()`` result; ``None`` means the
+    listing failed (auth, rate limit, network) — reconciliation is skipped entirely
+    rather than treating an error as "everything was deleted". A tracked id absent
+    from the listing flips the routine's status to ``missing_on_garmin``; an id
+    that reappears flips it back to ``success`` (self-healing a false positive from
+    a truncated listing). ``schedule_pending`` rows are never promoted to
+    ``success`` — that would cancel their schedule retry. Best-effort: never raises.
+
+    Returns the ``hevy_routine_id``s whose status changed.
+    """
+    if garmin_workouts is None:
+        return []
+    changed: list[str] = []
+    try:
+        present = {
+            str(w["workoutId"]) for w in garmin_workouts if w.get("workoutId") is not None
+        }
+        for row in store.list_synced_routines():
+            wid = row.get("garmin_workout_id")
+            if not wid:
+                continue
+            status = row.get("status") or "success"
+            if str(wid) not in present and status != "missing_on_garmin":
+                store.set_routine_status(row["hevy_routine_id"], "missing_on_garmin")
+                changed.append(row["hevy_routine_id"])
+                logger.info(
+                    "Routine %s (%s): Garmin workout %s is gone — marked missing",
+                    row["hevy_routine_id"], row.get("title") or "?", wid,
+                )
+            elif str(wid) in present and status == "missing_on_garmin":
+                store.set_routine_status(row["hevy_routine_id"], "success")
+                changed.append(row["hevy_routine_id"])
+    except Exception:
+        logger.debug("routine reconcile skipped", exc_info=True)
+    return changed

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -1498,6 +1498,46 @@ def _schedules_context(
     }
 
 
+# Timestamp cache for the page-load routine reconciliation, kept in the app_config KV
+# store (like ratelimit's cooldown) so it survives serverless restarts. The reconcile
+# *result* is the synced_routines.status column itself — this only throttles the check.
+_ROUTINE_RECONCILE_KEY = "routine_reconcile"
+_ROUTINE_RECONCILE_TTL = 300  # seconds
+
+
+def _reconcile_routines_best_effort(store, config: dict) -> None:
+    """Refresh "does the Garmin workout still exist" state, at most every TTL.
+
+    Best-effort by design: any failure (no Garmin auth, rate-limit cooldown, network)
+    leaves the DB state untouched and the page renders from it.
+    """
+    try:
+        from hevy2garmin._isotime import parse_iso
+        from hevy2garmin.garmin import get_client, list_workouts
+        from hevy2garmin.reconcile import reconcile_missing_routine_workouts
+
+        state = store.get_app_config(_ROUTINE_RECONCILE_KEY) or {}
+        if state.get("checked_at"):
+            age = (datetime.now(timezone.utc) - parse_iso(state["checked_at"])).total_seconds()
+            if age < _ROUTINE_RECONCILE_TTL:
+                return
+        if cooldown_remaining(store) > 0:
+            return
+        if not any(r.get("garmin_workout_id") for r in store.list_synced_routines()):
+            return  # nothing to check — don't even authenticate
+        client = get_client(
+            config.get("garmin_email"), config.get("garmin_password", ""),
+            config.get("garmin_token_dir", "~/.garminconnect"),
+        )
+        reconcile_missing_routine_workouts(store, list_workouts(client, limit=999))
+        store.set_app_config(
+            _ROUTINE_RECONCILE_KEY,
+            {"checked_at": datetime.now(timezone.utc).isoformat()},
+        )
+    except Exception:
+        logger.debug("routine reconcile on page load skipped", exc_info=True)
+
+
 @app.get("/routines", response_class=HTMLResponse)
 async def routines_page(request: Request):
     """List Hevy routines and their sync status."""
@@ -1516,6 +1556,7 @@ async def routines_page(request: Request):
         from hevy2garmin.sync import fetch_all_routines, _cache_routines_total, routine_payload_hash
 
         _db = db.get_db()
+        _reconcile_routines_best_effort(_db, config)
         hevy = HevyClient(api_key=config.get("hevy_api_key"))
         all_routines = fetch_all_routines(hevy)
         _cache_routines_total(_db, len(all_routines))
@@ -1544,6 +1585,7 @@ async def routines_page(request: Request):
                 "exercise_count": len(exercises),
                 "synced": record is not None,
                 "needs_update": needs_update,
+                "missing": (record or {}).get("status") == "missing_on_garmin",
                 "scheduled_date": (record or {}).get("scheduled_date"),
             })
     except Exception:

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -38,6 +38,7 @@ from hevy2garmin.routine import (
     workout_content_hash,
 )
 from hevy2garmin.merge import attempt_merge, reset_circuit_breaker
+from hevy2garmin.reconcile import reconcile_missing_routine_workouts
 from hevy2garmin.db_interface import Database
 
 try:  # rate-limit HR fetches like other Garmin data calls
@@ -826,24 +827,30 @@ def _reschedule_routine(
             store.add_routine_schedule(hevy_routine_id, str(schedule_id), day)
 
 
-def _build_library_by_name(garmin_client) -> dict[str, list[dict]]:
+def _build_library_by_name(garmin_client) -> tuple[dict[str, list[dict]], list[dict] | None]:
     """Map ``workoutName`` -> ``[{"id", "description"}, ...]`` of the workouts already in
     the Garmin library, so a sync can reconcile against Garmin's actual state before
     creating (not just the local DB row) — a DB reset or a crash in the create->persist
     window would otherwise leave an untracked workout that gets recreated as a duplicate.
     Best-effort: if the listing fails we fall back to DB-only dedup.
+
+    Returns ``(library_by_name, raw_workouts)``; ``raw_workouts`` is ``None`` when the
+    listing failed, so callers can tell "empty library" apart from "unknown" (an error
+    must not be reconciled as if the user had deleted everything).
     """
     library_by_name: dict[str, list[dict]] = {}
     try:
-        for w in list_workouts(garmin_client, limit=999):
-            name, wid = w.get("workoutName"), w.get("workoutId")
-            if name and wid is not None:
-                library_by_name.setdefault(name, []).append(
-                    {"id": str(wid), "description": w.get("description") or ""}
-                )
+        raw_workouts = list_workouts(garmin_client, limit=999)
     except Exception:
         logger.warning("Could not list Garmin workouts; falling back to DB-only dedup")
-    return library_by_name
+        return {}, None
+    for w in raw_workouts:
+        name, wid = w.get("workoutName"), w.get("workoutId")
+        if name and wid is not None:
+            library_by_name.setdefault(name, []).append(
+                {"id": str(wid), "description": w.get("description") or ""}
+            )
+    return library_by_name, raw_workouts
 
 
 def routine_payload_hash(routine: dict, cfg: dict[str, Any]) -> str:
@@ -916,7 +923,10 @@ def _sync_one_routine(
         # the user's own workouts and are left untouched.
         stale_ids = set()
         if existing and existing.get("garmin_workout_id"):
-            stale_ids.add(str(existing["garmin_workout_id"]))
+            # A workout already flagged missing is gone from Garmin — deleting it
+            # again would only burn a rate-limited 404.
+            if existing.get("status") != "missing_on_garmin":
+                stale_ids.add(str(existing["garmin_workout_id"]))
         for entry in library_by_name.get(payload["workoutName"], []):
             if ROUTINE_DESC_MARKER in entry["description"]:
                 stale_ids.add(entry["id"])
@@ -1034,7 +1044,8 @@ def sync_routines(
         logger.info("Authenticating with Garmin Connect...")
         garmin_client = get_client(garmin_email, garmin_password, garmin_token_dir)
         logger.info("Authenticated successfully")
-        library_by_name = _build_library_by_name(garmin_client)
+        library_by_name, garmin_workouts = _build_library_by_name(garmin_client)
+        reconcile_missing_routine_workouts(store, garmin_workouts)
 
     stats = {
         "created": 0,
@@ -1094,7 +1105,8 @@ def sync_routine(
 
     logger.info("Authenticating with Garmin Connect...")
     garmin_client = get_client(garmin_email, garmin_password, garmin_token_dir)
-    library_by_name = _build_library_by_name(garmin_client)
+    library_by_name, garmin_workouts = _build_library_by_name(garmin_client)
+    reconcile_missing_routine_workouts(store, garmin_workouts)
     res = _sync_one_routine(
         routine, store, garmin_client, library_by_name,
         weight_unit=weight_unit, default_rest_seconds=default_rest_seconds,
@@ -1115,6 +1127,7 @@ def sync_routine(
         "exercises": exercises,
         "exercise_count": len(exercises),
         "synced": record is not None,
+        "missing": (record or {}).get("status") == "missing_on_garmin",
         "scheduled_date": (record or {}).get("scheduled_date"),
     }
     logger.info("Synced routine %s — %s", hevy_routine_id, res["outcome"])

--- a/src/hevy2garmin/templates/routine_row.html
+++ b/src/hevy2garmin/templates/routine_row.html
@@ -6,19 +6,21 @@
       <div class="routine-name">{{ r.title }}</div>
       <button type="button" class="ex-toggle" aria-label="Toggle exercises">{{ r.exercise_count }} exercises <span class="chev">▾</span></button>
     </div>
-    {% if r.synced %}<span class="badge badge-success">✓ Synced</span>{% else %}<span class="badge badge-pending">Not synced</span>{% endif %}
+    {% if r.missing %}<span class="badge" style="background: rgba(248,113,113,0.15); color: #f87171;">Removed on Garmin</span>{% elif r.synced %}<span class="badge badge-success">✓ Synced</span>{% else %}<span class="badge badge-pending">Not synced</span>{% endif %}
     {% if r.synced and r.needs_update and not r.missing %}<span class="badge" style="background: rgba(251,191,36,0.15); color: #fbbf24;">Updated on Hevy</span>{% endif %}
     {% if r.scheduled_date %}<span class="sched-date">📅 {{ r.scheduled_date }}</span>{% endif %}
     <div class="routine-actions">
       <form hx-post="/api/routines/{{ r.id }}/sync" hx-target="#routines-result" hx-disabled-elt="find button" style="display:inline-flex;">
         {% if r.synced %}<input type="hidden" name="force" value="1">{% endif %}
-        <button type="submit" class="btn btn-primary btn-sm" title="{% if r.synced and r.needs_update %}The routine changed on Hevy — sync to update the Garmin workout{% elif r.synced %}Re-create this planned workout on Garmin{% else %}Create this planned workout on Garmin{% endif %}">
-          <span class="htmx-hide">{% if r.synced %}{% if r.needs_update %}Update{% else %}Re-sync{% endif %}{% else %}Sync{% endif %}</span>
+        <button type="submit" class="btn btn-primary btn-sm" title="{% if r.missing %}The planned workout was deleted on Garmin — sync to recreate it{% elif r.synced and r.needs_update %}The routine changed on Hevy — sync to update the Garmin workout{% elif r.synced %}Re-create this planned workout on Garmin{% else %}Create this planned workout on Garmin{% endif %}">
+          <span class="htmx-hide">{% if r.missing %}Re-create{% elif r.synced %}{% if r.needs_update %}Update{% else %}Re-sync{% endif %}{% else %}Sync{% endif %}</span>
           <span class="htmx-indicator"><span class="spinner"></span></span>
         </button>
       </form>
-      {% if r.synced %}
+      {% if r.synced and not r.missing %}
       <button type="button" class="icon-btn sched-toggle" title="Schedule on the Garmin calendar">📅 Schedule</button>
+      {% elif r.missing %}
+      <button type="button" class="icon-btn" disabled title="Re-sync first — the workout was removed on Garmin">📅 Schedule</button>
       {% else %}
       <button type="button" class="icon-btn" disabled title="Sync this routine first">📅 Schedule</button>
       {% endif %}
@@ -33,7 +35,7 @@
   </div>
   {% endif %}
 
-  {% if r.synced %}
+  {% if r.synced and not r.missing %}
   <div class="sched-panel">
     <form hx-post="/api/routines/{{ r.id }}/schedule" hx-target="#routines-result" hx-swap="innerHTML" hx-disabled-elt="find button"
           style="display:flex; flex-direction:column; gap:8px; font-size:13px; max-width:360px;">

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -81,6 +81,31 @@ class TestRoutineTracking:
         assert db.is_routine_synced("r1") is False
         assert db.delete_synced_routine("r1") is False
 
+    def test_set_routine_status_only_touches_status(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        db.mark_routine_synced("r1", garmin_workout_id="w1", title="Push",
+                               content_hash="h1")
+        db.set_routine_status("r1", "missing_on_garmin")
+        record = db.get_synced_routine("r1")
+        assert record["status"] == "missing_on_garmin"
+        assert record["garmin_workout_id"] == "w1"
+        assert record["content_hash"] == "h1"
+        # Unknown id is a silent no-op.
+        db.set_routine_status("r-unknown", "missing_on_garmin")
+        assert db.get_synced_routine("r-unknown") is None
+
+    def test_list_synced_routines(self, tmp_path: Path) -> None:
+        db = _make_db(tmp_path)
+        assert db.list_synced_routines() == []
+        db.mark_routine_synced("r1", garmin_workout_id="w1", title="Push")
+        db.mark_routine_synced("r2", garmin_workout_id="w2", title="Pull",
+                               status="schedule_pending")
+        rows = {r["hevy_routine_id"]: r for r in db.list_synced_routines()}
+        assert set(rows) == {"r1", "r2"}
+        assert rows["r1"]["garmin_workout_id"] == "w1"
+        assert rows["r1"]["status"] == "success"
+        assert rows["r2"]["status"] == "schedule_pending"
+
     def test_routine_schedule_round_trip(self, tmp_path: Path) -> None:
         db = _make_db(tmp_path)
         db.add_routine_schedule("r1", "111", "2026-07-20")

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -38,3 +38,77 @@ def test_never_raises_on_garmin_error():
     client = MagicMock()
     client.get_activities_by_date.side_effect = RuntimeError("boom")
     assert detect_duplicates(client, [WORKOUT]) == []
+
+
+# ── reconcile_missing_routine_workouts ──────────────────────────────────────
+
+
+def _routine_store(tmp_path):
+    from hevy2garmin.db_sqlite import SQLiteDatabase
+    return SQLiteDatabase(tmp_path / "reconcile.db")
+
+
+def test_marks_routine_missing_when_workout_gone(tmp_path):
+    from hevy2garmin.reconcile import reconcile_missing_routine_workouts
+    store = _routine_store(tmp_path)
+    store.mark_routine_synced("r1", garmin_workout_id="555", title="Push",
+                              content_hash="h1")
+    changed = reconcile_missing_routine_workouts(store, [{"workoutId": 999}])
+    assert changed == ["r1"]
+    record = store.get_synced_routine("r1")
+    assert record["status"] == "missing_on_garmin"
+    # Only the status flips — the hash and workout id stay for the re-sync.
+    assert record["content_hash"] == "h1"
+    assert record["garmin_workout_id"] == "555"
+
+
+def test_none_listing_is_a_noop(tmp_path):
+    # A failed listing (auth/rate limit) must not be read as "everything deleted".
+    from hevy2garmin.reconcile import reconcile_missing_routine_workouts
+    store = _routine_store(tmp_path)
+    store.mark_routine_synced("r1", garmin_workout_id="555")
+    assert reconcile_missing_routine_workouts(store, None) == []
+    assert store.get_synced_routine("r1")["status"] == "success"
+
+
+def test_missing_self_heals_when_workout_reappears(tmp_path):
+    # A false positive (e.g. truncated listing) recovers on the next reconcile.
+    from hevy2garmin.reconcile import reconcile_missing_routine_workouts
+    store = _routine_store(tmp_path)
+    store.mark_routine_synced("r1", garmin_workout_id="555")
+    store.set_routine_status("r1", "missing_on_garmin")
+    changed = reconcile_missing_routine_workouts(store, [{"workoutId": 555}])
+    assert changed == ["r1"]
+    assert store.get_synced_routine("r1")["status"] == "success"
+
+
+def test_schedule_pending_is_not_promoted_to_success(tmp_path):
+    # Promoting a present-but-pending row would cancel its schedule retry.
+    from hevy2garmin.reconcile import reconcile_missing_routine_workouts
+    store = _routine_store(tmp_path)
+    store.mark_routine_synced("r1", garmin_workout_id="555", status="schedule_pending")
+    assert reconcile_missing_routine_workouts(store, [{"workoutId": 555}]) == []
+    assert store.get_synced_routine("r1")["status"] == "schedule_pending"
+
+
+def test_schedule_pending_can_go_missing(tmp_path):
+    from hevy2garmin.reconcile import reconcile_missing_routine_workouts
+    store = _routine_store(tmp_path)
+    store.mark_routine_synced("r1", garmin_workout_id="555", status="schedule_pending")
+    assert reconcile_missing_routine_workouts(store, []) == ["r1"]
+    assert store.get_synced_routine("r1")["status"] == "missing_on_garmin"
+
+
+def test_rows_without_workout_id_are_ignored(tmp_path):
+    from hevy2garmin.reconcile import reconcile_missing_routine_workouts
+    store = _routine_store(tmp_path)
+    store.mark_routine_synced("r1")  # no garmin_workout_id
+    assert reconcile_missing_routine_workouts(store, []) == []
+    assert store.get_synced_routine("r1")["status"] == "success"
+
+
+def test_routine_reconcile_never_raises_on_broken_store():
+    from hevy2garmin.reconcile import reconcile_missing_routine_workouts
+    store = MagicMock()
+    store.list_synced_routines.side_effect = RuntimeError("db down")
+    assert reconcile_missing_routine_workouts(store, []) == []

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -252,11 +252,14 @@ class TestSyncRoutines:
         hevy.get_routines.return_value = {"routines": routines, "page_count": 1}
         create_mock = MagicMock(return_value=777)
         schedule_mock = MagicMock()
-        # patches[7] stubs list_workouts (the pre-create library reconciliation). It
-        # returns an empty library by default — no orphans — so it's a no-op for tests
-        # that don't exercise reconciliation, and it keeps the real list_workouts (with
-        # its 1s rate-limit sleep) out of every sync test. Tests that need orphans swap
-        # in their own list mock, the same way delete_workout (patches[5]) is overridden.
+        # patches[7] stubs list_workouts (the pre-create library reconciliation and the
+        # missing-workout check). It returns the ids these tests conventionally track
+        # (555) and create (777) — an EMPTY library would now mean "the user deleted
+        # everything on Garmin" and flag every tracked routine missing. The entries
+        # carry no ROUTINE_DESC_MARKER, so the orphan-delete path stays inert. It also
+        # keeps the real list_workouts (with its 1s rate-limit sleep) out of every sync
+        # test. Tests that need orphans swap in their own list mock, the same way
+        # delete_workout (patches[5]) is overridden.
         patches = [
             patch.object(sync_module, "load_config", return_value={
                 "hevy_api_key": "k", "garmin_email": "e", "garmin_password": "p"}),
@@ -266,7 +269,10 @@ class TestSyncRoutines:
             patch.object(sync_module, "create_workout", create_mock),
             patch.object(sync_module, "delete_workout", MagicMock()),
             patch.object(sync_module, "schedule_workout", schedule_mock),
-            patch.object(sync_module, "list_workouts", MagicMock(return_value=[])),
+            patch.object(sync_module, "list_workouts", MagicMock(return_value=[
+                {"workoutId": 555, "workoutName": "Push", "description": ""},
+                {"workoutId": 777, "workoutName": "Push", "description": ""},
+            ])),
         ]
         return store, create_mock, schedule_mock, patches
 
@@ -293,7 +299,7 @@ class TestSyncRoutines:
         assert result["row"] == {
             "id": "r1", "title": "Push",
             "exercises": [{"name": "Bench Press (Barbell)", "sets": 1}],
-            "exercise_count": 1, "synced": True, "scheduled_date": None}
+            "exercise_count": 1, "synced": True, "missing": False, "scheduled_date": None}
         create_mock.assert_called_once()
         assert store.get_synced_routine("r1")["garmin_workout_id"] == "777"
 
@@ -319,6 +325,33 @@ class TestSyncRoutines:
         assert result["skipped"] == 1
         assert result["created"] == 0
         create_mock.assert_not_called()
+
+    def test_missing_on_garmin_recreated_despite_unchanged_hash(self, tmp_path: Path) -> None:
+        # The user deleted the planned workout on Garmin: reconciliation (id 999 is
+        # absent from the stubbed library) flags the row missing, so the sync must
+        # recreate it even though the content hash is unchanged — and must not waste
+        # a delete call on the already-gone workout.
+        routines = [{"id": "r1", "title": "Push", "updated_at": "2026-01-01T00:00:00Z", "exercises": []}]
+        store, create_mock, schedule_mock, patches = self._patched(tmp_path, routines)
+        store.mark_routine_synced("r1", garmin_workout_id="999",
+                                  scheduled_date="2999-01-05",
+                                  content_hash=self._hash_for(routines[0]))
+        store.add_routine_schedule("r1", "old-1", "2999-01-05")
+        schedule_mock.side_effect = lambda _client, _wid, day: f"new-{day}"
+        delete_mock = MagicMock()
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+                patch.object(sync_module, "delete_workout", delete_mock), patches[6], patches[7]:
+            result = sync_module.sync_routines()
+        assert result["updated"] == 1
+        assert result["skipped"] == 0
+        create_mock.assert_called_once()
+        delete_mock.assert_not_called()  # 999 is already gone on Garmin
+        record = store.get_synced_routine("r1")
+        assert record["status"] == "success"
+        assert record["garmin_workout_id"] == "777"
+        # The intended schedule survives the deletion and lands on the new workout.
+        schedule_mock.assert_called_once()
+        assert schedule_mock.call_args[0][1:] == (777, "2999-01-05")
 
     def test_resyncs_when_hash_changed(self, tmp_path: Path) -> None:
         routines = [{"id": "r1", "title": "Push", "updated_at": "2026-01-01T00:00:00Z", "exercises": []}]
@@ -938,9 +971,13 @@ class TestRoutinesPageUI:
         db_patch, client = self._client(store)
         hevy = MagicMock()
         hevy.get_routines.return_value = {"routines": [routine], "page_count": 1}
+        # get_client raises so the page-load reconcile degrades to the DB state —
+        # these tests exercise the drift badge, not the Garmin listing.
         with db_patch, client, \
                 patch.object(srv, "load_config", return_value={"hevy_api_key": "k"}), \
-                patch("hevy2garmin.hevy.HevyClient", return_value=hevy):
+                patch("hevy2garmin.hevy.HevyClient", return_value=hevy), \
+                patch("hevy2garmin.garmin.get_client",
+                      side_effect=RuntimeError("no garmin in these tests")):
             return client.get("/routines").text
 
     def test_badge_shown_when_routine_drifted(self, tmp_path: Path) -> None:
@@ -983,6 +1020,8 @@ class TestRoutinesPageUI:
         with db_patch, client, \
                 patch.object(srv, "load_config", return_value={"hevy_api_key": "k"}), \
                 patch("hevy2garmin.hevy.HevyClient", return_value=hevy), \
+                patch("hevy2garmin.garmin.get_client",
+                      side_effect=RuntimeError("no garmin in these tests")), \
                 patch("hevy2garmin.sync.routine_to_garmin_workout",
                       side_effect=RuntimeError("bad routine")):
             html = client.get("/routines").text
@@ -997,6 +1036,94 @@ class TestRoutinesPageUI:
             routine_to_garmin_workout(routine, weight_unit="kilogram", default_rest_seconds=75)
         )
         assert sync_module.routine_payload_hash(routine, {}) == expected
+
+
+class TestRoutinesReconcileUI:
+    """GET /routines — page-load reconciliation of workouts deleted on Garmin."""
+
+    _ROUTINE = {"id": "r1", "title": "Push", "updated_at": "2026-01-01T00:00:00Z",
+                "exercises": []}
+
+    def _client(self, store: SQLiteDatabase):
+        srv._is_configured_cache = True  # skip the "not configured → /setup" redirect
+        return patch.object(srv.db, "get_db", return_value=store), TestClient(srv.app)
+
+    def _patches(self, garmin_library: list[dict]):
+        """Patch the collaborators routines_page imports lazily (at their source
+        modules) — Hevy returns one routine, Garmin returns ``garmin_library``."""
+        hevy = MagicMock()
+        hevy.get_routines.return_value = {"routines": [dict(self._ROUTINE)], "page_count": 1}
+        get_client_mock = MagicMock(return_value=MagicMock())
+        list_mock = MagicMock(return_value=garmin_library)
+        return (
+            patch.object(srv, "load_config", return_value={"hevy_api_key": "k",
+                                                           "garmin_email": "e"}),
+            patch("hevy2garmin.hevy.HevyClient", return_value=hevy),
+            patch("hevy2garmin.garmin.get_client", get_client_mock),
+            patch("hevy2garmin.garmin.list_workouts", list_mock),
+            get_client_mock,
+            list_mock,
+        )
+
+    def test_deleted_workout_shows_removed_badge(self, tmp_path: Path) -> None:
+        store = SQLiteDatabase(tmp_path / "ui.db")
+        store.mark_routine_synced("r1", garmin_workout_id="555", title="Push")
+        db_patch, client = self._client(store)
+        cfg, hevy_p, client_p, list_p, _, _ = self._patches(garmin_library=[
+            {"workoutId": 999, "workoutName": "Other", "description": ""}])
+        with db_patch, client, cfg, hevy_p, client_p, list_p:
+            html = client.get("/routines").text
+        assert "Removed on Garmin" in html
+        assert "✓ Synced" not in html
+        assert "Re-create" in html
+        assert "Re-sync first" in html  # Schedule button disabled with the hint
+        assert store.get_synced_routine("r1")["status"] == "missing_on_garmin"
+
+    def test_reconcile_is_throttled_by_ttl(self, tmp_path: Path) -> None:
+        store = SQLiteDatabase(tmp_path / "ui.db")
+        store.mark_routine_synced("r1", garmin_workout_id="555", title="Push")
+        db_patch, client = self._client(store)
+        cfg, hevy_p, client_p, list_p, _, list_mock = self._patches(garmin_library=[
+            {"workoutId": 555, "workoutName": "Push", "description": ""}])
+        with db_patch, client, cfg, hevy_p, client_p, list_p:
+            client.get("/routines")
+            client.get("/routines")
+        list_mock.assert_called_once()
+
+    def test_rate_limit_cooldown_skips_garmin(self, tmp_path: Path) -> None:
+        from hevy2garmin.ratelimit import record_rate_limit
+
+        store = SQLiteDatabase(tmp_path / "ui.db")
+        store.mark_routine_synced("r1", garmin_workout_id="555", title="Push")
+        record_rate_limit(store)  # active cooldown → don't even authenticate
+        db_patch, client = self._client(store)
+        cfg, hevy_p, client_p, list_p, get_client_mock, _ = self._patches(garmin_library=[])
+        with db_patch, client, cfg, hevy_p, client_p, list_p:
+            html = client.get("/routines").text
+        get_client_mock.assert_not_called()
+        # Page renders from the DB state untouched.
+        assert "✓ Synced" in html
+
+    def test_garmin_failure_degrades_to_db_state(self, tmp_path: Path) -> None:
+        store = SQLiteDatabase(tmp_path / "ui.db")
+        store.mark_routine_synced("r1", garmin_workout_id="555", title="Push")
+        db_patch, client = self._client(store)
+        cfg, hevy_p, client_p, list_p, get_client_mock, _ = self._patches(garmin_library=[])
+        get_client_mock.side_effect = RuntimeError("no auth")
+        with db_patch, client, cfg, hevy_p, client_p, list_p:
+            resp = client.get("/routines")
+        assert resp.status_code == 200
+        assert "✓ Synced" in resp.text
+        assert store.get_synced_routine("r1")["status"] == "success"
+
+    def test_no_tracked_workouts_skips_garmin_entirely(self, tmp_path: Path) -> None:
+        store = SQLiteDatabase(tmp_path / "ui.db")  # nothing synced
+        db_patch, client = self._client(store)
+        cfg, hevy_p, client_p, list_p, get_client_mock, _ = self._patches(garmin_library=[])
+        with db_patch, client, cfg, hevy_p, client_p, list_p:
+            resp = client.get("/routines")
+        assert resp.status_code == 200
+        get_client_mock.assert_not_called()
 
 
 class TestDbFacade:


### PR DESCRIPTION
### What changed and why

A routine's synced state came only from the local DB: a planned workout the user deleted on Garmin Connect kept showing "✓ Synced" — and a re-sync was skipped, because the stored `content_hash` still matched. Reconciliation now compares tracked `garmin_workout_id`s against the Garmin workout library listing; a missing workout flips the row to `missing_on_garmin`, shows a **"Removed on Garmin"** badge with a **"Re-create"** button, and the next sync recreates and reschedules it.

---

### Technical details

#### Files changed
- `src/hevy2garmin/reconcile.py` — new `reconcile_missing_routine_workouts(store, garmin_workouts)`; module docstring broadened.
- `src/hevy2garmin/db_interface.py` / `db_sqlite.py` / `db_postgres.py` — new `list_synced_routines()` and `set_routine_status()` methods (status-only UPDATE, never clobbers hash/`synced_at`).
- `src/hevy2garmin/sync.py` — `_build_library_by_name` now returns `(library, raw_workouts | None)` reusing the single `list_workouts` call syncs already made; reconcile wired into `sync_routines`/`sync_routine`; the tracked-id delete is skipped when already missing (avoids a rate-limited 404); `sync_routine`'s row gains `missing`.
- `src/hevy2garmin/server.py` — `_reconcile_routines_best_effort` on `/routines` page load, throttled by a timestamp cache (5-minute TTL) in the `app_config` KV store, with rate-limit-cooldown and nothing-tracked guards.
- `src/hevy2garmin/templates/routine_row.html` — red badge, "Re-create" button, scheduling disabled while missing.
- `tests/test_db.py`, `tests/test_reconcile.py`, `tests/test_routine.py` — 14 new tests; the suite's `list_workouts` stub now returns the conventional ids (an empty list would now mean "the user deleted everything").

#### Approach and trade-offs
A failed listing returns `None` and reconciliation becomes a no-op — an error is never read as "everything was deleted". An id that reappears self-heals back to `success` (false positive from a truncated listing). `schedule_pending` is never promoted to `success` (that would cancel its schedule retry). `routine_schedules` rows are kept while missing: they record the user's intended schedule, and the manual re-sync restores them. Documented pitfall: `list_workouts(limit=999)` — a larger library could false-positive, bounded by the self-heal. The status reuses the existing `TEXT`/`VARCHAR(20)` column — no migration.

#### How to test
```bash
PYTHONPATH=src pytest tests/test_reconcile.py tests/test_db.py tests/test_routine.py -q
DATABASE_URL=postgresql://test:test@localhost:5432/hevy2garmin_test PYTHONPATH=src pytest tests/ -q
```
Manual: delete the planned workout on Garmin Connect → reload `/routines` → "Removed on Garmin" badge and Schedule disabled; click "Re-create" → back to "✓ Synced" with future dates restored on the calendar. Reviewer note: the page performs at most one Garmin listing per 5 minutes and never breaks when Garmin is unreachable.

#### Breaking changes
None — the new status value fits the existing column; no API/DB contract changes.

#### Checklist
- [x] Tests added or updated (SQLite and Postgres)
- [x] No sensitive data in logs or responses
- [x] Migrations backward-compatible (no migration; existing column)
- [ ] Feature flag (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
