### PR TITLE
feat(mapper): normalized-title fallback for formatting drift

### DIFF
--- a/src/hevy2garmin/mapper.py
+++ b/src/hevy2garmin/mapper.py
@@ -18,6 +18,8 @@ FIT SDK exercise categories used:
 
 from __future__ import annotations
 
+import re
+
 from hevy2garmin.template_map import TEMPLATE_TO_GARMIN
 
 # --------------------------------------------------------------------------- #
@@ -728,6 +730,33 @@ def save_custom_mapping(hevy_name: str, category: int, subcategory: int) -> None
     _custom_mappings[hevy_name] = (category, subcategory)
 
 
+def _normalize_name(name: str) -> str:
+    """Collapse a Hevy title to its alphanumeric skeleton (lowercased).
+
+    Strips case, whitespace and punctuation so minor title formatting drift
+    (``Bench Press - Close Grip`` vs ``Bench Press – Close Grip``, stray
+    spaces, differing brackets) still resolves. This is NOT fuzzy matching:
+    only exact alphanumeric matches collapse together, so two genuinely
+    different exercises never collide. Letter-level typos ("Palloff" vs
+    "Pallof") stay misses by design — a wrong mapping is worse than UNKNOWN.
+    """
+    return re.sub(r"[^a-z0-9]+", "", name.lower())
+
+
+# Lazily-built normalized index of the built-in table (static at runtime).
+_normalized_index: dict[str, tuple[int, int]] | None = None
+
+
+def _get_normalized_index() -> dict[str, tuple[int, int]]:
+    global _normalized_index
+    if _normalized_index is None:
+        index: dict[str, tuple[int, int]] = {}
+        for name, pair in HEVY_TO_GARMIN.items():
+            index.setdefault(_normalize_name(name), pair)
+        _normalized_index = index
+    return _normalized_index
+
+
 def lookup_exercise(hevy_name: str, template_id: str | None = None) -> tuple[int, int, str]:
     """Return ``(category, subcategory, display_name)`` for a Hevy exercise.
 
@@ -736,6 +765,8 @@ def lookup_exercise(hevy_name: str, template_id: str | None = None) -> tuple[int
       2. The built-in English-name table.
       3. Hevy ``exercise_template_id``, which is the same regardless of the
          user's Hevy language, so non-English exercises still map (#173).
+      4. Normalized fallback (case/space/punctuation-insensitive) against the
+         custom mappings and then the table.
 
     The table is consulted before the template id even though the template id
     is the more precise key. ``TEMPLATE_TO_GARMIN`` is generated *from* this
@@ -761,6 +792,15 @@ def lookup_exercise(hevy_name: str, template_id: str | None = None) -> tuple[int
     #    table does not carry.
     if template_id:
         pair = TEMPLATE_TO_GARMIN.get(template_id)
+        if pair is not None:
+            return (pair[0], pair[1], hevy_name)
+    # 4. Normalized fallback — tolerates formatting drift, never fuzzy.
+    norm = _normalize_name(hevy_name)
+    if norm:
+        for name, custom_pair in _custom_mappings.items():
+            if _normalize_name(name) == norm:
+                return (custom_pair[0], custom_pair[1], hevy_name)
+        pair = _get_normalized_index().get(norm)
         if pair is not None:
             return (pair[0], pair[1], hevy_name)
     return (_UNKNOWN_CATEGORY, _UNKNOWN_SUBCATEGORY, hevy_name)

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -318,3 +318,83 @@ class TestGeneratedTemplateMapIsCurrent:
             "above. Re-run scripts/gen_template_map.py, or update both files in "
             "the same commit."
         )
+
+
+class TestNormalizedTitleFallback:
+    """A title that differs from the table key only in formatting still maps.
+
+    Hevy titles drift in punctuation and spacing (an en-dash where the table
+    has a hyphen, a doubled space, different brackets). Comparing alphanumeric
+    skeletons recovers those without ever guessing: only an exact match after
+    normalization counts, so two different exercises cannot collapse together
+    and a letter-level typo stays UNKNOWN rather than mapping to the wrong
+    Garmin exercise.
+    """
+
+    def test_en_dash_instead_of_hyphen(self) -> None:
+        key = next(k for k in HEVY_TO_GARMIN if " - " in k)
+        cat, sub, name = lookup_exercise(key.replace(" - ", " – "))
+        assert (cat, sub) == HEVY_TO_GARMIN[key]
+        assert name == key.replace(" - ", " – "), "the caller's title is echoed back"
+
+    def test_case_and_spacing_drift(self) -> None:
+        cat, sub, _ = lookup_exercise("bench  press   (BARBELL)")
+        assert (cat, sub) == HEVY_TO_GARMIN["Bench Press (Barbell)"]
+
+    def test_punctuation_dropped_entirely(self) -> None:
+        cat, sub, _ = lookup_exercise("Bench Press Barbell")
+        assert (cat, sub) == HEVY_TO_GARMIN["Bench Press (Barbell)"]
+
+    def test_letter_typo_stays_unknown(self) -> None:
+        """Not fuzzy: a misspelling must not resolve to a near neighbour."""
+        cat, _, _ = lookup_exercise("Bnch Press (Barbell)")
+        assert cat == _UNKNOWN_CATEGORY
+
+    def test_unrelated_name_stays_unknown(self) -> None:
+        cat, _, _ = lookup_exercise("Totally Made Up Exercise")
+        assert cat == _UNKNOWN_CATEGORY
+
+    def test_exact_match_is_not_affected(self) -> None:
+        """The normalized index is a fallback — exact keys resolve before it."""
+        for key in list(HEVY_TO_GARMIN)[:50]:
+            cat, sub, _ = lookup_exercise(key)
+            assert (cat, sub) == HEVY_TO_GARMIN[key], key
+
+    def test_template_id_wins_over_the_normalized_fallback(self) -> None:
+        """Order matters: an exact id is more precise than a normalized name."""
+        from hevy2garmin.template_map import TEMPLATE_TO_GARMIN
+
+        tid = next(iter(TEMPLATE_TO_GARMIN))
+        cat, sub, _ = lookup_exercise("bench  press (barbell)!!", template_id=tid)
+        assert (cat, sub) == TEMPLATE_TO_GARMIN[tid]
+
+    def test_custom_mapping_resolves_through_normalization(self, tmp_path, monkeypatch) -> None:
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _custom_mappings.clear()
+        _ensure_custom_loaded()
+        save_custom_mapping("My Weird Lift (Sandbag)", 3, 4)
+        try:
+            cat, sub, _ = lookup_exercise("my weird lift  sandbag")
+            assert (cat, sub) == (3, 4)
+        finally:
+            _custom_mappings.clear()
+
+    def test_normalized_index_prefers_the_first_table_entry(self) -> None:
+        """Two keys with the same skeleton must resolve deterministically."""
+        from hevy2garmin import mapper
+
+        mapper._normalized_index = None
+        try:
+            with patch.dict(
+                mapper.HEVY_TO_GARMIN,
+                {"Zzz Test (Thing)": (1, 2), "Zzz  Test Thing": (5, 6)},
+            ):
+                cat, sub, _ = lookup_exercise("zzztestthing")
+                assert (cat, sub) == (1, 2)
+        finally:
+            mapper._normalized_index = None
+
+    def test_empty_and_whitespace_titles_stay_unknown(self) -> None:
+        for title in ("", "   ", "!!!"):
+            cat, _, _ = lookup_exercise(title)
+            assert cat == _UNKNOWN_CATEGORY, title


### PR DESCRIPTION
Closes #297

Resolves a Hevy title whose punctuation or spacing differs from the table key by comparing
alphanumeric skeletons: `Bench Press – Close Grip` (en-dash), `bench  press   (BARBELL)`,
`Bench Press Barbell` all reach `Bench Press (Barbell)`.

**Exact match only after normalization — never fuzzy.** Two different exercises cannot collide,
and a letter-level typo (`Bnch Press (Barbell)`) stays UNKNOWN, because a wrong mapping is worse
than no mapping. Tests assert exactly that.

Ordering: this sits **last**, after custom mappings, the table and the template id, so it can only
ever turn a miss into a hit. Nothing that resolves today changes. The normalized index is built
lazily once and `setdefault` makes collisions deterministic (first table entry wins).

Tests: 9 new cases — each drift kind, the two negative cases, exact-match keys unaffected,
template id still winning over the fallback, custom mappings resolving through it, and empty /
punctuation-only titles staying UNKNOWN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)