### PR TITLE
fix(ui): describe the merge strategy as combining, not pushing into

### DIFF
--- a/src/hevy2garmin/templates/settings.html
+++ b/src/hevy2garmin/templates/settings.html
@@ -172,7 +172,7 @@
             </label>
         </div>
         <p class="section-description">
-            When you start a <strong>Strength Training</strong> activity on your Garmin watch at the gym, hevy2garmin will detect it and push your Hevy exercise data into that activity instead of creating a new one.
+            When you start a <strong>Strength Training</strong> activity on your Garmin watch at the gym, hevy2garmin will detect it and combine your Hevy exercise data with that activity instead of creating a new one.
             You get 1-second HR sampling, training effect, EPOC, and recovery data. If no matching watch activity is found, it falls back to the normal upload.
         </p>
     </div>


### PR DESCRIPTION
Closes #298

One line in `settings.html`. "push your Hevy exercise data **into** that activity" reads as a
promise that the sets land in the watch activity as named exercises — the one thing that strategy
cannot deliver, since Garmin ignores pushed names on device-recorded activities. "Combine ... with"
describes what happens without implying the names survive.

The sentence about the fallback below it is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)