### PR TITLE
build(docker): split the image into a builder and a runtime stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,19 @@
-FROM python:3.12-slim
+FROM python:3.12-slim AS builder
+
+ENV PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+# Toolchain for dependencies that fall back to an sdist when no wheel matches
+# the platform — pynacl, curl-cffi and psycopg2 all do this on arm64, so a
+# plain `pip install .` fails on a Raspberry Pi. Confined to this stage so the
+# compiler never ships in the runtime image.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential libffi-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 WORKDIR /app
 
@@ -6,6 +21,18 @@ COPY pyproject.toml README.md ./
 COPY src/ src/
 
 RUN pip install --no-cache-dir .
+
+
+FROM python:3.12-slim
+
+# Only the finished virtualenv crosses over — no build tools, no sources.
+COPY --from=builder /opt/venv /opt/venv
+
+ENV PATH="/opt/venv/bin:$PATH" \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
 
 EXPOSE 8123
 


### PR DESCRIPTION
Closes #281.

`pip install .` fails on arm64 whenever a dependency has no matching wheel and falls back to its sdist — `pynacl`, `curl-cffi` and `psycopg2` all do. Adding a compiler to the single-stage image would fix the build but ship `build-essential`, the sources and pip metadata to every user.

Installs into a virtualenv in a throwaway builder stage that has the toolchain, then copies only `/opt/venv` into a clean runtime stage. I verified the templates and static assets are package data in the built wheel, so the runtime stage needs nothing from the source tree.

**Runtime behaviour is unchanged**: same base image, same root user, same WORKDIR, same entrypoint — the documented `-v ~/.hevy2garmin:/root/...` volume mounts keep working, so this is not breaking for existing users.

I have a follow-up that also drops to a non-root user, but that moves the data directories to `/home/nonroot/...` and needs a migration note, so I kept it separate — happy to open it if you want it.

Note: I could not run `docker build` while preparing this (no daemon available on my machine), so the Dockerfile is reviewed rather than build-tested. CI does not build the image either. Worth a manual build before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)