### PR TITLE
fix(mapper): map the machine chest press and hip abduction to their machine variants

### DIFF
--- a/src/hevy2garmin/mapper.py
+++ b/src/hevy2garmin/mapper.py
@@ -48,7 +48,7 @@ HEVY_TO_GARMIN: dict[str, tuple[int, int]] = {
     "Incline Chest Press (Machine)":            (0, 9),    # bench_press / incline_dumbbell_bench_press (closest machine)
     "Iso-Lateral Chest Press (Machine)":        (0, 6),    # bench_press / dumbbell_bench_press (closest)
     "Chest Press (Band)":                       (0, 1),    # bench_press / barbell_bench_press (closest)
-    "Chest Press (Machine)":                    (0, 6),    # bench_press / dumbbell_bench_press (closest machine press)
+    "Chest Press (Machine)":                    (0, 22),   # bench_press / smith_machine_bench_press (machine, not free-weight)
     "Dumbbell Squeeze Press":                   (0, 6),    # bench_press / dumbbell_bench_press (squeeze variant)
     "Hex Press (Dumbbell)":                     (0, 6),    # bench_press / dumbbell_bench_press (hex variant)
     "JM Press (Barbell)":                       (0, 4),    # bench_press / close_grip_barbell_bench_press (closest)
@@ -433,7 +433,7 @@ HEVY_TO_GARMIN: dict[str, tuple[int, int]] = {
     "Fire Hydrants":                            (11, 5),   # hip_stability / fire_hydrant_kicks
     "Glute Kickback (Machine)":                 (11, 17),  # hip_stability / quadruped_hip_extension (closest)
     "Glute Kickback on Floor":                  (11, 17),  # hip_stability / quadruped_hip_extension
-    "Hip Abduction (Machine)":                  (11, 28),  # hip_stability / standing_hip_abduction
+    "Hip Abduction (Machine)":                  (11, 29),  # hip_stability / weighted_standing_hip_abduction (machine is loaded)
     "Hip Adduction (Machine)":                  (11, 25),  # hip_stability / standing_adduction
     "Lateral Band Walks":                       (11, 11),  # hip_stability / lateral_walks_with_band_at_ankles
     "Lateral Leg Raises":                       (11, 21),  # hip_stability / side_lying_leg_raise

--- a/src/hevy2garmin/template_map.py
+++ b/src/hevy2garmin/template_map.py
@@ -65,7 +65,7 @@ TEMPLATE_TO_GARMIN: dict[str, tuple[int, int]] = {
     "78683336": (9, 2),  # Chest Fly (Machine)
     "720B0D70": (9, 2),  # Chest Fly (Suspension)
     "EAC7D9C5": (0, 1),  # Chest Press (Band)
-    "7EB3F7C3": (0, 6),  # Chest Press (Machine)
+    "7EB3F7C3": (0, 22),  # Chest Press (Machine)
     "914F3A96": (23, 2),  # Chest Supported Incline Row (Dumbbell)
     "B582299E": (9, 5),  # Chest Supported Reverse Fly (Dumbbell)
     "F21D5693": (14, 10),  # Chest Supported Y Raise (Dumbbell)
@@ -157,7 +157,7 @@ TEMPLATE_TO_GARMIN: dict[str, tuple[int, int]] = {
     "150E076B": (2, 0),  # High Knees
     "023947AB": (2, 0),  # HIIT
     "1C34A172": (32, 1),  # Hiking
-    "F4B4C6EE": (11, 28),  # Hip Abduction (Machine)
+    "F4B4C6EE": (11, 29),  # Hip Abduction (Machine)
     "8BEBFED6": (11, 25),  # Hip Adduction (Machine)
     "92B8C7E1": (10, 0),  # Hip Thrust
     "D57C2EC7": (10, 1),  # Hip Thrust (Barbell)


### PR DESCRIPTION
Closes #289.

| exercise | was | now |
|---|---|---|
| `Chest Press (Machine)` | `(0, 6)` `dumbbell_bench_press` | `(0, 22)` `smith_machine_bench_press` |
| `Hip Abduction (Machine)` | `(11, 28)` `standing_hip_abduction` | `(11, 29)` `weighted_standing_hip_abduction` |

A machine press is guided and fixed-path, so the Smith-machine entry is the closer analogue; the abduction machine is loaded, so the weighted variant applies where the bodyweight one does not.

`template_map.py` is updated in the same commit for both entries — it is generated from the table and resolved first, so a table-only change would not reach a real sync.

Deliberately scoped to **only** these two generated entries, so it does not overlap with the wider resync in #286. Once that lands, `--check` covers both files together.

Full suite: 488 passed, 7 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)