### PR TITLE
fix(mapper): use the 65535 sentinel for entries meant to be generic

### DIFF
--- a/src/hevy2garmin/mapper.py
+++ b/src/hevy2garmin/mapper.py
@@ -558,7 +558,7 @@ HEVY_TO_GARMIN: dict[str, tuple[int, int]] = {
     # ======================================================================= #
     #  WARM UP (category 31)
     # ======================================================================= #
-    "Warm Up":                                  (31, 0),   # warm_up / generic warm up
+    "Warm Up":                                  (31, 65535),  # warm_up / generic warm up
 
     # ======================================================================= #
     #  FLEXIBILITY / STABILITY – mapped to known FIT categories
@@ -566,7 +566,7 @@ HEVY_TO_GARMIN: dict[str, tuple[int, int]] = {
     "Bird Dog":                                 (11, 1),   # hip_stability / dead_bug (closest quadruped stability)
     "Dead Bug":                                 (11, 1),   # hip_stability / dead_bug
     "Dead Hang":                                (21, 38),  # pull_up / pull_up (hang variant – grip/lat endurance)
-    "Downward Dog":                             (31, 0),   # warm_up / generic (yoga pose)
+    "Downward Dog":                             (31, 65535),  # warm_up / generic (yoga pose)
     "Front Lever Hold":                         (21, 38),  # pull_up / pull_up (front lever)
     "Front Lever Raise":                        (21, 38),  # pull_up / pull_up (front lever)
     "Handstand Hold":                           (22, 25),  # push_up / handstand_push_up (hold variant)
@@ -589,28 +589,28 @@ HEVY_TO_GARMIN: dict[str, tuple[int, int]] = {
     # ======================================================================= #
     #  CARDIO / MACHINES — uses newer FIT SDK categories (33+) where available
     # ======================================================================= #
-    "Aerobics":                                 (2, 0),    # cardio / generic
+    "Aerobics":                                 (2, 65535),   # cardio / generic
     "Air Bike":                                 (2, 65535),   # CARDIO / generic
     "Battle Ropes":                             (2, 65535),   # CARDIO / generic
     "Boxing":                                   (2, 65535),   # CARDIO / generic
-    "Climbing":                                 (2, 0),    # cardio / generic
+    "Climbing":                                 (2, 65535),   # cardio / generic
     "Cycling":                                  (2, 65535),   # CARDIO / generic
     "Elliptical Trainer":                       (2, 65535),   # CARDIO / generic
-    "HIIT":                                     (2, 0),    # cardio / generic
+    "HIIT":                                     (2, 65535),   # cardio / generic
     "Hiking":                                   (32, 1),   # run / walk (hiking = walking)
     "Jump Rope":                                (2, 6),    # cardio / jump_rope
     "Jumping Jack":                             (2, 12),   # cardio / jumping_jacks
-    "Pilates":                                  (2, 0),    # cardio / generic
+    "Pilates":                                  (2, 65535),   # cardio / generic
     "Rowing Machine":                           (2, 65535),   # CARDIO / generic
-    "Skating":                                  (2, 0),    # cardio / generic
-    "Skiing":                                   (2, 0),    # cardio / generic
-    "Snowboarding":                             (2, 0),    # cardio / generic
+    "Skating":                                  (2, 65535),   # cardio / generic
+    "Skiing":                                   (2, 65535),   # cardio / generic
+    "Snowboarding":                             (2, 65535),   # cardio / generic
     "Spinning":                                 (2, 65535),   # CARDIO / generic
-    "Stretching":                               (31, 0),   # warm_up / generic (stretching)
-    "Swimming":                                 (2, 0),    # cardio / generic
+    "Stretching":                               (31, 65535),  # warm_up / generic (stretching)
+    "Swimming":                                 (2, 65535),   # cardio / generic
     "Treadmill":                                (2, 65535),   # CARDIO / generic
     "Yoga":                                     (29, 65535),   # TOTAL_BODY / generic (not a Garmin strength exercise)
-    "High Knees":                               (2, 0),    # cardio / generic
+    "High Knees":                               (2, 65535),   # cardio / generic
     "Sprints":                                  (32, 3),   # run / sprint
     "Cable Pull Through":                       (10, 11),  # hip_raise / hip_raise (cable pull-through = hip hinge)
 

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -136,6 +136,33 @@ class TestSaveCustomMappingCloud:
         m._custom_mappings.clear()
 
 
+class TestGenericSubcategory:
+    """Subcategory 0 is a real exercise, not a "no specific exercise" marker.
+
+    FIT's unset value is 65535. An entry meant to say "this category, nothing
+    more specific" that uses 0 instead resolves to whatever exercise happens to
+    be first in that category — cardio/0 is BOB_AND_WEAVE_CIRCLE, so Swimming
+    uploaded to Garmin under that name.
+    """
+
+    def test_entries_documented_as_generic_use_the_sentinel(self) -> None:
+        import re
+
+        source = Path(__file__).parent.parent / "src" / "hevy2garmin" / "mapper.py"
+        table = source.read_text().split("HEVY_TO_GARMIN", 1)[1]
+        wrong = re.findall(
+            r'^\s{4}"([^"]+)":\s+\(\d+, 0\),\s+#.*generic.*$', table, re.M
+        )
+        assert not wrong, f"'generic' entries using subcategory 0 instead of 65535: {wrong}"
+
+    def test_swimming_is_not_a_boxing_drill(self) -> None:
+        from hevy2garmin.merge import _category_to_string, _exercise_to_string
+
+        cat, sub, _ = lookup_exercise("Swimming")
+        assert _category_to_string(cat) == "CARDIO"
+        assert _exercise_to_string(cat, sub) != "BOB_AND_WEAVE_CIRCLE"
+
+
 class TestValidCategories:
     """Bug B: some mappings used FIT categories (33-52) the installed fit_tool
     doesn't implement, so they silently fell back to TOTAL_BODY instead of their


### PR DESCRIPTION
Closes #273.

Twelve entries are commented "generic" but use subcategory `0`, which in FIT is a real exercise — the unset value is `65535`, already used correctly elsewhere in the table. So they resolve to whatever sits first in the category:

```
Swimming, Skiing, HIIT, Pilates, Climbing, Aerobics,
Skating, Snowboarding, High Knees  -> cardio/bob_and_weave_circle
Warm Up, Downward Dog, Stretching  -> warm_up/quadruped_rocking
```

A logged swim reaches Garmin Connect as "Bob and Weave Circle".

Points all twelve at `65535` and adds a guard so an entry documented as generic cannot use `0` again. Both new tests fail on `main` and pass after. Full suite: 478 passed, 7 skipped.

## Ordering

This is a no-op for real syncs until #271 / #272 lands — `template_map.py` holds the same `(2, 0)` pairs and currently wins. Best merged after #272; it touches `test_mapper.py` in the same region, so expect a trivial rebase.

`High Knees` deserves a separate look: FIT has `warm_up/walking_high_knees (31, 26)`, an exact name match, but moving it out of CARDIO is a judgement call so I left it generic here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)