### PR TITLE
feat(server): record every single-workout sync trigger in the sync log

### DIFF
--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -2344,12 +2344,23 @@ async def _sync_one_recorded(
 
     try:
         resp = await _do_sync_one(respect_grace=respect_grace)
+    except Exception:
+        # Record before re-raising, so a crash mid-sync is not the one failure
+        # mode that leaves /history looking healthy. The per-row and auto paths
+        # both record on exception; this makes cron and Sync Now agree.
+        _record_sync_log({"failed": 1}, trigger=trigger)
+        raise
     finally:
         _sync_executing.release()
 
     try:
         data = _json.loads(bytes(resp.body))
-        failed = 1 if (data.get("error") or data.get("skipped_error")) else 0
+        # `failed` is what _do_sync_one reports for a non-synced outcome
+        # ({"synced": 0, one.status: 1}); without it a rejected upload lands as
+        # 0 synced / 0 failed, indistinguishable from "nothing to sync" — the
+        # exact ambiguity this is meant to remove. error/skipped_error are the
+        # hard-stop shapes. needs_review/processing stay 0/0: still in flight.
+        failed = 1 if (data.get("error") or data.get("skipped_error") or data.get("failed")) else 0
         _record_sync_log({"synced": data.get("synced", 0), "failed": failed}, trigger=trigger)
     except Exception:
         logger.debug("sync_log record failed", exc_info=True)

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -278,13 +278,21 @@ def _stop_autosync() -> None:
 
 
 def _record_sync_log(result: dict, trigger: str = "manual") -> None:
-    """Record a sync result to SQLite."""
-    db.record_sync_log(
-        synced=result.get("synced", 0),
-        skipped=result.get("skipped", 0),
-        failed=result.get("failed", 0),
-        trigger=trigger,
-    )
+    """Record a sync result to SQLite. Best-effort — never breaks a sync.
+
+    Now that failure paths record too, this runs from inside exception
+    handlers; a DB write raising there would replace a handled error with a
+    500. The log is diagnostic, so losing a row is always the lesser loss.
+    """
+    try:
+        db.record_sync_log(
+            synced=result.get("synced", 0),
+            skipped=result.get("skipped", 0),
+            failed=result.get("failed", 0),
+            trigger=trigger,
+        )
+    except Exception:
+        logger.debug("sync_log record failed (trigger=%s)", trigger, exc_info=True)
 
 
 def _get_autosync_status() -> dict[str, Any]:
@@ -1836,7 +1844,7 @@ async def api_sync_single(request: Request, workout_id: str):
 
         garmin_client = get_client(config.get("garmin_email"))
         # Manual single-workout upload from the workouts page — bypass grace.
-        sync_one_workout(
+        one = sync_one_workout(
             workout,
             cfg=config,
             garmin_client=garmin_client,
@@ -1844,10 +1852,16 @@ async def api_sync_single(request: Request, workout_id: str):
             respect_grace=False,
             database=db.get_db(),
         )
+        _record_sync_log(
+            {"synced": 1 if one.status == "synced" else 0,
+             "failed": 1 if one.status == "failed" else 0},
+            trigger="manual (single)",
+        )
 
         start = (workout.get("start_time") or "")[:16]
         return HTMLResponse(f'<tr><td><span class="badge badge-success">✓ Synced</span></td><td>{start}</td><td><strong>{workout["title"]}</strong></td><td>{len(workout.get("exercises", []))}</td><td></td></tr>')
     except Exception as e:
+        _record_sync_log({"failed": 1}, trigger="manual (single)")
         return HTMLResponse(f'<td colspan="5" style="color: var(--pico-del-color);">Failed: {e}</td>')
 
 
@@ -2303,6 +2317,23 @@ async def api_setup_actions(request: Request):
 @app.post("/api/sync-one")
 async def api_sync_one(request: Request):
     """Sync exactly 1 unsynced workout. Returns JSON with status."""
+    # Manual Sync Now — bypass grace so the user gets an immediate upload.
+    return await _sync_one_recorded(respect_grace=False, trigger="manual (one)")
+
+
+async def _sync_one_recorded(
+    *,
+    respect_grace: bool = False,
+    trigger: str = "manual (one)",
+):
+    """Take the sync lock, sync one workout, and record it in the sync log.
+
+    Shared by every single-workout trigger so each one shows up on /history.
+    Dashboard and cron syncs previously left no trace, which made "what ran
+    this sync?" unanswerable when diagnosing a sync that stopped happening.
+    """
+    import json as _json
+
     from fastapi.responses import JSONResponse
 
     if is_demo_mode():
@@ -2312,10 +2343,17 @@ async def api_sync_one(request: Request):
         return JSONResponse({"error": "Sync already running", "busy": True})
 
     try:
-        # Manual Sync Now — bypass grace so the user gets an immediate upload.
-        return await _do_sync_one(request, respect_grace=False)
+        resp = await _do_sync_one(respect_grace=respect_grace)
     finally:
         _sync_executing.release()
+
+    try:
+        data = _json.loads(bytes(resp.body))
+        failed = 1 if (data.get("error") or data.get("skipped_error")) else 0
+        _record_sync_log({"synced": data.get("synced", 0), "failed": failed}, trigger=trigger)
+    except Exception:
+        logger.debug("sync_log record failed", exc_info=True)
+    return resp
 
 
 def _scan_for_unsynced(hevy, is_synced, total_count, failed_ids, on_page=None):
@@ -2355,7 +2393,7 @@ def _scan_for_unsynced(hevy, is_synced, total_count, failed_ids, on_page=None):
     return unsynced, unmapped
 
 
-async def _do_sync_one(request: Request, *, respect_grace: bool = False):
+async def _do_sync_one(*, respect_grace: bool = False):
     """Inner sync logic, called with _sync_executing lock held.
 
     ``respect_grace`` is True for Vercel cron (wait for watch data) and False
@@ -2512,17 +2550,8 @@ async def cron_sync(request: Request):
         if auth != f"Bearer {cron_secret}":
             return JSONResponse({"error": "Unauthorized"}, status_code=401)
 
-    if is_demo_mode():
-        return JSONResponse({"status": "demo", "message": "Sync disabled in demo mode"})
-
-    if not _acquire_sync_lock():
-        return JSONResponse({"error": "Sync already running", "busy": True})
-
-    try:
-        # Cron/autosync — respect grace so watch activities can land first.
-        return await _do_sync_one(request, respect_grace=True)
-    finally:
-        _sync_executing.release()
+    # Cron/autosync — respect grace so watch activities can land first.
+    return await _sync_one_recorded(respect_grace=True, trigger="cron")
 
 
 def run_server(host: str = "0.0.0.0", port: int = 8000) -> None:

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -742,6 +742,14 @@ def sync(
             'Add custom mappings: hevy2garmin map "Exercise Name" --category N --subcategory N'
         )
 
+    # One-line run summary, so the container log shows the outcome even when
+    # nothing synced — a silent run is indistinguishable from a dead one.
+    logger.info(
+        "Sync run complete: %d synced, %d skipped, %d failed, %d deferred, %d processing (of %d fetched)",
+        stats["synced"], stats["skipped"], stats["failed"],
+        stats["deferred"], stats["processing"], stats["total"],
+    )
+
     # Log-only duplicate scan (best-effort; never breaks a sync).
     if not dry_run and garmin_client:
         try:

--- a/tests/test_autosync.py
+++ b/tests/test_autosync.py
@@ -109,7 +109,7 @@ class TestCronGraceDeferral:
             patch("hevy2garmin.sync._workout_within_grace", return_value=True),
             patch("hevy2garmin.sync.sync_one_workout") as sync_one,
         ):
-            response = asyncio.run(server._do_sync_one(MagicMock(), respect_grace=True))
+            response = asyncio.run(server._do_sync_one(respect_grace=True))
 
         assert json.loads(response.body) == {
             "synced": 0,

--- a/tests/test_sync_log_triggers.py
+++ b/tests/test_sync_log_triggers.py
@@ -1,0 +1,195 @@
+"""Every single-workout sync trigger must leave a row in the sync log.
+
+Only auto-sync used to record one. Dashboard "Sync Now", the per-row sync on
+the workouts page and the cron endpoint all ran silently, so a gap on /history
+was indistinguishable from a sync that had stopped running — the exact question
+the log exists to answer. The trigger label is what makes the row useful, so
+each entry point is asserted by its own label.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def recorded(monkeypatch):
+    """Collect what _record_sync_log is asked to write."""
+    from hevy2garmin import server
+
+    rows: list[tuple[dict, str]] = []
+    monkeypatch.setattr(
+        server, "_record_sync_log", lambda result, trigger="manual": rows.append((result, trigger))
+    )
+    return rows
+
+
+@pytest.fixture
+def client(monkeypatch):
+    os.environ.pop("HEVY2GARMIN_SECRET", None)
+    os.environ.pop("DEMO_MODE", None)
+    os.environ.pop("CRON_SECRET", None)
+    from hevy2garmin import server
+
+    monkeypatch.setattr(server, "_is_configured_cache", True)
+    yield TestClient(server.app, follow_redirects=False)
+
+
+def _stub_sync_one(monkeypatch, payload: dict):
+    """Replace the inner sync with a canned JSON response."""
+    from fastapi.responses import JSONResponse
+
+    from hevy2garmin import server
+
+    async def _fake(*, respect_grace=False, **kw):
+        return JSONResponse(payload)
+
+    monkeypatch.setattr(server, "_do_sync_one", _fake)
+
+
+class TestSyncNowIsRecorded:
+    def test_successful_sync_now_records_one_synced(self, client, recorded, monkeypatch):
+        _stub_sync_one(monkeypatch, {"synced": 1, "title": "Push"})
+        resp = client.post("/api/sync-one")
+        assert resp.status_code == 200
+        assert recorded == [({"synced": 1, "failed": 0}, "manual (one)")]
+
+    def test_error_from_sync_now_records_a_failure(self, client, recorded, monkeypatch):
+        _stub_sync_one(monkeypatch, {"error": "Garmin upload failed"})
+        client.post("/api/sync-one")
+        assert recorded == [({"synced": 0, "failed": 1}, "manual (one)")]
+
+    def test_nothing_to_do_still_records_the_run(self, client, recorded, monkeypatch):
+        _stub_sync_one(monkeypatch, {"synced": 0, "done": True})
+        client.post("/api/sync-one")
+        assert recorded == [({"synced": 0, "failed": 0}, "manual (one)")]
+
+
+class TestCronIsRecorded:
+    def test_cron_sync_records_with_its_own_trigger(self, client, recorded, monkeypatch):
+        _stub_sync_one(monkeypatch, {"synced": 1, "title": "Pull"})
+        resp = client.get("/api/cron/sync")
+        assert resp.status_code == 200
+        assert recorded == [({"synced": 1, "failed": 0}, "cron")]
+
+    def test_cron_still_respects_grace(self, client, recorded, monkeypatch):
+        """The refactor must not turn cron into a grace-bypassing sync."""
+        from hevy2garmin import server
+
+        seen: dict = {}
+
+        async def _fake(*, respect_grace=False, **kw):
+            from fastapi.responses import JSONResponse
+
+            seen["respect_grace"] = respect_grace
+            return JSONResponse({"synced": 0, "deferred": 1})
+
+        monkeypatch.setattr(server, "_do_sync_one", _fake)
+        client.get("/api/cron/sync")
+        assert seen["respect_grace"] is True
+
+    def test_sync_now_still_bypasses_grace(self, client, recorded, monkeypatch):
+        from hevy2garmin import server
+
+        seen: dict = {}
+
+        async def _fake(*, respect_grace=False, **kw):
+            from fastapi.responses import JSONResponse
+
+            seen["respect_grace"] = respect_grace
+            return JSONResponse({"synced": 1})
+
+        monkeypatch.setattr(server, "_do_sync_one", _fake)
+        client.post("/api/sync-one")
+        assert seen["respect_grace"] is False
+
+    def test_unauthorized_cron_records_nothing(self, client, recorded, monkeypatch):
+        _stub_sync_one(monkeypatch, {"synced": 1})
+        monkeypatch.setenv("CRON_SECRET", "s3cret")
+        resp = client.get("/api/cron/sync")
+        assert resp.status_code == 401
+        assert recorded == []
+
+
+class TestLockIsStillHeldAndReleased:
+    def test_busy_response_records_nothing(self, client, recorded, monkeypatch):
+        from hevy2garmin import server
+
+        monkeypatch.setattr(server, "_acquire_sync_lock", lambda: False)
+        resp = client.post("/api/sync-one")
+        assert json.loads(resp.content)["busy"] is True
+        assert recorded == []
+
+    def test_lock_is_released_even_when_the_sync_raises(self, client, recorded, monkeypatch):
+        from hevy2garmin import server
+
+        async def _boom(*, respect_grace=False, **kw):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(server, "_do_sync_one", _boom)
+        with pytest.raises(RuntimeError):
+            client.post("/api/sync-one")
+        # A leaked semaphore would make the next sync permanently "busy".
+        assert server._acquire_sync_lock() is True
+        server._sync_executing.release()
+
+
+class TestRecordingNeverBreaksASync:
+    def test_a_failing_db_write_is_swallowed(self, monkeypatch):
+        """_record_sync_log now runs from inside except handlers."""
+        from hevy2garmin import db, server
+
+        def _boom(**kw):
+            raise RuntimeError("database is locked")
+
+        monkeypatch.setattr(db, "record_sync_log", _boom)
+        server._record_sync_log({"synced": 1}, trigger="manual (one)")  # must not raise
+
+
+class TestPerRowSyncIsRecorded:
+    """The workouts-page sync records on both paths, including its failure."""
+
+    def test_success_records_manual_single(self, client, recorded, monkeypatch):
+        from types import SimpleNamespace
+
+        import hevy2garmin.hevy as hevy_mod
+        import hevy2garmin.sync as sync_mod
+        from hevy2garmin import db, garmin, merge
+
+        monkeypatch.setattr(
+            hevy_mod,
+            "HevyClient",
+            lambda **kw: SimpleNamespace(
+                get_workout=lambda wid: {
+                    "id": wid,
+                    "title": "Push",
+                    "start_time": "2026-04-01T20:00:00+00:00",
+                    "exercises": [],
+                }
+            ),
+        )
+        monkeypatch.setattr(garmin, "get_client", lambda email=None: object())
+        monkeypatch.setattr(merge, "reset_circuit_breaker", lambda: None)
+        monkeypatch.setattr(db, "get_db", lambda: object())
+        monkeypatch.setattr(
+            sync_mod, "sync_one_workout", lambda *a, **kw: SimpleNamespace(status="synced")
+        )
+        resp = client.post("/api/sync/w1")
+        assert resp.status_code == 200
+        assert recorded == [({"synced": 1, "failed": 0}, "manual (single)")]
+
+    def test_an_exception_records_a_failure_and_still_renders(self, client, recorded, monkeypatch):
+        import hevy2garmin.hevy as hevy_mod
+
+        def _boom(**kw):
+            raise RuntimeError("Hevy API key missing")
+
+        monkeypatch.setattr(hevy_mod, "HevyClient", _boom)
+        resp = client.post("/api/sync/w1")
+        assert resp.status_code == 200
+        assert "Failed:" in resp.text
+        assert recorded == [({"failed": 1}, "manual (single)")]

--- a/tests/test_sync_log_triggers.py
+++ b/tests/test_sync_log_triggers.py
@@ -69,6 +69,46 @@ class TestSyncNowIsRecorded:
         assert recorded == [({"synced": 0, "failed": 0}, "manual (one)")]
 
 
+class TestFailuresAreDistinguishableFromNoWork:
+    """A failed sync must not look like "nothing to sync" on /history.
+
+    _do_sync_one reports a non-synced outcome as {"synced": 0, <status>: 1}, so a
+    rejected upload arrives as failed=1 — not as an `error` key. Classifying on
+    error/skipped_error alone logged it 0/0, which is byte-identical to a healthy
+    idle run and is the precise ambiguity the sync log exists to remove. It also
+    disagreed with the per-row path, which records failed=1 for the same event.
+    """
+
+    def test_failed_upload_is_recorded_as_a_failure(self, client, recorded, monkeypatch):
+        _stub_sync_one(monkeypatch, {"synced": 0, "failed": 1, "title": "Push", "done": False})
+        client.post("/api/sync-one")
+        assert recorded == [({"synced": 0, "failed": 1}, "manual (one)")]
+
+    def test_failed_upload_on_the_cron_path_too(self, client, recorded, monkeypatch):
+        _stub_sync_one(monkeypatch, {"synced": 0, "failed": 1, "title": "Push", "done": False})
+        client.get("/api/cron/sync")
+        assert recorded == [({"synced": 0, "failed": 1}, "cron")]
+
+    def test_in_flight_statuses_are_not_counted_as_failures(self, client, recorded, monkeypatch):
+        """needs_review / processing / deferred are unfinished, not failed."""
+        for status in ("needs_review", "processing", "deferred", "merge_pending"):
+            recorded.clear()
+            _stub_sync_one(monkeypatch, {"synced": 0, status: 1, "done": False})
+            client.post("/api/sync-one")
+            assert recorded == [({"synced": 0, "failed": 0}, "manual (one)")], status
+
+    def test_a_raising_sync_is_recorded_before_it_propagates(self, client, recorded, monkeypatch):
+        from hevy2garmin import server
+
+        async def _boom(*, respect_grace=False, **kw):
+            raise RuntimeError("Hevy 502")
+
+        monkeypatch.setattr(server, "_do_sync_one", _boom)
+        with pytest.raises(RuntimeError):
+            client.post("/api/sync-one")
+        assert recorded == [({"failed": 1}, "manual (one)")]
+
+
 class TestCronIsRecorded:
     def test_cron_sync_records_with_its_own_trigger(self, client, recorded, monkeypatch):
         _stub_sync_one(monkeypatch, {"synced": 1, "title": "Pull"})
@@ -136,6 +176,8 @@ class TestLockIsStillHeldAndReleased:
         # A leaked semaphore would make the next sync permanently "busy".
         assert server._acquire_sync_lock() is True
         server._sync_executing.release()
+        # Recording on the exception path must not swallow the exception either.
+        assert recorded == [({"failed": 1}, "manual (one)")]
 
 
 class TestRecordingNeverBreaksASync:


### PR DESCRIPTION
Closes #300

Extracts `_sync_one_recorded` (take the lock, sync one workout, record the result) and routes Sync
Now and the cron endpoint through it, tagged `manual (one)` and `cron`; the per-row sync on the
workouts page records `manual (single)` including its failure path. So /history now distinguishes
"nothing needed syncing" from "nothing ran".

Two things beyond the mechanical extraction:

**`_record_sync_log` is now best-effort.** The per-row sync records from inside its `except`
handler, so a raising DB write there would replace a handled error with a 500. The log is
diagnostic — losing a row is always the lesser loss.

**`_do_sync_one` never used its `Request` argument**, so the extracted helper does not take one
either. Beyond removing dead plumbing, that keeps per-request state out of a helper that is a
natural fit for callers which outlive the request.

Also logs a one-line run summary at the end of `sync()`, so a run that skipped everything still
says so in the container log rather than looking indistinguishable from a dead process.

Tests: 12 cases — each trigger's label including both per-row paths, cron still respecting the
grace period while Sync Now still bypasses it (the easiest thing to get wrong in this refactor),
a busy response recording nothing, the lock being released when a sync raises, and a failing log
write not breaking a sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)