### PR TITLE
refactor(routines): share hash-input resolution between badge and sync

### DIFF
--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -846,15 +846,30 @@ def _build_library_by_name(garmin_client) -> dict[str, list[dict]]:
     return library_by_name
 
 
+def _hash_inputs(cfg: dict[str, Any]) -> tuple[str, int | None]:
+    """Resolve the payload-affecting config: ``(weight_unit, default_rest_seconds)``.
+
+    The single place these defaults live. Every producer of a routine payload hash
+    (:func:`routine_payload_hash` for the page badge, :func:`sync_routines` /
+    :func:`sync_routine` for the stored ``content_hash``) must resolve them here —
+    a default changed in only one spot would make the badge and the sync skip check
+    silently disagree. ``or {}`` guards against a config key present but explicitly
+    null; the rest fallback mirrors the FIT timing default used for logged workouts.
+    """
+    weight_unit = (cfg.get("sync") or {}).get("weight_unit", "kilogram")
+    default_rest_seconds = (cfg.get("timing") or {}).get("rest_between_sets_seconds", 75)
+    return weight_unit, default_rest_seconds
+
+
 def routine_payload_hash(routine: dict, cfg: dict[str, Any]) -> str:
     """Hash of the Garmin payload ``routine`` would sync as (pure/local, no network).
 
     Single source of truth for "has this routine changed since last sync" — the
     /routines page badge and :func:`_sync_one_routine`'s skip check must agree, so
-    this resolves weight_unit and the rest default exactly like :func:`sync_routines`.
+    this resolves weight_unit and the rest default via the same :func:`_hash_inputs`
+    that :func:`sync_routines` uses.
     """
-    weight_unit = (cfg.get("sync") or {}).get("weight_unit", "kilogram")
-    default_rest_seconds = (cfg.get("timing") or {}).get("rest_between_sets_seconds", 75)
+    weight_unit, default_rest_seconds = _hash_inputs(cfg)
     return workout_content_hash(
         routine_to_garmin_workout(
             routine, weight_unit=weight_unit, default_rest_seconds=default_rest_seconds
@@ -1017,11 +1032,7 @@ def sync_routines(
     garmin_email = overrides.get("garmin_email") or cfg.get("garmin_email")
     garmin_password = overrides.get("garmin_password") or cfg.get("garmin_password", "")
     garmin_token_dir = cfg.get("garmin_token_dir", "~/.garminconnect")
-    # ``or {}`` guards against a config key present but explicitly null.
-    weight_unit = (cfg.get("sync") or {}).get("weight_unit", "kilogram")
-    # Fallback rest between sets when a Hevy routine doesn't specify one, mirroring
-    # the FIT timing default used for logged workouts.
-    default_rest_seconds = (cfg.get("timing") or {}).get("rest_between_sets_seconds", 75)
+    weight_unit, default_rest_seconds = _hash_inputs(cfg)
 
     hevy = HevyClient(api_key=hevy_api_key)
     routines = fetch_all_routines(hevy)
@@ -1082,8 +1093,7 @@ def sync_routine(
     garmin_email = overrides.get("garmin_email") or cfg.get("garmin_email")
     garmin_password = overrides.get("garmin_password") or cfg.get("garmin_password", "")
     garmin_token_dir = cfg.get("garmin_token_dir", "~/.garminconnect")
-    weight_unit = (cfg.get("sync") or {}).get("weight_unit", "kilogram")
-    default_rest_seconds = (cfg.get("timing") or {}).get("rest_between_sets_seconds", 75)
+    weight_unit, default_rest_seconds = _hash_inputs(cfg)
 
     hevy = HevyClient(api_key=hevy_api_key)
     routine = next(

--- a/tests/test_routine.py
+++ b/tests/test_routine.py
@@ -309,6 +309,25 @@ class TestSyncRoutines:
         payload = routine_to_garmin_workout(routine, weight_unit="kilogram", default_rest_seconds=75)
         return workout_content_hash(payload)
 
+    def test_stored_content_hash_matches_routine_payload_hash(self, tmp_path: Path) -> None:
+        # Binds the page badge's hash to the one the sync actually persists: a real
+        # sync runs end-to-end, then routine_payload_hash — fed the same config the
+        # sync loaded (no sync/timing keys → both resolve the defaults through
+        # _hash_inputs) — must reproduce the stored content_hash exactly. If the
+        # config resolution ever diverges between badge and sync, this fails.
+        # Two sets with weight and no explicit rest, so the payload actually
+        # depends on BOTH hash inputs (a rest step lands between the sets).
+        routines = [{"id": "r1", "title": "Push", "updated_at": "2026-01-01T00:00:00Z",
+                     "exercises": [{"title": "Bench Press (Barbell)",
+                                    "sets": [{"type": "normal", "reps": 5, "weight_kg": 60},
+                                             {"type": "normal", "reps": 5, "weight_kg": 60}]}]}]
+        store, _, _, patches = self._patched(tmp_path, routines)
+        cfg = {"hevy_api_key": "k", "garmin_email": "e", "garmin_password": "p"}
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6], patches[7]:
+            sync_module.sync_routines()
+        stored = store.get_synced_routine("r1")["content_hash"]
+        assert stored == sync_module.routine_payload_hash(routines[0], cfg)
+
     def test_skips_when_hash_unchanged(self, tmp_path: Path) -> None:
         routines = [{"id": "r1", "title": "Push", "updated_at": "2026-01-01T00:00:00Z", "exercises": []}]
         store, create_mock, _, patches = self._patched(tmp_path, routines)


### PR DESCRIPTION
### What changed and why

Follow-up to the two hardening suggestions from the #265 review. The `(weight_unit, default_rest_seconds)` resolution was copy-pasted in three spots (`sync_routines`, `sync_routine`, `routine_payload_hash`); a default changed in only one of them would make the "Updated on Hevy" badge and the sync skip check silently disagree. This extracts a shared `_hash_inputs(cfg)` helper and adds a test that binds `routine_payload_hash` to the `content_hash` a real sync actually persists, instead of a re-implemented formula.

---

### Technical details

#### Files changed
- `src/hevy2garmin/sync.py` — new `_hash_inputs(cfg) -> (weight_unit, default_rest_seconds)` helper; `sync_routines`, `sync_routine` and `routine_payload_hash` all resolve through it.
- `tests/test_routine.py` — `test_stored_content_hash_matches_routine_payload_hash`: runs `sync_routines()` end-to-end with the suite's mocks, then asserts `routine_payload_hash` (fed the same config, exercising the defaults) reproduces the stored `content_hash` byte-for-byte.

#### Approach and trade-offs
Pure refactor — no behavior change; the resolved values and the defaults are identical. The test routine uses two weighted sets with no explicit rest so the payload genuinely depends on **both** hash inputs (a rest step lands between the sets); with a single set the rest default never enters the payload and the test couldn't catch a divergence. Verified by mutation: re-inlining the resolution in `sync_routines` with a different rest default makes the new test fail, while the pre-refactor suite stayed green.

#### How to test
```bash
PYTHONPATH=src pytest tests/test_routine.py -q
PYTHONPATH=src pytest tests/ -q
```

#### Breaking changes
None

#### Checklist
- [x] Tests added or updated
- [x] No sensitive data in logs or responses
- [ ] Migrations backward-compatible (n/a)
- [ ] Feature flag (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
