### PR TITLE
fix(garmin): harden list_workouts against a non-list 2xx body

### DIFF
--- a/src/hevy2garmin/garmin.py
+++ b/src/hevy2garmin/garmin.py
@@ -421,7 +421,14 @@ def create_workout(client: Garmin, payload: dict) -> int | None:
 
 
 def list_workouts(client: Garmin, limit: int = 100) -> list[dict]:
-    """List the user's saved Garmin workouts (for idempotency / reconciliation)."""
+    """List the user's saved Garmin workouts (for idempotency / reconciliation).
+
+    Raises on a non-list 2xx body (an error envelope or a shape drift) so callers
+    treat it as "unknown" rather than an empty library. Reading an error-as-200 as
+    ``[]`` would make routine reconciliation flag every synced routine as deleted on
+    Garmin. Both callers wrap this in a best-effort try/except, so a raise degrades
+    to the last-known DB state instead of acting on a false empty listing.
+    """
     time.sleep(1.0)  # manual rate limit
     resp = client.client.request(
         "GET",
@@ -429,7 +436,12 @@ def list_workouts(client: Garmin, limit: int = 100) -> list[dict]:
         f"/workout-service/workouts?start=1&limit={limit}&myWorkoutsOnly=true",
     )
     data = resp.json() if hasattr(resp, "json") else resp
-    return data if isinstance(data, list) else []
+    if not isinstance(data, list):
+        raise RuntimeError(
+            f"Garmin workout listing returned a {type(data).__name__}, not a list; "
+            "treating as unknown rather than empty"
+        )
+    return data
 
 
 def delete_workout(client: Garmin, workout_id: int | str) -> None:

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -243,3 +243,28 @@ class TestGenerateDescription:
         desc = generate_description(workout)
         assert "80.0kg" in desc
         assert "3.0km" in desc
+
+
+def test_list_workouts_raises_on_non_list_body():
+    """A 2xx response with a non-list body (an error envelope or shape drift) must
+    raise, not be read as an empty library. Reading it as ``[]`` would make routine
+    reconciliation flag every synced routine as deleted on Garmin."""
+    from hevy2garmin.garmin import list_workouts
+    client = MagicMock()
+    resp = MagicMock()
+    resp.json.return_value = {"error": "temporarily unavailable"}  # dict, not a list
+    client.client.request.return_value = resp
+    with patch("hevy2garmin.garmin.time.sleep"):
+        with pytest.raises(RuntimeError, match="not a list"):
+            list_workouts(client)
+
+
+def test_list_workouts_returns_well_formed_list():
+    """A well-formed list body passes through unchanged."""
+    from hevy2garmin.garmin import list_workouts
+    client = MagicMock()
+    resp = MagicMock()
+    resp.json.return_value = [{"workoutId": 1}, {"workoutId": 2}]
+    client.client.request.return_value = resp
+    with patch("hevy2garmin.garmin.time.sleep"):
+        assert list_workouts(client) == [{"workoutId": 1}, {"workoutId": 2}]


### PR DESCRIPTION
### What changed and why

`list_workouts` (`garmin.py`) mapped a non-list 2xx body (an error-as-200 envelope or a shape drift) to `[]`. Routine reconciliation read that as "every planned workout was deleted on Garmin" and would flip every synced routine to `missing_on_garmin` for one reconcile-TTL cycle. It self-heals and the marker gate means it can never wrongly delete a user's workout, but it is a bad UI blip and a transient duplicate.

It now raises on a non-list body. Both callers (`_build_library_by_name` and the best-effort page-load reconcile) already wrap the call in try/except and degrade to the last-known DB state, so a raise is treated as "unknown listing", not "empty library".

### Files

- `src/hevy2garmin/garmin.py` — `list_workouts` raises on a non-list 2xx body instead of returning `[]`.
- `tests/test_garmin.py` — a dict body raises `RuntimeError`; a well-formed list passes through.

476 passed, 7 skipped (SQLite).

Closes #268
