### PR TITLE
docs+build: make self-hosting a documented, first-class path

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+# The build context is only pyproject.toml, README.md and src/ — everything
+# else just slows the build down and can bloat the layer cache.
+.git
+.github
+.venv
+venv
+**/__pycache__
+**/*.pyc
+.pytest_cache
+.ruff_cache
+.mypy_cache
+tests
+docs
+scripts
+typescript
+universal
+worker
+worker-di
+api
+node_modules
+*.md
+!README.md
+.env
+.env.*
+!.env.example
+*.fit
+*.db

--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,12 @@ DEMO_MODE=
 # Optional: CSRF protection secret for POST endpoints
 HEVY2GARMIN_SECRET=
 
+# ── Self-hosted only ──────────────────────────────────────────────────────
+# Collect the Garmin password and MFA code on this instance and run the login
+# here, instead of posting them to the hosted exchange worker. Off by default.
+# Needs a writable home directory, so it does not work on serverless.
+H2G_DIRECT_GARMIN_LOGIN=
+
 # ── Vercel-specific (auto-set by Vercel) ──────────────────────────────────
 # DATABASE_URL=              # Auto-set by Vercel Postgres integration
 # VERCEL=1                   # Auto-set when running on Vercel

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,16 +25,36 @@ RUN pip install --no-cache-dir .
 
 FROM python:3.12-slim
 
+# Run unprivileged: a container escape starts as uid 999 rather than root, and
+# files written into a bind mount are not root-owned on the host.
+#
+# HOME stays /root on purpose. Every path the app uses is HOME-relative
+# (~/.hevy2garmin, ~/.garminconnect), so keeping HOME means the volume paths in
+# the README keep working exactly as before — this is not a breaking change for
+# existing installs. The directory is handed to the new user instead.
+RUN groupadd --system --gid 999 nonroot \
+ && useradd --system --gid 999 --uid 999 --home-dir /root --no-create-home nonroot \
+ && mkdir -p /root/.hevy2garmin /root/.garminconnect \
+ && chown -R 999:999 /root \
+ && chmod 755 /root
+
 # Only the finished virtualenv crosses over — no build tools, no sources.
 COPY --from=builder /opt/venv /opt/venv
 
 ENV PATH="/opt/venv/bin:$PATH" \
     PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    HOME=/root
 
+USER nonroot
 WORKDIR /app
 
 EXPOSE 8123
+
+# Lets `docker compose` restart policies and `docker ps` reflect real health
+# rather than just "the process is alive".
+HEALTHCHECK --interval=60s --timeout=5s --start-period=20s --retries=3 \
+  CMD python -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8123/login', timeout=4).status < 500 else 1)"
 
 ENTRYPOINT ["hevy2garmin"]
 CMD ["status"]

--- a/README.md
+++ b/README.md
@@ -331,6 +331,54 @@ The dashboard has no login by default (fine for a private local install). **If y
 
 See [`.env.example`](.env.example) for all the related variables.
 
+## Self-hosting
+
+The Vercel deploy is the quickest way to run hevy2garmin, but it is not the only one. Running it on your own machine — a spare box, a NAS, a Raspberry Pi — keeps your Hevy and Garmin data on hardware you control, and removes the once-a-day cron ceiling that serverless imposes.
+
+### Docker Compose (recommended)
+
+```bash
+git clone https://github.com/drkostas/hevy2garmin.git
+cd hevy2garmin
+cp .env.example .env      # set HEVY_API_KEY and H2G_PASSWORD
+docker compose up -d --build
+```
+
+Open [localhost:8123](http://localhost:8123) and connect Garmin from the setup page.
+
+The compose file uses named volumes for the sync database and the Garmin token store. Keep them: the token store is what saves you re-authenticating with Garmin (tokens last roughly a year), and the database is what stops already-synced workouts uploading twice.
+
+It also binds the port to `127.0.0.1` rather than all interfaces, drops all capabilities, and sets `no-new-privileges`. The image runs as an unprivileged user (uid 999).
+
+### Keeping credentials on your own machine
+
+Two settings matter if the point of self-hosting is that nothing leaves your network:
+
+- **`H2G_DIRECT_GARMIN_LOGIN=true`** — collect your Garmin password and MFA code on your own instance and run the login there, instead of posting them to the hosted exchange worker the Vercel deploy uses. Off by default; the worker path is unchanged unless you set this. Requires a writable home directory, so it is for self-hosted installs only, not serverless.
+The resulting token store lives in `~/.garminconnect` by default (`garmin_token_dir` in `~/.hevy2garmin/config.json`). Back that directory up and you will not have to log in again after a rebuild — which is what the `garmin_auth` volume in the compose file is for.
+
+Your Hevy API key stays local either way.
+
+### Behind a reverse proxy
+
+Put the dashboard behind nginx, Caddy or Traefik on a subdomain, terminate TLS there, and keep the container bound to `127.0.0.1`. **Set `H2G_PASSWORD` before exposing it** — see [Securing the dashboard](#securing-the-dashboard).
+
+Serving it at the **root of a subdomain** (`https://hevy.example.com/`) works. Serving it under a **sub-path** (`https://example.com/hevy2garmin/`) is not fully supported yet: the templates build some URLs in JavaScript against the origin root, so those requests escape the prefix.
+
+### Keeping it in sync
+
+Auto-sync runs on a timer inside the process, so a self-hosted instance can poll as often as you like — enable it and set the interval on the dashboard. This is the main practical difference from the Vercel deploy, where scheduling comes from a platform cron that is limited to once per day on Vercel's Hobby plan.
+
+### Running as a non-root user
+
+The image runs as uid 999. Named volumes (what the compose file uses) are handled automatically. If you use **bind mounts** instead — the `-v ~/.hevy2garmin:/root/.hevy2garmin` form shown in the Docker section — grant that user access once:
+
+```bash
+sudo chown -R 999:999 ~/.hevy2garmin ~/.garminconnect
+```
+
+The paths inside the container are unchanged, so nothing needs moving.
+
 ## Updating
 
 ### Vercel (fork-based deploy)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+# Self-hosted hevy2garmin.
+#
+#   cp .env.example .env      # fill in HEVY_API_KEY and H2G_PASSWORD
+#   docker compose up -d --build
+#
+# Then open http://localhost:8123 and connect Garmin from the setup page.
+#
+# The named volumes hold your sync database and your Garmin token store. Keep
+# them: the token store is what saves you from logging in to Garmin again
+# (tokens last roughly a year), and the database is what stops already-synced
+# workouts being uploaded twice.
+
+services:
+  hevy2garmin:
+    build: .
+    image: hevy2garmin
+    container_name: hevy2garmin
+    restart: unless-stopped
+    command: serve
+    env_file: .env
+    ports:
+      # Bound to localhost. If you put this behind a reverse proxy, keep it
+      # that way and let the proxy terminate TLS. Exposing 8123 directly on a
+      # public interface means anyone who finds it can read your data unless
+      # H2G_PASSWORD is set — see "Securing the dashboard" in the README.
+      - "127.0.0.1:8123:8123"
+    volumes:
+      - hevy2garmin_data:/root/.hevy2garmin
+      - garmin_auth:/root/.garminconnect
+    # The image runs as uid 999. These are defence in depth, not a substitute
+    # for setting a dashboard password.
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+
+volumes:
+  hevy2garmin_data:
+  garmin_auth:

--- a/src/hevy2garmin/cli.py
+++ b/src/hevy2garmin/cli.py
@@ -41,6 +41,34 @@ def _require_config(args: argparse.Namespace) -> None:
         sys.exit(1)
 
 
+def _garmin_interactive_login(email: str, password: str) -> None:
+    """Two-step Garmin login for the terminal; prints status, never raises."""
+    from hevy2garmin import garmin_login
+
+    result = garmin_login.begin(email, password)
+    if result["status"] == "needs_mfa":
+        try:
+            code = input("  Garmin sent a verification code — enter it: ").strip()
+        except EOFError:
+            print("✗ No input available — cannot complete MFA.")
+            return
+        result = garmin_login.complete(result["session_id"], code)
+
+    status = result["status"]
+    if status == "success":
+        print(f"✓ Authenticated as {result.get('display_name') or 'Garmin'}")
+    elif status == "invalid_credentials":
+        print("✗ Failed: check your Garmin email and password.")
+    elif status == "rate_limited":
+        print("✗ Garmin is rate-limiting logins from this server. Try again in 1–2 h.")
+    elif status == "mfa_failed":
+        print("✗ The verification code was rejected.")
+    elif status == "session_expired":
+        print("✗ Login session expired — run init again.")  # parity with HTTP surface; unreachable in CLI
+    else:
+        print(f"✗ Failed: {result.get('message', 'unknown error')}")
+
+
 def cmd_init(args: argparse.Namespace) -> None:
     """Interactive setup wizard."""
     print("hevy2garmin setup\n")
@@ -76,16 +104,9 @@ def cmd_init(args: argparse.Namespace) -> None:
     if email:
         pw = getpass.getpass("Garmin password (enter to skip if tokens exist): ")
         if pw:
-            # Test login
-            print("  Checking Garmin login...", end=" ", flush=True)
-            try:
-                from garmin_auth import GarminAuth
-                auth = GarminAuth(email=email, password=pw)
-                client = auth.login()
-                print(f"✓ Authenticated as {client.display_name}")
-            except Exception as e:
-                print(f"✗ Failed: {e}")
-                print("  You can fix this later. Continuing setup...")
+            print("  Checking Garmin login...")
+            _garmin_interactive_login(email, pw)
+            # Login failures are non-fatal — tokens can be set up later.
 
     # User profile
     print("\nUser profile (for calorie estimation):")

--- a/src/hevy2garmin/garmin.py
+++ b/src/hevy2garmin/garmin.py
@@ -33,6 +33,22 @@ def get_client(
     Uses DBTokenStore when DATABASE_URL is set (cloud/Vercel),
     falls back to file-based tokens (local/Docker).
     """
+    auth = GarminAuth(**auth_kwargs(email, password, token_dir))
+    return auth.login()
+
+
+def auth_kwargs(
+    email: str | None = None,
+    password: str | None = None,
+    token_dir: str = "~/.garminconnect",
+) -> dict:
+    """Build the GarminAuth kwargs selecting the right token store.
+
+    Every path that authenticates with Garmin must agree on where tokens
+    live, or one writes a store the other never reads and the account looks
+    permanently un-authenticated. Shared by get_client and the dashboard's
+    direct login so the choice is made in exactly one place.
+    """
     from hevy2garmin.db import get_database_url
     database_url = get_database_url()
 
@@ -44,9 +60,7 @@ def get_client(
         kwargs["token_dir"] = "/tmp/.garminconnect"
     else:
         kwargs["token_dir"] = token_dir
-
-    auth = GarminAuth(**kwargs)
-    return auth.login()
+    return kwargs
 
 
 def _sanitize_activity_id(raw: object) -> int | None:

--- a/src/hevy2garmin/garmin_login.py
+++ b/src/hevy2garmin/garmin_login.py
@@ -1,0 +1,109 @@
+"""In-memory two-step Garmin login (password -> MFA) served from the Pi.
+
+This is the only module that knows the MFA mechanics; the dashboard and CLI both
+drive it through begin()/complete(). Login happens directly from this host (a
+residential IP Garmin does not block), so the password never leaves the Pi.
+
+Pending MFA logins are held in memory between the two HTTP requests; the ``serve``
+daemon is a single long-lived process, so the pending GarminAuth object survives
+from begin() to complete(). Assumes a single worker process (see spec, open risks).
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+import threading
+import time
+
+from garmin_auth import GarminAuth
+from garmin_auth.auth import NEEDS_MFA
+from garminconnect import (
+    GarminConnectAuthenticationError,
+    GarminConnectConnectionError,
+    GarminConnectTooManyRequestsError,
+)
+
+logger = logging.getLogger("hevy2garmin")
+
+_TTL = 600  # seconds a pending MFA session stays valid
+
+
+class _PendingStore:
+    """Thread-safe store of pending MFA logins, keyed by an opaque session id."""
+
+    def __init__(self, ttl: int = _TTL) -> None:
+        self._ttl = ttl
+        self._lock = threading.Lock()
+        self._pending: dict[str, tuple[GarminAuth, float]] = {}
+
+    def _evict_expired(self, now: float) -> None:
+        # caller holds the lock
+        expired = [sid for sid, (_, ts) in self._pending.items() if now - ts > self._ttl]
+        for sid in expired:
+            del self._pending[sid]
+
+    def put(self, auth: GarminAuth, now: float) -> str:
+        sid = secrets.token_urlsafe(32)
+        with self._lock:
+            self._evict_expired(now)
+            self._pending[sid] = (auth, now)
+        return sid
+
+    def get(self, sid: str, now: float) -> GarminAuth | None:
+        with self._lock:
+            self._evict_expired(now)
+            entry = self._pending.get(sid)
+            return entry[0] if entry else None
+
+    def pop(self, sid: str, now: float) -> GarminAuth | None:
+        with self._lock:
+            self._evict_expired(now)
+            entry = self._pending.pop(sid, None)
+            return entry[0] if entry else None
+
+
+_store = _PendingStore()
+
+
+def begin(email: str, password: str) -> dict:
+    """Start a Garmin login. Returns a status dict; never raises for auth errors."""
+    try:
+        auth = GarminAuth(email=email, password=password, return_on_mfa=True)
+        result = auth.login()
+    except GarminConnectAuthenticationError as e:
+        return {"status": "invalid_credentials", "message": str(e)[:200]}
+    except GarminConnectTooManyRequestsError as e:
+        return {"status": "rate_limited", "message": str(e)[:200]}
+    except GarminConnectConnectionError as e:
+        return {"status": "error", "message": str(e)[:200]}
+    except Exception as e:
+        logger.warning("garmin_login.begin unexpected error: %s", e)
+        return {"status": "error", "message": str(e)[:200]}
+
+    if result == NEEDS_MFA:
+        sid = _store.put(auth, time.time())
+        return {"status": "needs_mfa", "session_id": sid}
+
+    # result is an authenticated Garmin client; login() already persisted tokens.
+    return {"status": "success", "display_name": getattr(result, "display_name", None)}
+
+
+def complete(session_id: str, code: str) -> dict:
+    """Finish a pending MFA login with the user's code."""
+    # get-then-pop is two lock acquisitions; safe only because serve runs as a
+    # single process (see module docstring). A multi-worker deployment would need
+    # an atomic pop-if-present here.
+    auth = _store.get(session_id, time.time())
+    if auth is None:
+        return {"status": "session_expired"}
+    try:
+        client = auth.resume_login(code)
+    except (GarminConnectAuthenticationError, ValueError):
+        # Wrong/empty code — keep the pending entry so the user can re-enter just the code.
+        return {"status": "mfa_failed", "message": "Code rejected, try again"}
+    except Exception as e:
+        logger.warning("garmin_login.complete unexpected error: %s", e)
+        return {"status": "error", "message": str(e)[:200]}
+    _store.pop(session_id, time.time())
+    return {"status": "success", "display_name": getattr(client, "display_name", None)}

--- a/src/hevy2garmin/garmin_login.py
+++ b/src/hevy2garmin/garmin_login.py
@@ -69,7 +69,12 @@ _store = _PendingStore()
 def begin(email: str, password: str) -> dict:
     """Start a Garmin login. Returns a status dict; never raises for auth errors."""
     try:
-        auth = GarminAuth(email=email, password=password, return_on_mfa=True)
+        from hevy2garmin.garmin import auth_kwargs
+
+        # Same store selection as get_client — a direct login that wrote to a
+        # different store than sync reads from would look like it never
+        # happened (#296 review).
+        auth = GarminAuth(**auth_kwargs(email, password), return_on_mfa=True)
         result = auth.login()
     except GarminConnectAuthenticationError as e:
         return {"status": "invalid_credentials", "message": str(e)[:200]}

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -15,10 +15,11 @@ from typing import Any
 
 from fastapi import FastAPI, Form, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.concurrency import run_in_threadpool
 from fastapi.staticfiles import StaticFiles
 from jinja2 import Environment, FileSystemLoader
 
-from hevy2garmin import db, login_ratelimit, __version__
+from hevy2garmin import db, garmin_login, login_ratelimit, __version__
 from hevy2garmin.db_interface import NoWritableDatabaseError
 from hevy2garmin.auth import (
     auth_enabled, verify_session, sign_session, check_password, SESSION_COOKIE, session_ttl,
@@ -430,7 +431,8 @@ async def check_setup(request: Request, call_next):
             return Response("Unauthorized", status_code=401)
 
     # Setup page and sync endpoints: skip the "is configured?" redirect
-    if path in ("/login", "/setup", "/api/sync-one", "/api/cron/sync", "/api/setup-actions", "/api/garmin-ticket"):
+    if path in ("/login", "/setup", "/api/sync-one", "/api/cron/sync", "/api/setup-actions",
+                "/api/garmin-ticket", "/api/garmin-login", "/api/garmin-login-mfa"):
         response = await call_next(request)
     else:
         # Redirect to setup if not configured
@@ -656,6 +658,16 @@ async def dashboard(request: Request):
 
 
 
+def _direct_garmin_login() -> bool:
+    """Whether the dashboard collects Garmin credentials itself.
+
+    Off by default: the hosted deployment hands the login to the exchange
+    worker so the app never sees a Garmin password. Self-hosted installs can
+    opt in, keeping the credentials on their own machine.
+    """
+    return os.environ.get("H2G_DIRECT_GARMIN_LOGIN", "").strip().lower() in ("1", "true", "yes", "on")
+
+
 @app.get("/setup", response_class=HTMLResponse)
 async def setup_page(request: Request):
     garmin_cooldown = 0
@@ -667,7 +679,8 @@ async def setup_page(request: Request):
     except Exception:
         pass
     return _render("setup.html", config=load_config(), is_cloud=bool(db.get_database_url()),
-                   garmin_cooldown=garmin_cooldown, garmin_cooldown_str=garmin_cooldown_str)
+                   garmin_cooldown=garmin_cooldown, garmin_cooldown_str=garmin_cooldown_str,
+                   direct_garmin_login=_direct_garmin_login())
 
 
 @app.post("/setup")
@@ -876,6 +889,34 @@ async def api_garmin_rate_limited(request: Request):
     except Exception as e:
         logger.warning("Could not record rate-limit: %s", e)
         return HTMLResponse(_json.dumps({"cooldown_seconds": 0}))
+
+
+@app.post("/api/garmin-login")
+async def garmin_login_begin(request: Request):
+    """Direct (self-hosted) Garmin login, step 1. The password never leaves the host."""
+    from fastapi.responses import JSONResponse
+
+    body = await request.json()
+    email = (body.get("email") or "").strip()
+    password = body.get("password") or ""
+    if not email or not password:
+        return JSONResponse({"status": "error", "message": "Email and password required"}, status_code=400)
+    result = await run_in_threadpool(garmin_login.begin, email, password)
+    return JSONResponse(result)
+
+
+@app.post("/api/garmin-login-mfa")
+async def garmin_login_mfa(request: Request):
+    """Direct (self-hosted) Garmin login, step 2 — submit the MFA code."""
+    from fastapi.responses import JSONResponse
+
+    body = await request.json()
+    session_id = (body.get("session_id") or "").strip()
+    code = (body.get("code") or "").strip()
+    if not session_id or not code:
+        return JSONResponse({"status": "error", "message": "session_id and code required"}, status_code=400)
+    result = await run_in_threadpool(garmin_login.complete, session_id, code)
+    return JSONResponse(result)
 
 
 @app.get("/workouts", response_class=HTMLResponse)

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -901,7 +901,28 @@ async def garmin_login_begin(request: Request):
     password = body.get("password") or ""
     if not email or not password:
         return JSONResponse({"status": "error", "message": "Email and password required"}, status_code=400)
+
+    # Same limiter the dashboard login uses. Garmin rate-limits the account
+    # itself, so hammering this endpoint locks the user out upstream — worth
+    # throttling locally first, especially on an open self-host.
+    key = f"garmin-login:{client_ip(request)}"
+    try:
+        store = db.get_db()
+    except Exception:
+        store = None  # DB unavailable → skip the limiter, never block setup on an outage
+    remaining = login_ratelimit.lockout_remaining(store, key) if store else 0
+    if remaining > 0:
+        return JSONResponse(
+            {"status": "error", "message": f"Too many attempts. Try again in {format_cooldown(remaining)}."},
+            status_code=429,
+        )
+
     result = await run_in_threadpool(garmin_login.begin, email, password)
+    if store:
+        if result.get("status") in ("success", "needs_mfa"):
+            login_ratelimit.clear_failures(store, key)
+        else:
+            login_ratelimit.record_failure(store, key)
     return JSONResponse(result)
 
 

--- a/src/hevy2garmin/templates/setup.html
+++ b/src/hevy2garmin/templates/setup.html
@@ -137,6 +137,7 @@
 
 <script>
 const GARMIN_WORKER_BASE = 'https://hevy2garmin-exchange-di.gkos.workers.dev';
+const DIRECT_LOGIN = {{ direct_garmin_login | default(false) | tojson }};
 
 // ── Garmin inline login (preferred UX, no copy-paste) ──────────────────────
 
@@ -154,7 +155,8 @@ async function garminConnect() {
     btn.disabled = true;
     result.innerHTML = '<span style="color: var(--text-muted);">Connecting to Garmin...</span>';
     try {
-        const resp = await fetch(GARMIN_WORKER_BASE + '/login', {
+        const url = DIRECT_LOGIN ? '/api/garmin-login' : (GARMIN_WORKER_BASE + '/login');
+        const resp = await fetch(url, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ email: email, password: password }),
@@ -183,10 +185,14 @@ async function garminSubmitMfa() {
     btn.disabled = true;
     result.innerHTML = '<span style="color: var(--text-muted);">Verifying code...</span>';
     try {
-        const resp = await fetch(GARMIN_WORKER_BASE + '/login-mfa', {
+        const url = DIRECT_LOGIN ? '/api/garmin-login-mfa' : (GARMIN_WORKER_BASE + '/login-mfa');
+        const body = DIRECT_LOGIN
+            ? { session_id: garminMfaSessionId, code: code }
+            : { session_id: garminMfaSessionId, mfa_code: code };
+        const resp = await fetch(url, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ session_id: garminMfaSessionId, mfa_code: code }),
+            body: JSON.stringify(body),
         });
         const data = await resp.json();
         await handleGarminLoginResponse(data);

--- a/src/hevy2garmin/templates/setup.html
+++ b/src/hevy2garmin/templates/setup.html
@@ -211,6 +211,13 @@ async function handleGarminLoginResponse(data) {
         // Hide MFA row if it was shown
         mfaRow.style.display = 'none';
         garminMfaSessionId = null;
+        if (DIRECT_LOGIN) {
+            // The login ran on this host, so the token store is already written.
+            // There are no DI tokens in the response to relay — posting them
+            // anyway sends {"tokens":{}} and gets a spurious "Invalid tokens".
+            result.innerHTML = '<span style="color: var(--accent);">&#10003; Connected to Garmin</span>';
+            return;
+        }
         // Persist tokens on our server
         const storeResp = await fetch('/api/garmin-ticket', {
             method: 'POST',

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -364,3 +364,87 @@ class TestSecurityHeaders:
         assert "strict-transport-security" not in {k.lower() for k in plain.headers.keys()}
         secure = client.get("/login", headers={"X-Forwarded-Proto": "https"})
         assert secure.headers.get("strict-transport-security")
+
+
+class TestGarminLoginEndpoints:
+    def test_login_requires_cookie(self, client_with_secret) -> None:
+        resp = client_with_secret.post("/api/garmin-login", json={"email": "e", "password": "p"})
+        assert resp.status_code == 401
+
+    def test_mfa_requires_cookie(self, client_with_secret) -> None:
+        resp = client_with_secret.post(
+            "/api/garmin-login-mfa", json={"session_id": "s", "code": "123456"}
+        )
+        assert resp.status_code == 401
+
+    def test_login_begin_success(self, client_with_secret) -> None:
+        with patch("hevy2garmin.garmin_login.begin",
+                   return_value={"status": "success", "display_name": "Jane"}):
+            resp = client_with_secret.post(
+                "/api/garmin-login",
+                json={"email": "e@x.com", "password": "pw"},
+                cookies={"h2g_auth": "test-secret-123"},
+            )
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "success", "display_name": "Jane"}
+
+    def test_login_begin_needs_mfa(self, client_with_secret) -> None:
+        with patch("hevy2garmin.garmin_login.begin",
+                   return_value={"status": "needs_mfa", "session_id": "sid-1"}):
+            resp = client_with_secret.post(
+                "/api/garmin-login",
+                json={"email": "e@x.com", "password": "pw"},
+                cookies={"h2g_auth": "test-secret-123"},
+            )
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "needs_mfa", "session_id": "sid-1"}
+
+    def test_login_missing_fields_returns_400(self, client_with_secret) -> None:
+        resp = client_with_secret.post(
+            "/api/garmin-login", json={}, cookies={"h2g_auth": "test-secret-123"}
+        )
+        assert resp.status_code == 400
+        assert resp.json()["status"] == "error"
+
+    def test_mfa_missing_fields_returns_400(self, client_with_secret) -> None:
+        resp = client_with_secret.post(
+            "/api/garmin-login-mfa", json={"session_id": "sid"},
+            cookies={"h2g_auth": "test-secret-123"},
+        )
+        assert resp.status_code == 400
+        assert resp.json()["status"] == "error"
+
+    def test_login_mfa_complete(self, client_with_secret) -> None:
+        with patch("hevy2garmin.garmin_login.complete",
+                   return_value={"status": "success", "display_name": "Jane"}) as comp:
+            resp = client_with_secret.post(
+                "/api/garmin-login-mfa",
+                json={"session_id": "sid-1", "code": "123456"},
+                cookies={"h2g_auth": "test-secret-123"},
+            )
+        comp.assert_called_once_with("sid-1", "123456")
+        assert resp.json()["status"] == "success"
+
+
+@pytest.fixture
+def client_direct_login():
+    """TestClient with the direct-login flag on (and no HEVY2GARMIN_SECRET).
+
+    The env patch is honored because _direct_garmin_login() is evaluated at
+    request time (inside the /setup route), not at module import — so the
+    cached server module doesn't need reloading.
+    """
+    with patch.dict(os.environ, {"H2G_DIRECT_GARMIN_LOGIN": "true"}, clear=False):
+        os.environ.pop("HEVY2GARMIN_SECRET", None)
+        from hevy2garmin.server import app
+        yield TestClient(app)
+
+
+class TestDirectLoginFlag:
+    def test_setup_renders_direct_flag_on(self, client_direct_login) -> None:
+        resp = client_direct_login.get("/setup")
+        assert "const DIRECT_LOGIN = true" in resp.text
+
+    def test_setup_renders_direct_flag_off(self, client_no_secret) -> None:
+        resp = client_no_secret.get("/setup")
+        assert "const DIRECT_LOGIN = false" in resp.text

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,3 +62,52 @@ class TestSyncDryRun:
     def test_since_flag(self) -> None:
         result = run_cli("sync", "--since", "2026-01-01", "--help")
         assert result.returncode == 0
+
+
+from hevy2garmin.cli import _garmin_interactive_login
+
+
+class TestGarminInteractiveLogin:
+    def test_clean_success(self, capsys) -> None:
+        with patch("hevy2garmin.garmin_login.begin",
+                   return_value={"status": "success", "display_name": "Jane"}):
+            _garmin_interactive_login("e@x.com", "pw")
+        assert "Authenticated as Jane" in capsys.readouterr().out
+
+    def test_mfa_flow(self, capsys) -> None:
+        with patch("hevy2garmin.garmin_login.begin",
+                   return_value={"status": "needs_mfa", "session_id": "sid-1"}), \
+             patch("hevy2garmin.garmin_login.complete",
+                   return_value={"status": "success", "display_name": "Jane"}) as comp, \
+             patch("builtins.input", return_value="123456"):
+            _garmin_interactive_login("e@x.com", "pw")
+        comp.assert_called_once_with("sid-1", "123456")
+        assert "Authenticated as Jane" in capsys.readouterr().out
+
+    def test_invalid_credentials_prints_and_returns(self, capsys) -> None:
+        with patch("hevy2garmin.garmin_login.begin",
+                   return_value={"status": "invalid_credentials", "message": "bad"}):
+            _garmin_interactive_login("e@x.com", "pw")
+        assert "email" in capsys.readouterr().out.lower()
+
+    def test_rate_limited(self, capsys) -> None:
+        with patch("hevy2garmin.garmin_login.begin",
+                   return_value={"status": "rate_limited", "message": "429"}):
+            _garmin_interactive_login("e@x.com", "pw")
+        assert "rate-limit" in capsys.readouterr().out.lower()
+
+    def test_mfa_failed(self, capsys) -> None:
+        with patch("hevy2garmin.garmin_login.begin",
+                   return_value={"status": "needs_mfa", "session_id": "sid-1"}), \
+             patch("hevy2garmin.garmin_login.complete",
+                   return_value={"status": "mfa_failed", "message": "Code rejected, try again"}), \
+             patch("builtins.input", return_value="000000"):
+            _garmin_interactive_login("e@x.com", "pw")
+        assert "rejected" in capsys.readouterr().out.lower()
+
+    def test_mfa_eof_is_handled(self, capsys) -> None:
+        with patch("hevy2garmin.garmin_login.begin",
+                   return_value={"status": "needs_mfa", "session_id": "sid-1"}), \
+             patch("builtins.input", side_effect=EOFError):
+            _garmin_interactive_login("e@x.com", "pw")  # must not raise
+        assert "no input" in capsys.readouterr().out.lower()

--- a/tests/test_garmin_login.py
+++ b/tests/test_garmin_login.py
@@ -1,0 +1,96 @@
+"""Tests for the in-memory two-step Garmin login."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+from garmin_auth.auth import NEEDS_MFA
+from garminconnect import (
+    GarminConnectAuthenticationError,
+    GarminConnectConnectionError,
+    GarminConnectTooManyRequestsError,
+)
+
+from hevy2garmin import garmin_login
+from hevy2garmin.garmin_login import _PendingStore
+
+
+@pytest.fixture(autouse=True)
+def fresh_store():
+    """Each test gets an empty pending store."""
+    garmin_login._store = _PendingStore()
+    yield
+
+
+def _client(name="Jane Athlete"):
+    c = MagicMock()
+    c.display_name = name
+    return c
+
+
+def test_begin_clean_success():
+    with patch("hevy2garmin.garmin_login.GarminAuth") as GA:
+        GA.return_value.login.return_value = _client()
+        out = garmin_login.begin("e@x.com", "pw")
+    assert out == {"status": "success", "display_name": "Jane Athlete"}
+
+
+def test_begin_needs_mfa_stores_session():
+    with patch("hevy2garmin.garmin_login.GarminAuth") as GA:
+        GA.return_value.login.return_value = NEEDS_MFA
+        out = garmin_login.begin("e@x.com", "pw")
+    assert out["status"] == "needs_mfa"
+    assert out["session_id"]
+    assert garmin_login._store.get(out["session_id"], 0.0) is not None
+
+
+@pytest.mark.parametrize("exc,status", [
+    (GarminConnectAuthenticationError("bad"), "invalid_credentials"),
+    (GarminConnectTooManyRequestsError("429"), "rate_limited"),
+    (GarminConnectConnectionError("down"), "error"),
+])
+def test_begin_exception_mapping(exc, status):
+    with patch("hevy2garmin.garmin_login.GarminAuth") as GA:
+        GA.return_value.login.side_effect = exc
+        out = garmin_login.begin("e@x.com", "pw")
+    assert out["status"] == status
+
+
+def test_complete_success_evicts():
+    auth = MagicMock()
+    auth.resume_login.return_value = _client()
+    sid = garmin_login._store.put(auth, time.time())  # stored "now"; complete() reads now+epsilon
+    out = garmin_login.complete(sid, "123456")
+    assert out == {"status": "success", "display_name": "Jane Athlete"}
+    assert garmin_login._store.get(sid, 0.0) is None
+
+
+def test_complete_unknown_session():
+    assert garmin_login.complete("nope", "123456") == {"status": "session_expired"}
+
+
+def test_complete_wrong_code_keeps_entry():
+    auth = MagicMock()
+    auth.resume_login.side_effect = GarminConnectAuthenticationError("bad code")
+    sid = garmin_login._store.put(auth, time.time())  # stored "now"; complete() reads now+epsilon
+    out = garmin_login.complete(sid, "000000")
+    assert out["status"] == "mfa_failed"
+    assert garmin_login._store.get(sid, 0.0) is not None  # retained for retry
+
+
+def test_pending_store_ttl_eviction():
+    store = _PendingStore(ttl=600)
+    sid = store.put(MagicMock(), now=1000.0)
+    assert store.get(sid, now=1500.0) is not None       # within TTL
+    assert store.get(sid, now=1000.0 + 601) is None      # expired
+
+
+def test_complete_empty_code_is_mfa_failed():
+    auth = MagicMock()
+    auth.resume_login.side_effect = ValueError("mfa_code must be a non-empty string")
+    sid = garmin_login._store.put(auth, time.time())
+    out = garmin_login.complete(sid, "")
+    assert out["status"] == "mfa_failed"
+    assert garmin_login._store.get(sid, 0.0) is not None  # retained for retry

--- a/tests/test_garmin_login.py
+++ b/tests/test_garmin_login.py
@@ -94,3 +94,88 @@ def test_complete_empty_code_is_mfa_failed():
     out = garmin_login.complete(sid, "")
     assert out["status"] == "mfa_failed"
     assert garmin_login._store.get(sid, 0.0) is not None  # retained for retry
+
+
+class TestDirectLoginSuccessPath:
+    """The direct-login success branch in setup.html.
+
+    The endpoints return {status, display_name} and no DI tokens, because the
+    login ran here and the token store is already written. The page must not
+    relay that to /api/garmin-ticket: there is nothing to relay, so it posts
+    {"tokens": {}} and gets back a 400 "Invalid tokens" — a red error on a
+    login that actually succeeded (#296 review).
+    """
+
+    def _setup_html(self) -> str:
+        from pathlib import Path
+
+        return (
+            Path(__file__).parent.parent
+            / "src" / "hevy2garmin" / "templates" / "setup.html"
+        ).read_text()
+
+    def test_success_handler_short_circuits_before_the_ticket_relay(self) -> None:
+        html = self._setup_html()
+        body = html.split("async function handleGarminLoginResponse", 1)[1]
+        success = body.split("if (data.status === 'success')", 1)[1].split("if (data.status ===", 1)[0]
+        guard = success.find("if (DIRECT_LOGIN)")
+        relay = success.find("/api/garmin-ticket")
+        assert guard != -1, "success branch does not special-case DIRECT_LOGIN"
+        assert relay != -1, "expected the worker-mode ticket relay to still exist"
+        assert guard < relay, "DIRECT_LOGIN guard must come before the ticket relay"
+        assert "return;" in success[guard:relay], "DIRECT_LOGIN branch must return, not fall through"
+
+    def test_ticket_relay_still_used_in_worker_mode(self) -> None:
+        """Worker mode is unchanged — the tokens still have to be persisted."""
+        html = self._setup_html()
+        assert "di_token: data.di_token" in html
+
+
+class TestTokenStoreSelection:
+    """begin() must write the store sync later reads from.
+
+    get_client picks DBTokenStore when DATABASE_URL is set. If the direct
+    login authenticated against the default file store instead, a Postgres
+    self-host would save tokens to disk while sync read the database, and
+    every sync would report "needs MFA" forever (#296 review).
+    """
+
+    def test_begin_uses_the_same_kwargs_as_get_client(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        import hevy2garmin.garmin_login as gl
+
+        sentinel = {"email": "e@x.com", "password": "pw", "store": object(),
+                    "token_dir": "/tmp/.garminconnect"}
+        with patch("hevy2garmin.garmin.auth_kwargs", return_value=dict(sentinel)) as kw, \
+             patch.object(gl, "GarminAuth") as auth_cls:
+            auth_cls.return_value.login.return_value = MagicMock()
+            gl.begin("e@x.com", "pw")
+
+        kw.assert_called_once_with("e@x.com", "pw")
+        passed = auth_cls.call_args.kwargs
+        assert passed["store"] is sentinel["store"]
+        assert passed["token_dir"] == "/tmp/.garminconnect"
+        assert passed["return_on_mfa"] is True
+
+    def test_auth_kwargs_matches_get_client_without_database_url(self) -> None:
+        from unittest.mock import patch
+
+        from hevy2garmin.garmin import auth_kwargs
+
+        with patch("hevy2garmin.db.get_database_url", return_value=None):
+            kwargs = auth_kwargs("e@x.com", "pw", token_dir="~/.garminconnect")
+        assert "store" not in kwargs
+        assert kwargs["token_dir"] == "~/.garminconnect"
+
+    def test_auth_kwargs_selects_db_store_when_database_url_set(self) -> None:
+        from unittest.mock import MagicMock, patch
+
+        from hevy2garmin.garmin import auth_kwargs
+
+        with patch("hevy2garmin.db.get_database_url", return_value="postgresql://x/y"), \
+             patch("garmin_auth.storage.DBTokenStore", return_value=MagicMock()) as store:
+            kwargs = auth_kwargs("e@x.com", "pw")
+        store.assert_called_once_with("postgresql://x/y")
+        assert "store" in kwargs
+        assert kwargs["token_dir"] == "/tmp/.garminconnect"


### PR DESCRIPTION
Closes #295.

**Nothing here touches the Vercel deploy.** `vercel.json` builds `api/index.py` via `@vercel/python` and never reads the Dockerfile, so the Dockerfile and compose file are self-hosting-only artifacts. The one runtime change (direct Garmin login) is opt-in and off by default.

## Docs

A `## Self-hosting` section covering the compose quickstart, keeping credentials on your own machine, reverse-proxy guidance, the scheduling difference, and the non-root note. It documents what exists — including two honest limitations: sub-path reverse proxying is **not** supported yet (JS-built URLs escape the prefix), and direct Garmin login needs a writable home so it is not for serverless.

## Docker

- **`docker-compose.yml`** — named volumes for the sync DB and Garmin token store, port bound to `127.0.0.1`, `cap_drop: ALL`, `no-new-privileges`.
- **`.dockerignore`** — the build only needs `pyproject.toml`, `README.md` and `src/`; the context was shipping `tests/`, `.git` and any local `.venv`.
- **`HEALTHCHECK`** so compose restart policies and `docker ps` reflect real health.
- **Non-root runtime (uid 999)** — and **not a breaking change**. `HOME` deliberately stays `/root`: every path is HOME-relative (`~/.hevy2garmin`, `~/.garminconnect`), so the documented volume paths are unchanged and nothing has to move. Named volumes are handled automatically. Bind mounts — the `-v ~/.hevy2garmin:/root/.hevy2garmin` form in the README — need a one-time `sudo chown -R 999:999`, which the README now states.

## Direct Garmin login (opt-in, `H2G_DIRECT_GARMIN_LOGIN`)

Runs the Garmin password + MFA exchange on the instance itself rather than posting credentials to the hosted worker. Default is unchanged — flag off, worker path untouched, the setup page only swaps its two fetch targets when enabled.

## Verification

Built and run on **arm64 (Raspberry Pi)**, the platform this matters most for:

```
runs as        uid=999(nonroot) gid=999(nonroot)   HOME=/root
paths resolve  /root/.hevy2garmin/sync.db          (unchanged)
volumes        both writable
compose        Up (healthy), /login -> 200
bind mount     denied before `chown -R 999:999`, OK after   <- documented
```

Full suite: 514 passed, 7 skipped.

## Deliberately not included

The webhook receiver and the sub-path proxy fix. The webhook cannot work on serverless — Python on Vercel has no `waitUntil` equivalent, and Hobby crons are daily-only — so it needs to be framed as self-hosted-only and is a separate conversation. Happy to open it if you want it. I also split this so you can take the docs and Docker pieces without the login change if you would rather; say the word and I will drop that commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)