### PR TITLE
feat(server): serve correctly under a reverse-proxy sub-path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,12 @@ HEVY2GARMIN_SECRET=
 # Needs a writable home directory, so it does not work on serverless.
 H2G_DIRECT_GARMIN_LOGIN=
 
+# Believe X-Forwarded-Prefix, for serving the dashboard under a reverse-proxy
+# sub-path. Off by default because any client can send that header and every URL
+# on the page derives from it — only turn this on when your proxy sets the header
+# itself. See "Behind a reverse proxy" in the README.
+H2G_TRUST_FORWARDED_PREFIX=
+
 # ── Vercel-specific (auto-set by Vercel) ──────────────────────────────────
 # DATABASE_URL=              # Auto-set by Vercel Postgres integration
 # VERCEL=1                   # Auto-set when running on Vercel

--- a/README.md
+++ b/README.md
@@ -363,7 +363,30 @@ Your Hevy API key stays local either way.
 
 Put the dashboard behind nginx, Caddy or Traefik on a subdomain, terminate TLS there, and keep the container bound to `127.0.0.1`. **Set `H2G_PASSWORD` before exposing it** — see [Securing the dashboard](#securing-the-dashboard).
 
-Serving it at the **root of a subdomain** (`https://hevy.example.com/`) works. Serving it under a **sub-path** (`https://example.com/hevy2garmin/`) is not fully supported yet: the templates build some URLs in JavaScript against the origin root, so those requests escape the prefix.
+Serving it at the **root of a subdomain** (`https://hevy.example.com/`) works with no extra configuration.
+
+Serving it under a **sub-path** (`https://example.com/hevy2garmin/`) works too, as long as the proxy tells the app which sub-path it is mounted at. Send `X-Forwarded-Prefix` and strip the prefix from the forwarded path:
+
+```nginx
+location /hevy2garmin/ {
+    proxy_pass http://127.0.0.1:8123/;
+    proxy_set_header Host              $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Prefix /hevy2garmin;
+}
+```
+
+Caddy equivalent:
+
+```caddyfile
+handle_path /hevy2garmin/* {
+    reverse_proxy 127.0.0.1:8123 {
+        header_up X-Forwarded-Prefix /hevy2garmin
+    }
+}
+```
+
+The app then emits every link, asset, form action, htmx call, redirect and JavaScript-built API URL under that prefix. The proxy does **not** need to rewrite response bodies. Without the header nothing changes, so a root install and the Vercel deploy are unaffected.
 
 ### Keeping it in sync
 

--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ Put the dashboard behind nginx, Caddy or Traefik on a subdomain, terminate TLS t
 
 Serving it at the **root of a subdomain** (`https://hevy.example.com/`) works with no extra configuration.
 
-Serving it under a **sub-path** (`https://example.com/hevy2garmin/`) works too, as long as the proxy tells the app which sub-path it is mounted at. Send `X-Forwarded-Prefix` and strip the prefix from the forwarded path:
+Serving it under a **sub-path** (`https://example.com/hevy2garmin/`) works too. It needs two things: the proxy tells the app which sub-path it is mounted at, and you set `H2G_TRUST_FORWARDED_PREFIX=true` so the app believes it.
 
 ```nginx
 location /hevy2garmin/ {
@@ -376,7 +376,9 @@ location /hevy2garmin/ {
 }
 ```
 
-Caddy equivalent:
+**The opt-in is not busywork.** Any client can send `X-Forwarded-Prefix`, and every URL on the page is built from it — the login form's `action`, the Garmin token POST, redirect targets. On an instance that is *not* behind a prefix-setting proxy, believing the header would let a caller re-point those at their own host. So the header is ignored unless you turn this on, and even then only a plain absolute path is accepted (no `//host`, no scheme, no quotes or angle brackets); anything else is treated as no prefix and the app serves from the root. **Your proxy must set the header itself rather than passing a client-supplied one through.**
+
+Caddy equivalent (`header_up` replaces any incoming value, which is what you want):
 
 ```caddyfile
 handle_path /hevy2garmin/* {

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextvars
 import logging
 import os
 import re
@@ -40,6 +41,53 @@ logger = logging.getLogger("hevy2garmin")
 
 TEMPLATES_DIR = Path(__file__).parent / "templates"
 STATIC_DIR = Path(__file__).parent / "static"
+
+# Sub-path this app is served under when it sits behind a reverse proxy that
+# mounts it below the origin root (X-Forwarded-Prefix, e.g. "/apps/hevy2garmin").
+# Empty for a normal root install; set per request by the middleware.
+#
+# Every URL this app emits is root-absolute ("/workouts", "/api/sync-one"), which
+# is correct at the root and wrong one level down, so all three kinds are moved
+# onto the prefix: HTML attributes and redirect Locations server-side (below),
+# and the URLs the page's JavaScript builds at runtime via `window.APP_PREFIX`
+# (base.html). A proxy cannot fix the third kind, so the app has to own all of it.
+_url_prefix: contextvars.ContextVar[str] = contextvars.ContextVar("url_prefix", default="")
+
+# Root-absolute URL in an attribute that navigates or fetches. Deliberately not
+# every attribute: only these carry a URL the browser resolves against the origin.
+_ROOT_ABSOLUTE_ATTR = re.compile(
+    r'(\s(?:href|src|action|hx-get|hx-post|hx-put|hx-patch|hx-delete)=")/(?!/)'
+)
+
+
+def _apply_prefix(html: str, prefix: str) -> str:
+    """Move root-absolute URL attributes in ``html`` onto ``prefix``.
+
+    A no-op without a prefix, so a root install renders byte-identical HTML.
+    Rewriting the rendered output rather than the templates keeps the prefix out
+    of ~50 template call sites, where a single missed one is an unreachable page.
+    Already-prefixed URLs are left alone, so this stays safe to apply twice (a
+    proxy that does its own HTML rewriting may have got there first).
+    """
+    if not prefix:
+        return html
+
+    def _sub(m: re.Match[str]) -> str:
+        rest = html[m.end() - 1 :]
+        if rest == prefix or rest.startswith((prefix + "/", prefix + '"', prefix + "?")):
+            return m.group(0)
+        return f"{m.group(1)}{prefix}/"
+
+    return _ROOT_ABSOLUTE_ATTR.sub(_sub, html)
+
+
+def _prefix_location(location: str, prefix: str) -> str:
+    """Move a root-relative redirect target onto ``prefix``; idempotent."""
+    if not prefix or not location.startswith("/") or location.startswith("//"):
+        return location
+    if location == prefix or location.startswith((prefix + "/", prefix + "?")):
+        return location
+    return prefix + location
 
 
 def _get_cat_names() -> dict[int, str]:
@@ -81,7 +129,9 @@ def _render(template_name: str, **ctx) -> HTMLResponse:
     ctx.setdefault("auth_enabled", auth_enabled())
     ctx.setdefault("demo_mode", is_demo_mode())
     ctx.setdefault("version", __version__)
-    return HTMLResponse(t.render(**ctx))
+    prefix = _url_prefix.get()
+    ctx.setdefault("url_prefix", prefix)
+    return HTMLResponse(_apply_prefix(t.render(**ctx), prefix))
 
 
 app = FastAPI(title="hevy2garmin", docs_url=None, redoc_url=None)
@@ -401,6 +451,7 @@ def _session_epoch() -> int:
 
 _is_configured_cache: bool | None = None
 
+
 @app.middleware("http")
 async def check_setup(request: Request, call_next):
     global _is_configured_cache
@@ -453,6 +504,32 @@ async def check_setup(request: Request, call_next):
     return response
 
 
+# Registered after check_setup so it wraps it, which is what lets it fix the
+# Location of the redirects check_setup issues itself (the /login and /setup
+# gates) — those never reach a route handler.
+@app.middleware("http")
+async def reverse_proxy_prefix(request: Request, call_next):
+    """Serve correctly when a proxy mounts this app below the origin root.
+
+    Reads X-Forwarded-Prefix (e.g. "/apps/hevy2garmin") once per request and
+    publishes it for the rest of the request; the trailing slash is trimmed so
+    callers concatenate a leading-slash path. Redirect targets are moved onto
+    the prefix here, because a proxy sees only a root-relative Location it has
+    no way to attribute. Empty header = empty prefix = unchanged behaviour.
+    """
+    prefix = request.headers.get("x-forwarded-prefix", "").rstrip("/")
+    token = _url_prefix.set(prefix)
+    try:
+        response = await call_next(request)
+    finally:
+        _url_prefix.reset(token)
+    if prefix:
+        location = response.headers.get("location")
+        if location:
+            response.headers["location"] = _prefix_location(location, prefix)
+    return response
+
+
 @app.middleware("http")
 async def security_headers(request: Request, call_next):
     """Defense-in-depth response headers. Registered after check_setup so it is
@@ -479,13 +556,20 @@ async def security_headers(request: Request, call_next):
 
 # ── Auth pages ───────────────────────────────────────────────────────────────
 
+def _render_login(*, error: str | None, status_code: int = 200) -> HTMLResponse:
+    """Render login.html. Not routed through _render: it has no shared context."""
+    prefix = _url_prefix.get()
+    html = _jinja_env.get_template("login.html").render(error=error, url_prefix=prefix)
+    return HTMLResponse(_apply_prefix(html, prefix), status_code=status_code)
+
+
 @app.get("/login", response_class=HTMLResponse)
 async def login_page(request: Request):
     """Show login form. Redirects to dashboard if already authenticated or auth disabled."""
     if not auth_enabled() or verify_session(request.cookies.get(SESSION_COOKIE), _session_epoch()):
         return RedirectResponse("/")
     error = request.query_params.get("error")
-    return HTMLResponse(_jinja_env.get_template("login.html").render(error=error))
+    return _render_login(error=error)
 
 
 @app.post("/login")
@@ -503,10 +587,7 @@ async def login_submit(request: Request, password: str = Form(...)):
         store = None  # DB unavailable → skip the limiter (never lock the admin out on an outage)
 
     def _error(msg: str, status: int) -> HTMLResponse:
-        return HTMLResponse(
-            _jinja_env.get_template("login.html").render(error=msg),
-            status_code=status,
-        )
+        return _render_login(error=msg, status_code=status)
 
     # Rate limit: check the lockout BEFORE comparing credentials.
     remaining = login_ratelimit.lockout_remaining(store, key) if store else 0

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -59,6 +59,43 @@ _ROOT_ABSOLUTE_ATTR = re.compile(
     r'(\s(?:href|src|action|hx-get|hx-post|hx-put|hx-patch|hx-delete)=")/(?!/)'
 )
 
+# A prefix is a single-origin absolute path and nothing else. The character class
+# excludes ":" (no scheme), quotes and angle brackets (no breaking out of an
+# attribute or a script tag), and the explicit "//" rejection blocks a
+# protocol-relative value, which would silently re-point every URL on the page at
+# another host.
+_SAFE_PREFIX = re.compile(r"^/[A-Za-z0-9._~/-]+$")
+
+
+def trust_forwarded_prefix() -> bool:
+    """Whether X-Forwarded-Prefix may be believed.
+
+    Off by default, and that default is the security boundary: any client can
+    send the header, so on a directly-exposed instance — or one behind a proxy
+    that forwards client headers untouched — trusting it hands an attacker
+    control of every URL the page emits, including the login form's action and
+    the Garmin token POST. Only the operator knows a proxy is setting it.
+    """
+    return os.environ.get("H2G_TRUST_FORWARDED_PREFIX", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def _validated_prefix(raw: str) -> str:
+    """Normalize a claimed sub-path, or return "" if it is not one.
+
+    Rejecting outright rather than sanitizing: a prefix that needed cleaning was
+    not sent by the proxy this feature exists for, and serving the page at the
+    origin root is the safe fallback in every case.
+    """
+    candidate = (raw or "").strip().rstrip("/")
+    if not candidate or candidate.startswith("//") or not _SAFE_PREFIX.match(candidate):
+        return ""
+    return candidate
+
 
 def _apply_prefix(html: str, prefix: str) -> str:
     """Move root-absolute URL attributes in ``html`` onto ``prefix``.
@@ -72,18 +109,29 @@ def _apply_prefix(html: str, prefix: str) -> str:
     if not prefix:
         return html
 
+    # Escaped even though _validated_prefix already excludes every character
+    # that matters here: this is the sink, and a sink that cannot be broken
+    # regardless of what reaches it does not depend on validation staying correct.
+    safe = escape(prefix, quote=True)
+
     def _sub(m: re.Match[str]) -> str:
         rest = html[m.end() - 1 :]
-        if rest == prefix or rest.startswith((prefix + "/", prefix + '"', prefix + "?")):
+        if rest == safe or rest.startswith((safe + "/", safe + '"', safe + "?")):
             return m.group(0)
-        return f"{m.group(1)}{prefix}/"
+        return f"{m.group(1)}{safe}/"
 
     return _ROOT_ABSOLUTE_ATTR.sub(_sub, html)
 
 
 def _prefix_location(location: str, prefix: str) -> str:
-    """Move a root-relative redirect target onto ``prefix``; idempotent."""
-    if not prefix or not location.startswith("/") or location.startswith("//"):
+    """Move a root-relative redirect target onto ``prefix``; idempotent.
+
+    Both sides are checked for a protocol-relative form: a "//evil.example.com"
+    prefix would otherwise turn any internal redirect into an off-site one.
+    """
+    if not prefix or prefix.startswith("//"):
+        return location
+    if not location.startswith("/") or location.startswith("//"):
         return location
     if location == prefix or location.startswith((prefix + "/", prefix + "?")):
         return location
@@ -516,8 +564,16 @@ async def reverse_proxy_prefix(request: Request, call_next):
     callers concatenate a leading-slash path. Redirect targets are moved onto
     the prefix here, because a proxy sees only a root-relative Location it has
     no way to attribute. Empty header = empty prefix = unchanged behaviour.
+
+    The header is only read when H2G_TRUST_FORWARDED_PREFIX is set, and then only
+    if it is a plain absolute path — see trust_forwarded_prefix and
+    _validated_prefix. Anything else is treated as no prefix at all.
     """
-    prefix = request.headers.get("x-forwarded-prefix", "").rstrip("/")
+    prefix = (
+        _validated_prefix(request.headers.get("x-forwarded-prefix", ""))
+        if trust_forwarded_prefix()
+        else ""
+    )
     token = _url_prefix.set(prefix)
     try:
         response = await call_next(request)

--- a/src/hevy2garmin/templates/base.html
+++ b/src/hevy2garmin/templates/base.html
@@ -9,6 +9,10 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <!-- Sub-path this app is mounted under behind a reverse proxy; empty at the
+         root. A proxy can rewrite root-absolute href/src/action attributes, but
+         not URLs that JavaScript builds at runtime — those must use this. -->
+    <script>window.APP_PREFIX = {{ (url_prefix or '')|tojson }};</script>
     <script src="https://unpkg.com/htmx.org@2.0.4"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
     <style>

--- a/src/hevy2garmin/templates/dashboard.html
+++ b/src/hevy2garmin/templates/dashboard.html
@@ -439,7 +439,7 @@ async function syncNow() {
 
     while (!_syncStopped) {
         try {
-            const resp = await fetch('/api/sync-one', { method: 'POST' });
+            const resp = await fetch(window.APP_PREFIX + '/api/sync-one', { method: 'POST' });
             const data = await resp.json();
 
             if (data.busy) {

--- a/src/hevy2garmin/templates/mappings.html
+++ b/src/hevy2garmin/templates/mappings.html
@@ -236,7 +236,7 @@ document.querySelectorAll('#mappings-table tr.mapping-row').forEach(row => {
 
 // Load categories from API and populate all category selects
 let catData = {};
-fetch('/api/garmin-categories').then(r => r.json()).then(data => {
+fetch(window.APP_PREFIX + '/api/garmin-categories').then(r => r.json()).then(data => {
     catData = data;
     const selects = document.querySelectorAll('.cat-select');
     // Sort by numeric ID

--- a/src/hevy2garmin/templates/setup.html
+++ b/src/hevy2garmin/templates/setup.html
@@ -219,7 +219,7 @@ async function handleGarminLoginResponse(data) {
             return;
         }
         // Persist tokens on our server
-        const storeResp = await fetch('/api/garmin-ticket', {
+        const storeResp = await fetch(window.APP_PREFIX + '/api/garmin-ticket', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ tokens: {
@@ -260,7 +260,7 @@ async function handleGarminLoginResponse(data) {
     if (data.status === 'rate_limited') {
         // Record the cooldown server-side so the dashboard can display it,
         // then disable the Connect button so the user can't retry and reset Garmin's timer.
-        fetch('/api/garmin-rate-limited', { method: 'POST' }).catch(function() {});
+        fetch(window.APP_PREFIX + '/api/garmin-rate-limited', { method: 'POST' }).catch(function() {});
         var connectBtn = document.getElementById('garmin_connect_btn');
         if (connectBtn) { connectBtn.disabled = true; }
         result.innerHTML = '<span style="color: var(--red);">&#10007; Garmin rate-limited this account on their side (separate from your password, your Garmin app still works). It clears on its own, usually within a few hours. Repeated retries just reset the timer, so leave it a while and try once more.</span>';
@@ -346,7 +346,7 @@ async function exchangeTicket() {
             return;
         }
         // Step 2: Store tokens on our server (garmin-auth >= 0.3.0 single-file DI format)
-        const storeResp = await fetch('/api/garmin-ticket', {
+        const storeResp = await fetch(window.APP_PREFIX + '/api/garmin-ticket', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ tokens: {

--- a/src/hevy2garmin/templates/setup.html
+++ b/src/hevy2garmin/templates/setup.html
@@ -155,7 +155,7 @@ async function garminConnect() {
     btn.disabled = true;
     result.innerHTML = '<span style="color: var(--text-muted);">Connecting to Garmin...</span>';
     try {
-        const url = DIRECT_LOGIN ? '/api/garmin-login' : (GARMIN_WORKER_BASE + '/login');
+        const url = DIRECT_LOGIN ? (window.APP_PREFIX + '/api/garmin-login') : (GARMIN_WORKER_BASE + '/login');
         const resp = await fetch(url, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -185,7 +185,7 @@ async function garminSubmitMfa() {
     btn.disabled = true;
     result.innerHTML = '<span style="color: var(--text-muted);">Verifying code...</span>';
     try {
-        const url = DIRECT_LOGIN ? '/api/garmin-login-mfa' : (GARMIN_WORKER_BASE + '/login-mfa');
+        const url = DIRECT_LOGIN ? (window.APP_PREFIX + '/api/garmin-login-mfa') : (GARMIN_WORKER_BASE + '/login-mfa');
         const body = DIRECT_LOGIN
             ? { session_id: garminMfaSessionId, code: code }
             : { session_id: garminMfaSessionId, mfa_code: code };
@@ -362,7 +362,7 @@ async function exchangeTicket() {
                 + 'If your first sync fails with an upload error, go to '
                 + '<a href="https://connect.garmin.com/modern/settings" target="_blank" style="color: var(--accent);">Garmin Connect Settings</a>'
                 + ' > Data > enable <strong>Device Upload</strong>. This is a one-time requirement for some accounts.</p>';
-            setTimeout(function() { window.location.href = '/'; }, 5000);
+            setTimeout(function() { window.location.href = (window.APP_PREFIX || '') + '/'; }, 5000);
         } else {
             result.innerHTML = '<span style="font-size: 12px; color: var(--red);">&#10007; ' + (storeData.error || 'Failed to save tokens') + '</span>';
         }

--- a/src/hevy2garmin/templates/workouts.html
+++ b/src/hevy2garmin/templates/workouts.html
@@ -374,7 +374,7 @@ async function loadHRChart(hevyId, summaryEl) {
     if (hrChartCache[hevyId]) return; // already loaded
 
     try {
-        const resp = await fetch('/api/workout/' + hevyId + '/hr');
+        const resp = await fetch(window.APP_PREFIX + '/api/workout/' + hevyId + '/hr');
         if (!resp.ok) {
             const err = await resp.json();
             container.innerHTML = '<p style="color: var(--text-muted); font-size: 13px; padding: 12px 0;">No HR data available' + (err.error ? ': ' + err.error : '') + '</p>';
@@ -522,11 +522,11 @@ async function resyncWorkout(hevyId, btn) {
         // Step 1: unsync + delete old Garmin activity
         const form = new FormData();
         form.append('delete_garmin', 'true');
-        const unsyncResp = await fetch('/api/unsync/' + hevyId, { method: 'POST', body: form });
+        const unsyncResp = await fetch(window.APP_PREFIX + '/api/unsync/' + hevyId, { method: 'POST', body: form });
         const unsyncData = await unsyncResp.json();
         if (!unsyncData.ok) { alert('Unsync failed: ' + (unsyncData.error || 'Unknown')); btn.disabled = false; btn.textContent = 'Re-sync'; return; }
         // Step 2: re-sync with force=1 (bypass dedup check)
-        const syncResp = await fetch('/api/sync/' + hevyId + '?force=1', { method: 'POST' });
+        const syncResp = await fetch(window.APP_PREFIX + '/api/sync/' + hevyId + '?force=1', { method: 'POST' });
         if (syncResp.ok) { window.location.reload(); }
         else { alert('Re-sync upload failed. The workout is now pending — try syncing from the dashboard.'); window.location.reload(); }
     } catch (e) {
@@ -547,7 +547,7 @@ async function pendingAction(hevyId, action, btn) {
     const form = new FormData();
     if (action === 'retry' || action === 'abandon') form.append('confirm', hevyId);
     try {
-        const resp = await fetch('/api/pending/' + encodeURIComponent(hevyId) + '/' + action, {method: 'POST', body: form});
+        const resp = await fetch(window.APP_PREFIX + '/api/pending/' + encodeURIComponent(hevyId) + '/' + action, {method: 'POST', body: form});
         const data = await resp.json();
         if (!resp.ok || !data.ok) throw new Error(data.error || 'Operation failed');
         window.location.reload();
@@ -571,7 +571,7 @@ async function manualAction(hevyId, action, btn) {
     }
     btn.disabled = true;
     try {
-        const resp = await fetch('/api/workout/' + encodeURIComponent(hevyId) + '/' + action, {method: 'POST', body: form});
+        const resp = await fetch(window.APP_PREFIX + '/api/workout/' + encodeURIComponent(hevyId) + '/' + action, {method: 'POST', body: form});
         const data = await resp.json();
         if (!resp.ok || !data.ok) throw new Error(data.error || 'Operation failed');
         window.location.reload();
@@ -586,7 +586,7 @@ async function unsyncWorkout(hevyId, btn) {
     btn.textContent = 'Removing…';
     try {
         const form = new FormData();
-        const resp = await fetch('/api/unsync/' + hevyId, { method: 'POST', body: form });
+        const resp = await fetch(window.APP_PREFIX + '/api/unsync/' + hevyId, { method: 'POST', body: form });
         const data = await resp.json();
         if (data.ok) {
             window.location.reload();
@@ -610,7 +610,7 @@ async function unsyncAll(btn) {
     try {
         const form = new FormData();
         form.append('confirm', 'RESET');
-        const resp = await fetch('/api/unsync-all', { method: 'POST', body: form });
+        const resp = await fetch(window.APP_PREFIX + '/api/unsync-all', { method: 'POST', body: form });
         const data = await resp.json();
         if (data.ok) {
             window.location.reload();

--- a/tests/test_reverse_proxy_prefix.py
+++ b/tests/test_reverse_proxy_prefix.py
@@ -1,0 +1,159 @@
+"""Tests for serving the dashboard under a reverse-proxy sub-path.
+
+A proxy that mounts this app below the origin root (e.g. at
+"/apps/hevy2garmin") can rewrite root-absolute references in the HTML it
+forwards — href, src, action, hx-* — but it cannot rewrite URLs that the
+page's JavaScript builds at runtime. Those are rendered against
+``window.APP_PREFIX``, which carries the X-Forwarded-Prefix value. With no
+such header (a normal root install) the prefix must be empty so the emitted
+URLs are unchanged.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    os.environ.pop("HEVY2GARMIN_SECRET", None)
+    os.environ.pop("DEMO_MODE", None)
+    from hevy2garmin.server import app
+
+    yield TestClient(app, follow_redirects=False)
+
+
+def _app_prefix(html: str) -> str:
+    m = re.search(r"window\.APP_PREFIX = (.*?);", html)
+    assert m, "window.APP_PREFIX global not rendered"
+    return m.group(1)
+
+
+class TestReverseProxyPrefix:
+    def test_prefix_injected_from_forwarded_header(self, client):
+        """X-Forwarded-Prefix reaches the page, with the trailing slash trimmed."""
+        resp = client.get("/setup", headers={"X-Forwarded-Prefix": "/apps/hevy2garmin/"})
+        assert resp.status_code == 200
+        assert _app_prefix(resp.text) == '"/apps/hevy2garmin"'
+
+    def test_prefix_empty_without_header(self, client):
+        """A root install is unaffected: the prefix is an empty string."""
+        resp = client.get("/setup")
+        assert resp.status_code == 200
+        assert _app_prefix(resp.text) == '""'
+
+    def test_prefix_does_not_leak_between_requests(self, client):
+        """The prefix is per-request state, not sticky across requests."""
+        client.get("/setup", headers={"X-Forwarded-Prefix": "/apps/hevy2garmin"})
+        resp = client.get("/setup")
+        assert _app_prefix(resp.text) == '""'
+
+    def test_prefix_is_json_escaped(self, client):
+        """The header is attacker-controllable, so it must be escaped, not interpolated."""
+        resp = client.get("/setup", headers={"X-Forwarded-Prefix": '/x"</script><script>x'})
+        assert "</script><script>x" not in _app_prefix(resp.text)
+
+    def test_client_side_urls_are_prefixed(self, client):
+        """Every JS-built API URL on the page resolves under the sub-path."""
+        resp = client.get("/setup", headers={"X-Forwarded-Prefix": "/apps/hevy2garmin"})
+        assert "window.APP_PREFIX + '/api/garmin-ticket'" in resp.text
+        # No JS fetch() may target a root-absolute path.
+        assert not re.search(r"fetch\((['\"])/(?!/)", resp.text)
+
+
+class TestServerRenderedUrlsArePrefixed:
+    """Root-absolute href/src/action/hx-* must move onto the prefix too.
+
+    The JS globals alone are not enough: an ordinary nginx/Caddy/Traefik
+    sub-path mount forwards the HTML untouched, so navigation, static assets
+    and every htmx call would still resolve against the origin root. The app
+    is the only component that can fix all three kinds of URL, so it owns all
+    three.
+    """
+
+    PREFIX = "/apps/hevy2garmin"
+
+    def test_no_root_absolute_attribute_survives(self, client):
+        resp = client.get("/setup", headers={"X-Forwarded-Prefix": self.PREFIX})
+        assert resp.status_code == 200
+        leftovers = re.findall(
+            r'\s(?:href|src|action|hx-get|hx-post|hx-put|hx-patch|hx-delete)="/(?!/)[^"]*',
+            resp.text,
+        )
+        assert [x for x in leftovers if self.PREFIX not in x] == []
+
+    def test_navigation_and_assets_are_prefixed(self, client):
+        resp = client.get("/setup", headers={"X-Forwarded-Prefix": self.PREFIX})
+        assert f'src="{self.PREFIX}/static/favicon.svg"' in resp.text
+        assert f'action="{self.PREFIX}/setup"' in resp.text
+
+    def test_external_urls_are_untouched(self, client):
+        resp = client.get("/setup", headers={"X-Forwarded-Prefix": self.PREFIX})
+        assert 'href="https://fonts.googleapis.com' in resp.text
+        assert f"{self.PREFIX}/https:" not in resp.text
+
+    def test_protocol_relative_urls_are_untouched(self, client):
+        from hevy2garmin.server import _apply_prefix
+
+        assert _apply_prefix(' src="//cdn.example.com/x.js"', "/p") == ' src="//cdn.example.com/x.js"'
+
+    def test_rewrite_is_idempotent(self, client):
+        """A proxy may already have rewritten the HTML — don't prefix twice."""
+        from hevy2garmin.server import _apply_prefix
+
+        once = _apply_prefix(' href="/workouts" action="/login"', "/p")
+        assert once == ' href="/p/workouts" action="/p/login"'
+        assert _apply_prefix(once, "/p") == once
+
+    def test_prefix_root_link_is_not_doubled(self):
+        from hevy2garmin.server import _apply_prefix
+
+        assert _apply_prefix(' href="/p"', "/p") == ' href="/p"'
+        assert _apply_prefix(' href="/p?x=1"', "/p") == ' href="/p?x=1"'
+
+    def test_root_install_html_is_byte_identical(self, client):
+        """No header must mean no rewriting at all, not merely equivalent output."""
+        plain = client.get("/setup").text
+        from hevy2garmin.server import _apply_prefix
+
+        assert _apply_prefix(plain, "") == plain
+        assert 'action="/setup"' in plain
+
+
+class TestRedirectLocationIsPrefixed:
+    """A root-relative Location escapes the sub-path unless the app fixes it.
+
+    nginx's proxy_redirect only rewrites absolute upstream URLs, so
+    ``Location: /setup`` from the not-configured gate would send the browser to
+    the origin root. These redirects come from the outer middleware, which is
+    why the Location fix has to sit outside the gate that issues them.
+    """
+
+    PREFIX = "/apps/hevy2garmin"
+
+    def test_setup_gate_redirect_is_prefixed(self, client, monkeypatch):
+        monkeypatch.setattr("hevy2garmin.server._is_configured_cache", False)
+        monkeypatch.setattr("hevy2garmin.server.is_configured", lambda: False)
+        resp = client.get("/", headers={"X-Forwarded-Prefix": self.PREFIX})
+        assert resp.status_code in (302, 307)
+        assert resp.headers["location"] == f"{self.PREFIX}/setup"
+
+    def test_redirect_is_unchanged_at_the_root(self, client, monkeypatch):
+        monkeypatch.setattr("hevy2garmin.server._is_configured_cache", False)
+        monkeypatch.setattr("hevy2garmin.server.is_configured", lambda: False)
+        resp = client.get("/")
+        assert resp.headers["location"] == "/setup"
+
+    def test_location_helper_is_idempotent_and_safe(self):
+        from hevy2garmin.server import _prefix_location
+
+        assert _prefix_location("/setup", "/p") == "/p/setup"
+        assert _prefix_location("/p/setup", "/p") == "/p/setup"
+        assert _prefix_location("/p", "/p") == "/p"
+        assert _prefix_location("//evil.example.com", "/p") == "//evil.example.com"
+        assert _prefix_location("https://x.example.com/y", "/p") == "https://x.example.com/y"
+        assert _prefix_location("/setup", "") == "/setup"

--- a/tests/test_reverse_proxy_prefix.py
+++ b/tests/test_reverse_proxy_prefix.py
@@ -19,9 +19,22 @@ from fastapi.testclient import TestClient
 
 
 @pytest.fixture
-def client():
+def client(monkeypatch):
+    """Client with the header explicitly trusted — the deployed-behind-a-proxy case."""
     os.environ.pop("HEVY2GARMIN_SECRET", None)
     os.environ.pop("DEMO_MODE", None)
+    monkeypatch.setenv("H2G_TRUST_FORWARDED_PREFIX", "1")
+    from hevy2garmin.server import app
+
+    yield TestClient(app, follow_redirects=False)
+
+
+@pytest.fixture
+def untrusting_client():
+    """Client with the flag absent — the default, and every non-proxied install."""
+    os.environ.pop("HEVY2GARMIN_SECRET", None)
+    os.environ.pop("DEMO_MODE", None)
+    os.environ.pop("H2G_TRUST_FORWARDED_PREFIX", None)
     from hevy2garmin.server import app
 
     yield TestClient(app, follow_redirects=False)
@@ -58,11 +71,31 @@ class TestReverseProxyPrefix:
         assert "</script><script>x" not in _app_prefix(resp.text)
 
     def test_client_side_urls_are_prefixed(self, client):
-        """Every JS-built API URL on the page resolves under the sub-path."""
+        """Every JS-built URL on the page resolves under the sub-path.
+
+        Not just fetch(): a bare `const url = '/api/…'` or a
+        `location.href = '/'` escapes the prefix just as thoroughly, and those
+        are the forms the direct-login POSTs and the post-connect redirect used.
+        """
         resp = client.get("/setup", headers={"X-Forwarded-Prefix": "/apps/hevy2garmin"})
         assert "window.APP_PREFIX + '/api/garmin-ticket'" in resp.text
-        # No JS fetch() may target a root-absolute path.
-        assert not re.search(r"fetch\((['\"])/(?!/)", resp.text)
+        for pattern in (
+            r"fetch\((['\"])/(?!/)",            # fetch('/…')
+            r"=\s*(['\"])/api/(?!/)",           # const url = '/api/…'
+            r"location\.href\s*=\s*(['\"])/",  # location.href = '/…'
+        ):
+            assert not re.search(pattern, resp.text), pattern
+
+    def test_direct_login_posts_are_prefixed(self, client):
+        """H2G_DIRECT_GARMIN_LOGIN is exactly the self-hosted sub-path case."""
+        resp = client.get("/setup", headers={"X-Forwarded-Prefix": "/apps/hevy2garmin"})
+        assert "window.APP_PREFIX + '/api/garmin-login'" in resp.text
+        assert "window.APP_PREFIX + '/api/garmin-login-mfa'" in resp.text
+
+    def test_post_connect_redirect_is_prefixed(self, client):
+        """Fires on every successful Garmin connect; bounced sub-path users home."""
+        resp = client.get("/setup", headers={"X-Forwarded-Prefix": "/apps/hevy2garmin"})
+        assert "window.location.href = (window.APP_PREFIX || '') + '/'" in resp.text
 
 
 class TestServerRenderedUrlsArePrefixed:
@@ -157,3 +190,99 @@ class TestRedirectLocationIsPrefixed:
         assert _prefix_location("//evil.example.com", "/p") == "//evil.example.com"
         assert _prefix_location("https://x.example.com/y", "/p") == "https://x.example.com/y"
         assert _prefix_location("/setup", "") == "/setup"
+
+
+class TestForwardedPrefixIsNotTrustedBlindly:
+    """X-Forwarded-Prefix is client-supplied, and every URL on the page derives
+    from it — the login form's action, the Garmin token POST, redirect targets.
+    So it is read only when the operator says a proxy sets it, and then only if
+    it is a plain absolute path. Both halves matter: the gate protects instances
+    that are not behind a rewriting proxy at all (non-standard headers pass
+    straight through hosted platforms), and the validation protects the ones that
+    are, against a proxy that forwards client headers untouched.
+    """
+
+    XSS = '"><script>alert(document.domain)</script><x y="'
+    OFFSITE = "//evil.example.com"
+
+    def test_header_is_ignored_without_the_opt_in(self, untrusting_client):
+        resp = untrusting_client.get(
+            "/setup", headers={"X-Forwarded-Prefix": "/apps/hevy2garmin"}
+        )
+        assert _app_prefix(resp.text) == '""'
+        assert 'action="/setup"' in resp.text
+
+    def test_no_html_injection_through_the_prefix(self, client):
+        resp = client.get("/setup", headers={"X-Forwarded-Prefix": self.XSS})
+        assert "<script>alert(document.domain)</script>" not in resp.text
+        assert _app_prefix(resp.text) == '""'
+
+    def test_protocol_relative_prefix_cannot_repoint_urls(self, client):
+        """//evil.example.com would send the password and Garmin tokens off-site."""
+        resp = client.get("/setup", headers={"X-Forwarded-Prefix": self.OFFSITE})
+        assert "evil.example.com" not in resp.text
+        assert _app_prefix(resp.text) == '""'
+        assert 'action="/setup"' in resp.text
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            '"><script>x</script>',
+            "//evil.example.com",
+            "///evil.example.com",
+            "https://evil.example.com",
+            "javascript:alert(1)",
+            "/a'b",
+            "/a<b>",
+            "/a b",
+            "/a\\\\b",
+            "no-leading-slash",
+            "/",
+            "",
+            "/a%2e%2e",
+            "/a?b=c",
+            "/a#b",
+        ],
+    )
+    def test_rejected_shapes_fall_back_to_the_root(self, bad):
+        from hevy2garmin.server import _validated_prefix
+
+        assert _validated_prefix(bad) == "", bad
+
+    @pytest.mark.parametrize(
+        "good,expected",
+        [
+            ("/hevy2garmin", "/hevy2garmin"),
+            ("/apps/hevy2garmin", "/apps/hevy2garmin"),
+            ("/apps/hevy2garmin/", "/apps/hevy2garmin"),
+            ("/a-b_c.d~e", "/a-b_c.d~e"),
+        ],
+    )
+    def test_accepted_shapes_survive(self, good, expected):
+        from hevy2garmin.server import _validated_prefix
+
+        assert _validated_prefix(good) == expected
+
+    def test_redirect_cannot_be_sent_off_site(self):
+        from hevy2garmin.server import _prefix_location
+
+        assert _prefix_location("/login", "//evil.example.com") == "/login"
+        assert _prefix_location("/login", "/apps/h2g") == "/apps/h2g/login"
+
+    def test_html_sink_escapes_even_if_validation_were_bypassed(self):
+        """Defense in depth: the sink must hold on its own."""
+        from hevy2garmin.server import _apply_prefix
+
+        out = _apply_prefix(' href="/workouts"', '"><script>x</script>')
+        assert "<script>" not in out
+        assert "&lt;script&gt;" in out
+
+    def test_opt_in_accepts_the_documented_flag_spellings(self, monkeypatch):
+        from hevy2garmin.server import trust_forwarded_prefix
+
+        for on in ("1", "true", "TRUE", "yes", "on"):
+            monkeypatch.setenv("H2G_TRUST_FORWARDED_PREFIX", on)
+            assert trust_forwarded_prefix() is True, on
+        for off in ("", "0", "false", "no", "off", "maybe"):
+            monkeypatch.setenv("H2G_TRUST_FORWARDED_PREFIX", off)
+            assert trust_forwarded_prefix() is False, off


### PR DESCRIPTION
Closes #299

Makes the sub-path case the README documents as unsupported actually work, by reading
`X-Forwarded-Prefix` and applying it to all three kinds of URL the app emits:

| Kind | Where |
| --- | --- |
| HTML attributes (`href`/`src`/`action`/`hx-*`) | rewritten on the way out of `_render` |
| Redirect `Location` | rewritten in a middleware wrapping `check_setup` |
| URLs JavaScript builds at runtime | `window.APP_PREFIX`, set in `base.html` |

Three decisions worth flagging, since they are the reviewable part:

**The HTML is rewritten, not the templates.** There are ~50 root-absolute attributes across the
templates, and one missed occurrence is an unreachable page with no test that would catch it. A
single narrow regex over the rendered output is provably complete instead — the test asserts that
*no* root-absolute URL attribute survives, which a template-by-template edit could never assert.

**The middleware is registered after `check_setup` so it wraps it.** The `/login` and `/setup`
gates redirect from inside that middleware and never reach a route handler, so a fix applied
anywhere further in would miss exactly the redirects that matter most.

**Both rewrites skip URLs already under the prefix**, so they are idempotent. That keeps this safe
behind a proxy that *does* rewrite bodies (some authenticating proxies do) rather than fighting it.

**Nothing changes without the header.** The prefix is the empty string, both rewrites short-circuit,
and the emitted HTML is byte-identical — asserted by a test, not just by inspection. Vercel is
untouched.

Tests: 15 cases — the prefix arriving and being trimmed, not leaking between requests, `tojson`
escaping a hostile header, every JS-built URL prefixed, no root-absolute attribute surviving,
external and protocol-relative URLs untouched, idempotency, the setup-gate redirect, and the
root install being byte-identical.

Verified on real hardware behind nginx at `/coaching/apps/hevy2garmin` (arm64, Docker): navigation,
static assets, htmx, Sync Now and the redirects all resolve under the prefix.

README gains nginx and Caddy snippets in place of the "not fully supported yet" paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)