### PR TITLE
feat(mapper): add Walking Lunge (Sandbag), Burpee Broad Jumps and Sled Pull

### DIFF
--- a/src/hevy2garmin/mapper.py
+++ b/src/hevy2garmin/mapper.py
@@ -374,6 +374,7 @@ HEVY_TO_GARMIN: dict[str, tuple[int, int]] = {
     "Split Squat (Dumbbell)":                   (17, 28),  # lunge / dumbbell_split_squat
     "Walking Lunge":                            (17, 78),  # lunge / walking_lunge
     "Walking Lunge (Dumbbell)":                 (17, 77),  # lunge / walking_dumbbell_lunge
+    "Walking Lunge (Sandbag)":                  (17, 79),  # lunge / weighted_walking_lunge
 
     # ======================================================================= #
     #  LEGS – Deadlift (category 8)
@@ -567,12 +568,14 @@ HEVY_TO_GARMIN: dict[str, tuple[int, int]] = {
     # ======================================================================= #
     "Burpee":                                   (29, 0),   # total_body / burpee
     "Burpee Over the Bar":                      (29, 0),   # total_body / burpee (over bar variant)
+    "Burpee Broad Jumps":                       (29, 0),   # total_body / burpee (broad-jump variant)
 
     # ======================================================================= #
     #  CARRY (category 3)
     # ======================================================================= #
     "Farmers Walk":                             (3, 1),    # carry / farmers_walk
     "Suitcase Carry (Dumbbell)":                (3, 1),    # carry / farmers_walk (single-arm variant)
+    "Sled Pull":                                (3, 65535), # carry / generic (no sled exercise in FIT)
 
     # ======================================================================= #
     #  WARM UP (category 31)


### PR DESCRIPTION
Closes #293. Purely additive — 3 insertions, no deletions.

| exercise | mapping | note |
|---|---|---|
| `Walking Lunge (Sandbag)` | `(17, 79)` `weighted_walking_lunge` | exact match, sits with the existing `walking_lunge` / `walking_dumbbell_lunge` entries |
| `Burpee Broad Jumps` | `(29, 0)` `burpee` | same entry `Burpee` and `Burpee Over the Bar` already use |
| `Sled Pull` | `(3, 65535)` `carry/generic` | FIT has no sled exercise; CARRY still beats UNKNOWN |

All three non-custom, confirmed against `exercise_templates`.

On why #292 missed them — worth recording because it is a flaw in the method, not a one-off: I ran that coverage query against a checkout that already carried these three locally, so they never registered as gaps. The sweep is only as good as the table you compare against, and it needs pointing at a clean `main`.

Audit clean across 458 entries: 0 duplicate keys, 0 invalid categories, 0 invalid subcategories. `--check` green, 489 passed / 7 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)