### PR TITLE
fix(garmin): never adopt an excluded activity id from the import result

### DIFF
--- a/src/hevy2garmin/garmin.py
+++ b/src/hevy2garmin/garmin.py
@@ -84,7 +84,8 @@ def upload_fit(
         fit_path: Path to the .fit file.
         workout_start: ISO-8601 start time for matching the uploaded activity.
         exclude_activity_ids: Activities that existed before the upload. These
-            must not be mistaken for the newly imported activity.
+            must not be mistaken for the newly imported activity — not even
+            when Garmin names one of them in the import result itself.
 
     Returns dict with upload_id and activity_id (if found).
     """
@@ -127,6 +128,22 @@ def upload_fit(
         logger.info("  Upload result: upload_id=%s activity_id=%s", upload_id, activity_id)
     else:
         logger.info("  Upload response: %s", str(resp)[:200])
+
+    # A pre-existing activity must never be taken for the new one, even when
+    # Garmin reports it as the import "success". Under the "replace" strategy
+    # the watch copy shares the workout's start time, so Garmin can answer the
+    # import with that id instead of creating a new activity — the caller then
+    # deletes the watch copy and renames an activity that is already gone
+    # (404). Drop the echoed id and fall through to the start-time lookup.
+    if activity_id is not None and exclude_activity_ids:
+        excluded = {str(x) for x in exclude_activity_ids}
+        if str(activity_id) in excluded:
+            logger.warning(
+                "  Import result returned excluded activity %s (pre-existing duplicate); "
+                "resolving the new activity by start time instead",
+                activity_id,
+            )
+            activity_id = None
 
     # Find the activity ID for renaming (retry with backoff if needed).
     # Only match by start time — never grab "most recent activity" because

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -137,6 +137,64 @@ class TestUploadFit:
         assert result == {"upload_id": "u1", "activity_id": 2}
         assert finder.call_args.kwargs["exclude_activity_ids"] == ["1"]
 
+    def test_import_result_echoing_an_excluded_id_is_rejected(self, tmp_path: Path) -> None:
+        """Garmin can answer an import with the id of a pre-existing duplicate.
+
+        Under the "replace" strategy the watch copy shares the workout's start
+        time, so Garmin may report it as the import "success" instead of
+        creating a new activity. Trusting that id makes the caller delete the
+        watch copy and then rename an activity that no longer exists (404).
+        The echoed id must be discarded and the start-time lookup used instead.
+        """
+        fit_path = tmp_path / "workout.fit"
+        fit_path.write_bytes(b"fit")
+        client = MagicMock()
+        client.upload_activity.return_value = {
+            "detailedImportResult": {
+                "uploadId": "u1",
+                "successes": [{"internalId": 1}],  # the watch copy we are about to delete
+            }
+        }
+
+        with patch("hevy2garmin.garmin._limiter") as limiter, patch(
+            "hevy2garmin.garmin.time.sleep"
+        ), patch(
+            "hevy2garmin.garmin.find_activity_by_start_time", return_value=2
+        ) as finder:
+            limiter.call.side_effect = lambda func, *args: func(*args)
+            result = upload_fit(
+                client,
+                fit_path,
+                workout_start="2026-04-01T20:00:00+00:00",
+                exclude_activity_ids=[1],
+            )
+
+        assert result["activity_id"] == 2
+        assert finder.called
+
+    def test_import_result_id_is_kept_when_not_excluded(self, tmp_path: Path) -> None:
+        """The normal path is untouched: a genuine new activity id is used as-is."""
+        fit_path = tmp_path / "workout.fit"
+        fit_path.write_bytes(b"fit")
+        client = MagicMock()
+        client.upload_activity.return_value = {
+            "detailedImportResult": {"uploadId": "u1", "successes": [{"internalId": 2}]}
+        }
+
+        with patch("hevy2garmin.garmin._limiter") as limiter, patch(
+            "hevy2garmin.garmin.find_activity_by_start_time"
+        ) as finder:
+            limiter.call.side_effect = lambda func, *args: func(*args)
+            result = upload_fit(
+                client,
+                fit_path,
+                workout_start="2026-04-01T20:00:00+00:00",
+                exclude_activity_ids=[1],
+            )
+
+        assert result == {"upload_id": "u1", "activity_id": 2}
+        assert not finder.called
+
 
 class TestGenerateDescription:
     def test_basic_description(self, sample_workout: dict) -> None:


### PR DESCRIPTION
Closes #279.

`upload_fit` already refuses pre-existing activities when it resolves the upload by start time, but it trusts `detailedImportResult.successes[0].internalId` unconditionally.

Under the `replace` watch strategy that id can be the watch copy: it shares the workout's start time, so Garmin may report the import as a duplicate of the existing activity instead of creating a new one. The caller then deletes the watch copy (it is `merge_delete_id`) and renames the id it just deleted, which 404s — leaving the workout unsynced for the next auto-sync to merge into an all-Unknown activity.

Discards an echoed id that appears in `exclude_activity_ids` and falls through to the existing start-time lookup, which already excludes it. Logs a warning when it fires, since it means Garmin deduplicated the upload and no new activity exists.

## Verification

`test_import_result_echoing_an_excluded_id_is_rejected` fails on `main` (resolves to the excluded `1` instead of the new `2`) and passes after. `test_import_result_id_is_kept_when_not_excluded` pins the normal path — a genuine new id is still used as-is with no lookup. Full suite: 478 passed, 7 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)