### PR TITLE
feat(server): sync on a Hevy webhook, staged so the merge still wins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,15 @@ HEVY2GARMIN_SECRET=
 # Needs a writable home directory, so it does not work on serverless.
 H2G_DIRECT_GARMIN_LOGIN=
 
+# ── Optional: Hevy webhook staging ────────────────────────────────────────
+# POST /api/cron/webhook (Bearer CRON_SECRET) syncs on a Hevy push instead of
+# waiting for the next poll. The sync is staged so the Garmin watch activity
+# has time to arrive and can be merged; only the last attempt uploads plainly.
+# Needs a long-running process — see "Syncing on a Hevy webhook" in the README.
+# WEBHOOK_DELAY_SECONDS=300
+# WEBHOOK_RETRY_INTERVAL_SECONDS=600
+# WEBHOOK_MAX_ATTEMPTS=3
+
 # ── Vercel-specific (auto-set by Vercel) ──────────────────────────────────
 # DATABASE_URL=              # Auto-set by Vercel Postgres integration
 # VERCEL=1                   # Auto-set when running on Vercel

--- a/README.md
+++ b/README.md
@@ -369,6 +369,22 @@ Serving it at the **root of a subdomain** (`https://hevy.example.com/`) works. S
 
 Auto-sync runs on a timer inside the process, so a self-hosted instance can poll as often as you like — enable it and set the interval on the dashboard. This is the main practical difference from the Vercel deploy, where scheduling comes from a platform cron that is limited to once per day on Vercel's Hobby plan.
 
+### Syncing on a Hevy webhook instead of polling
+
+Polling means a finished workout waits up to a full interval. Hevy can push instead: point a Hevy webhook subscription at `POST /api/cron/webhook`, authenticated with the same `CRON_SECRET` bearer token as the cron endpoint.
+
+A webhook that synced immediately would be *worse* than polling for watch users, though: the paired Garmin activity has not arrived yet, the merge finds nothing, and the workout uploads as a plain FIT — leaving exactly the duplicate the merge exists to avoid. So the endpoint answers 200 straight away (Hevy times out in seconds) and stages the sync:
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `WEBHOOK_DELAY_SECONDS` | `300` | Wait this long before the first attempt |
+| `WEBHOOK_RETRY_INTERVAL_SECONDS` | `600` | Gap between attempts |
+| `WEBHOOK_MAX_ATTEMPTS` | `3` | Attempts before giving up |
+
+Every attempt but the last is merge-only; only the final one falls back to a plain upload, so nothing is left unsynced. Retry state is in memory, so a restart drops it — auto-sync stays the safety net, and is worth leaving enabled at a long interval.
+
+**On serverless this staging cannot run**, because the function is frozen as soon as it responds and Python on Vercel has no `waitUntil`. The endpoint detects that and does the only safe thing instead: with the watch merge on it defers to the scheduled cron (and logs that it did); with the watch merge off there is nothing to wait for, so it syncs inline — which on Vercel's Hobby plan replaces a once-a-day cron with a sync per workout.
+
 ### Running as a non-root user
 
 The image runs as uid 999. Named volumes (what the compose file uses) are handled automatically. If you use **bind mounts** instead — the `-v ~/.hevy2garmin:/root/.hevy2garmin` form shown in the Docker section — grant that user access once:

--- a/README.md
+++ b/README.md
@@ -383,7 +383,11 @@ A webhook that synced immediately would be *worse* than polling for watch users,
 
 Every attempt but the last is merge-only; only the final one falls back to a plain upload, so nothing is left unsynced. Retry state is in memory, so a restart drops it — auto-sync stays the safety net, and is worth leaving enabled at a long interval.
 
+`CRON_SECRET` must be set for the endpoint to work at all — with no secret configured it answers `503` rather than accepting unauthenticated calls, since it is internet-facing and is deliberately exempt from the dashboard password. At most `WEBHOOK_MAX_INFLIGHT` (4) staged syncs run at once; past that a request is acknowledged but not staged, because the ones already running plus auto-sync cover the work.
+
 **On serverless this staging cannot run**, because the function is frozen as soon as it responds and Python on Vercel has no `waitUntil`. The endpoint detects that and does the only safe thing instead: with the watch merge on it defers to the scheduled cron (and logs that it did); with the watch merge off there is nothing to wait for, so it syncs inline — which on Vercel's Hobby plan replaces a once-a-day cron with a sync per workout.
+
+> One caveat for that last case: an inline sync can take longer than Hevy's few-second timeout, and Hevy then retries. On serverless the retry is a *separate process*, so the in-process sync lock cannot serialize the two, and the same workout could upload twice. It only applies with the watch merge off (not the default) on a serverless host; if that is your setup, prefer leaving the webhook unconfigured and relying on cron.
 
 ### Running as a non-root user
 

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hmac
 import logging
 import os
 import re
@@ -2549,6 +2550,16 @@ async def _do_sync_one(*, respect_grace: bool = False, merge_only: bool = False)
             return JSONResponse({"synced": 0, "skipped_error": True, "title": unsynced["title"], "remaining": max(0, remaining), "done": remaining <= 0})
 
 
+def _bearer_ok(request: Request, secret: str) -> bool:
+    """Constant-time check of `Authorization: Bearer <secret>`.
+
+    compare_digest rather than `!=` so the comparison cannot leak the shared
+    secret a byte at a time to a caller who can time the response.
+    """
+    auth = request.headers.get("authorization") or ""
+    return hmac.compare_digest(auth, f"Bearer {secret}")
+
+
 @app.get("/api/cron/sync")
 async def cron_sync(request: Request, merge_only: bool = Query(False)):
     """Vercel cron endpoint. Syncs 1 workout per invocation."""
@@ -2557,8 +2568,7 @@ async def cron_sync(request: Request, merge_only: bool = Query(False)):
     # Vercel sets CRON_SECRET to verify cron requests
     cron_secret = os.environ.get("CRON_SECRET")
     if cron_secret:
-        auth = request.headers.get("authorization")
-        if auth != f"Bearer {cron_secret}":
+        if not _bearer_ok(request, cron_secret):
             return JSONResponse({"error": "Unauthorized"}, status_code=401)
 
     # Cron/autosync — respect grace so watch activities can land first.
@@ -2574,6 +2584,8 @@ async def cron_sync(request: Request, merge_only: bool = Query(False)):
 WEBHOOK_DELAY_SECONDS = int(os.environ.get("WEBHOOK_DELAY_SECONDS", "300"))
 WEBHOOK_RETRY_INTERVAL_SECONDS = int(os.environ.get("WEBHOOK_RETRY_INTERVAL_SECONDS", "600"))
 WEBHOOK_MAX_ATTEMPTS = int(os.environ.get("WEBHOOK_MAX_ATTEMPTS", "3"))
+# Ceiling on concurrently staged syncs; a burst past this is declined, not queued.
+WEBHOOK_MAX_INFLIGHT = int(os.environ.get("WEBHOOK_MAX_INFLIGHT", "4"))
 
 _webhook_tasks: set = set()  # strong refs — bare asyncio tasks get garbage collected
 
@@ -2660,15 +2672,40 @@ async def cron_webhook(request: Request):
 
     from fastapi.responses import JSONResponse
 
+    # Fail CLOSED. This endpoint is internet-facing by design and is exempt from
+    # the dashboard cookie/CSRF middleware, so treating "no secret set" as "no
+    # auth needed" leaves an anonymous sync trigger exposed on any instance
+    # whose owner set a dashboard password but read CRON_SECRET as a Vercel-only
+    # concern. Unconfigured means unavailable, not open.
     cron_secret = os.environ.get("CRON_SECRET")
-    if cron_secret:
-        auth = request.headers.get("authorization")
-        if auth != f"Bearer {cron_secret}":
-            logger.warning("Hevy webhook rejected: bad or missing Authorization header")
-            return JSONResponse({"error": "Unauthorized"}, status_code=401)
+    if not cron_secret:
+        logger.warning(
+            "Hevy webhook refused: CRON_SECRET is not set, so there is no way to authenticate "
+            "Hevy. Set CRON_SECRET to enable the endpoint."
+        )
+        return JSONResponse(
+            {"error": "Webhook not configured: CRON_SECRET is unset"}, status_code=503
+        )
+    if not _bearer_ok(request, cron_secret):
+        logger.warning("Hevy webhook rejected: bad or missing Authorization header")
+        return JSONResponse({"error": "Unauthorized"}, status_code=401)
 
     if not _can_run_background_work():
         return await _webhook_sync_serverless()
+
+    # Each accepted request owns a task for up to WEBHOOK_DELAY +
+    # (MAX_ATTEMPTS - 1) * RETRY_INTERVAL seconds (~25 min by default), so
+    # unbounded spawning lets a burst pile up tasks that only queue on the sync
+    # lock and hammer Garmin. Past the cap, decline to add another: those
+    # already staged plus auto-sync cover the work, and Hevy still gets a 200 so
+    # it does not retry into the same wall.
+    if len(_webhook_tasks) >= WEBHOOK_MAX_INFLIGHT:
+        logger.warning(
+            "Hevy webhook throttled: %d staged syncs already in flight — they and "
+            "auto-sync will pick this workout up",
+            len(_webhook_tasks),
+        )
+        return JSONResponse({"status": "throttled", "in_flight": len(_webhook_tasks)})
 
     logger.info(
         "Hevy webhook received — staged sync in %ds (up to %d attempts)",

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -13,7 +13,7 @@ from math import ceil
 from pathlib import Path
 from typing import Any
 
-from fastapi import FastAPI, Form, Request
+from fastapi import FastAPI, Form, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.concurrency import run_in_threadpool
 from fastapi.staticfiles import StaticFiles
@@ -431,16 +431,23 @@ async def check_setup(request: Request, call_next):
             return RedirectResponse(f"/login?next={path}")
 
     # Auth check for POST /api/* endpoints (CSRF protection).
-    # Cron has its own Bearer token check. All others require the cookie or X-Api-Key.
-    if secret and request.method == "POST" and path.startswith("/api/") and path != "/api/cron/sync":
+    # Cron and the Hevy webhook have their own Bearer token check. All others
+    # require the cookie or X-Api-Key.
+    if (
+        secret
+        and request.method == "POST"
+        and path.startswith("/api/")
+        and path not in ("/api/cron/sync", "/api/cron/webhook")
+    ):
         token = request.cookies.get("h2g_auth") or request.headers.get("x-api-key")
         if token != secret:
             from starlette.responses import Response
             return Response("Unauthorized", status_code=401)
 
     # Setup page and sync endpoints: skip the "is configured?" redirect
-    if path in ("/login", "/setup", "/api/sync-one", "/api/cron/sync", "/api/setup-actions",
-                "/api/garmin-ticket", "/api/garmin-login", "/api/garmin-login-mfa"):
+    if path in ("/login", "/setup", "/api/sync-one", "/api/cron/sync", "/api/cron/webhook",
+                "/api/setup-actions", "/api/garmin-ticket", "/api/garmin-login",
+                "/api/garmin-login-mfa"):
         response = await call_next(request)
     else:
         # Redirect to setup if not configured
@@ -2315,15 +2322,18 @@ async def api_setup_actions(request: Request):
 
 
 @app.post("/api/sync-one")
-async def api_sync_one(request: Request):
+async def api_sync_one(request: Request, merge_only: bool = Query(False)):
     """Sync exactly 1 unsynced workout. Returns JSON with status."""
     # Manual Sync Now — bypass grace so the user gets an immediate upload.
-    return await _sync_one_recorded(respect_grace=False, trigger="manual (one)")
+    return await _sync_one_recorded(
+        respect_grace=False, merge_only=merge_only, trigger="manual (one)"
+    )
 
 
 async def _sync_one_recorded(
     *,
     respect_grace: bool = False,
+    merge_only: bool = False,
     trigger: str = "manual (one)",
 ):
     """Take the sync lock, sync one workout, and record it in the sync log.
@@ -2343,7 +2353,7 @@ async def _sync_one_recorded(
         return JSONResponse({"error": "Sync already running", "busy": True})
 
     try:
-        resp = await _do_sync_one(respect_grace=respect_grace)
+        resp = await _do_sync_one(respect_grace=respect_grace, merge_only=merge_only)
     finally:
         _sync_executing.release()
 
@@ -2393,7 +2403,7 @@ def _scan_for_unsynced(hevy, is_synced, total_count, failed_ids, on_page=None):
     return unsynced, unmapped
 
 
-async def _do_sync_one(*, respect_grace: bool = False):
+async def _do_sync_one(*, respect_grace: bool = False, merge_only: bool = False):
     """Inner sync logic, called with _sync_executing lock held.
 
     ``respect_grace`` is True for Vercel cron (wait for watch data) and False
@@ -2484,6 +2494,7 @@ async def _do_sync_one(*, respect_grace: bool = False):
                 cfg=config,
                 garmin_client=garmin_client,
                 respect_grace=False,  # already checked above
+                merge_only=merge_only,
                 database=db.get_db(),
             )
 
@@ -2539,7 +2550,7 @@ async def _do_sync_one(*, respect_grace: bool = False):
 
 
 @app.get("/api/cron/sync")
-async def cron_sync(request: Request):
+async def cron_sync(request: Request, merge_only: bool = Query(False)):
     """Vercel cron endpoint. Syncs 1 workout per invocation."""
     from fastapi.responses import JSONResponse
 
@@ -2551,7 +2562,123 @@ async def cron_sync(request: Request):
             return JSONResponse({"error": "Unauthorized"}, status_code=401)
 
     # Cron/autosync — respect grace so watch activities can land first.
-    return await _sync_one_recorded(respect_grace=True, trigger="cron")
+    return await _sync_one_recorded(respect_grace=True, merge_only=merge_only, trigger="cron")
+
+
+# ── Hevy webhook receiver ────────────────────────────────────────────────────
+# Hevy fires this when a workout is saved. The paired watch activity usually
+# reaches Garmin Connect a few minutes later, so the sync is staged: wait,
+# then try merge-only, and only the final attempt falls back to a plain FIT
+# upload — so a workout is never left unsynced. Retry state is in-memory
+# only; a restart drops it and auto-sync is the safety net.
+WEBHOOK_DELAY_SECONDS = int(os.environ.get("WEBHOOK_DELAY_SECONDS", "300"))
+WEBHOOK_RETRY_INTERVAL_SECONDS = int(os.environ.get("WEBHOOK_RETRY_INTERVAL_SECONDS", "600"))
+WEBHOOK_MAX_ATTEMPTS = int(os.environ.get("WEBHOOK_MAX_ATTEMPTS", "3"))
+
+_webhook_tasks: set = set()  # strong refs — bare asyncio tasks get garbage collected
+
+
+def _can_run_background_work() -> bool:
+    """Whether work scheduled now will still run after the response is sent.
+
+    False on serverless, where the function is frozen or torn down as soon as
+    it responds: an asyncio task created here would simply never be resumed.
+    Python on Vercel has no `waitUntil` equivalent to hand the work to.
+    """
+    return not os.environ.get("VERCEL")
+
+
+async def _webhook_sync() -> None:
+    """Background worker behind /api/cron/webhook."""
+    import asyncio
+    import json
+
+    await asyncio.sleep(WEBHOOK_DELAY_SECONDS)
+    for attempt in range(1, WEBHOOK_MAX_ATTEMPTS + 1):
+        is_last = attempt == WEBHOOK_MAX_ATTEMPTS
+        try:
+            resp = await _sync_one_recorded(merge_only=not is_last, trigger="webhook")
+            data = json.loads(bytes(resp.body))
+        except Exception as e:
+            logger.error("Webhook sync attempt %d/%d failed: %s",
+                         attempt, WEBHOOK_MAX_ATTEMPTS, str(e)[:300])
+            return
+        # A lock collision with auto-sync is not an answer — retry, don't give up.
+        retry = bool(data.get("busy")) or bool(data.get("merge_pending"))
+        if not retry:
+            logger.info(
+                "Webhook sync attempt %d/%d: %s",
+                attempt,
+                WEBHOOK_MAX_ATTEMPTS,
+                f"synced '{data.get('title', '?')}'" if data.get("synced") else "nothing pending",
+            )
+            return
+        if not is_last:
+            await asyncio.sleep(WEBHOOK_RETRY_INTERVAL_SECONDS)
+    logger.warning(
+        "Webhook sync: workout still pending after %d attempts — auto-sync will retry",
+        WEBHOOK_MAX_ATTEMPTS,
+    )
+
+
+async def _webhook_sync_serverless():
+    """Handle the webhook without background work, for serverless deployments.
+
+    There is no "later" here: the process stops at the response, so the staged
+    retry cannot run. What is safe to do instead depends on the watch merge:
+
+    - Merge on (the default): the watch activity has almost certainly not
+      reached Garmin Connect yet. Uploading now produces exactly the duplicate
+      the merge exists to prevent, and there is no second attempt to wait for,
+      so hand the workout to the platform cron and only say so.
+    - Merge off: nothing is being waited for, so sync immediately — which is
+      the whole point of a webhook, and a large win over a daily cron.
+    """
+    from fastapi.responses import JSONResponse
+
+    if load_config().get("merge_mode", True):
+        logger.info(
+            "Hevy webhook received on a serverless deployment with the watch merge on — "
+            "leaving it to the scheduled sync so the watch activity can land first"
+        )
+        return JSONResponse({"status": "deferred", "reason": "no background work; cron will sync"})
+
+    logger.info("Hevy webhook received — syncing now (watch merge off, nothing to wait for)")
+    return await _sync_one_recorded(respect_grace=False, trigger="webhook")
+
+
+@app.post("/api/cron/webhook")
+async def cron_webhook(request: Request):
+    """Hevy webhook endpoint, fired when a workout is saved.
+
+    Hevy expects a 200 within a few seconds, so on a long-running deployment
+    this only checks the Bearer token and schedules the staged sync in the
+    background. Serverless has no background to schedule into — see
+    _webhook_sync_serverless.
+    """
+    import asyncio
+
+    from fastapi.responses import JSONResponse
+
+    cron_secret = os.environ.get("CRON_SECRET")
+    if cron_secret:
+        auth = request.headers.get("authorization")
+        if auth != f"Bearer {cron_secret}":
+            logger.warning("Hevy webhook rejected: bad or missing Authorization header")
+            return JSONResponse({"error": "Unauthorized"}, status_code=401)
+
+    if not _can_run_background_work():
+        return await _webhook_sync_serverless()
+
+    logger.info(
+        "Hevy webhook received — staged sync in %ds (up to %d attempts)",
+        WEBHOOK_DELAY_SECONDS,
+        WEBHOOK_MAX_ATTEMPTS,
+    )
+    task = asyncio.create_task(_webhook_sync())
+    _webhook_tasks.add(task)
+    task.add_done_callback(_webhook_tasks.discard)
+    return JSONResponse({"status": "accepted"})
 
 
 def run_server(host: str = "0.0.0.0", port: int = 8000) -> None:

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -68,7 +68,7 @@ def _cache_routines_total(store: Any, count: int) -> None:
 class SyncOneResult:
     """Outcome of syncing a single Hevy workout."""
 
-    status: str  # "synced" | "dry_run" | "deferred" | "processing" | "needs_review" | "failed"
+    status: str  # "synced" | "dry_run" | "deferred" | "merge_pending" | "processing" | "needs_review" | "failed"
     activity_id: int | None = None
     sync_method: str = "upload"
     merged: bool = False
@@ -288,12 +288,18 @@ def sync_one_workout(
     dry_run: bool = False,
     force_upload: bool = False,
     respect_grace: bool = False,
+    merge_only: bool = False,
     database: Any | None = None,
 ) -> SyncOneResult:
     """Sync one Hevy workout to Garmin (merge, FIT upload, or dry-run).
 
     When ``respect_grace`` is True (autosync/cron), too-new workouts return
     ``status="deferred"`` so a watch activity can land before we upload.
+
+    When ``merge_only`` is True (webhook staged retry), a merge attempt that
+    does not land returns ``status="merge_pending"`` instead of falling back
+    to a plain FIT upload, so a later attempt can still merge once the watch
+    activity has reached Garmin Connect.
 
     Raises on FIT generation / upload failures so callers can map errors.
     """
@@ -375,6 +381,17 @@ def sync_one_workout(
         merge_forced_fresh = merge_result.force_fresh_upload
         merge_delete_id = merge_result.delete_after_upload
         merge_fallback = True
+
+        # merge_only: the caller (the webhook retry loop) wants a merge or
+        # nothing. Don't fall back to a plain FIT upload — leave the workout
+        # unsynced so the next attempt can merge once the watch activity has
+        # had more time to reach Garmin Connect.
+        if merge_only and not dry_run:
+            logger.info(
+                "  merge_only: no mergeable Garmin watch activity yet for '%s', will retry",
+                title,
+            )
+            return SyncOneResult(status="merge_pending", merge_fallback=True)
     else:
         merge_fallback = False
 

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -1,0 +1,199 @@
+"""Tests for the /api/cron/webhook receiver + staged retry worker."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client_with_cron_secret():
+    with patch.dict(os.environ, {"CRON_SECRET": "cron-123"}):
+        os.environ.pop("VERCEL", None)
+        from hevy2garmin.server import app
+        yield TestClient(app)
+
+
+class TestWebhookEndpoint:
+    def test_rejects_missing_bearer(self, client_with_cron_secret) -> None:
+        resp = client_with_cron_secret.post("/api/cron/webhook")
+        assert resp.status_code == 401
+
+    def test_rejects_wrong_bearer(self, client_with_cron_secret) -> None:
+        resp = client_with_cron_secret.post(
+            "/api/cron/webhook", headers={"Authorization": "Bearer nope"}
+        )
+        assert resp.status_code == 401
+
+    def test_accepts_and_schedules_background_sync(self, client_with_cron_secret) -> None:
+        """Valid Bearer → immediate 200 (Hevy requires an answer within 5 s)."""
+        with patch("hevy2garmin.server._webhook_sync", new_callable=AsyncMock) as worker:
+            resp = client_with_cron_secret.post(
+                "/api/cron/webhook", headers={"Authorization": "Bearer cron-123"}
+            )
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "accepted"}
+        worker.assert_called_once()
+
+    def test_not_blocked_by_dashboard_auth(self) -> None:
+        """POST /api/cron/webhook bypasses the cookie/X-Api-Key middleware."""
+        with patch.dict(
+            os.environ, {"HEVY2GARMIN_SECRET": "dash-secret", "CRON_SECRET": "cron-123"}
+        ):
+            os.environ.pop("VERCEL", None)
+            from hevy2garmin.server import app
+            client = TestClient(app)
+            with patch("hevy2garmin.server._webhook_sync", new_callable=AsyncMock):
+                resp = client.post(
+                    "/api/cron/webhook", headers={"Authorization": "Bearer cron-123"}
+                )
+        assert resp.status_code == 200
+
+
+class TestWebhookWorker:
+    """Staged retry semantics: all but the last attempt are merge_only, so a
+    workout is uploaded plainly only once the watch activity clearly is not
+    coming; the last attempt does a full sync so nothing is left unsynced."""
+
+    def _run(self, responses: list[dict]) -> list[bool]:
+        from hevy2garmin import server
+
+        calls: list[bool] = []
+
+        async def fake_sync_one(merge_only=False, **kwargs):
+            calls.append(merge_only)
+            return JSONResponse(responses[len(calls) - 1])
+
+        with (
+            patch.object(server, "WEBHOOK_DELAY_SECONDS", 0),
+            patch.object(server, "WEBHOOK_RETRY_INTERVAL_SECONDS", 0),
+            patch.object(server, "_sync_one_recorded", fake_sync_one),
+        ):
+            asyncio.run(server._webhook_sync())
+        return calls
+
+    def test_merge_only_until_last_attempt(self) -> None:
+        pending = {"synced": 0, "merge_pending": True, "done": False}
+        calls = self._run([pending, pending, {"synced": 1, "done": True}])
+        assert calls == [True, True, False]
+
+    def test_stops_after_first_successful_sync(self) -> None:
+        calls = self._run([{"synced": 1, "done": True}])
+        assert calls == [True]
+
+    def test_stops_when_nothing_is_pending(self) -> None:
+        calls = self._run([{"synced": 0, "merge_pending": False, "done": False}])
+        assert calls == [True]
+
+    def test_a_lock_collision_is_retried_not_treated_as_done(self) -> None:
+        """auto-sync holding the lock is not an answer about this workout.
+
+        The busy reply carries no merge_pending, so a plain "did it merge?"
+        check reads it as "nothing to do" and abandons the webhook sync — the
+        workout then waits for the next auto-sync, which is the delay the
+        webhook exists to remove.
+        """
+        busy = {"error": "Sync already running", "busy": True}
+        calls = self._run([busy, busy, {"synced": 1, "done": True}])
+        assert calls == [True, True, False]
+
+    def test_a_raising_attempt_stops_the_worker(self) -> None:
+        from hevy2garmin import server
+
+        calls: list[bool] = []
+
+        async def boom(merge_only=False, **kwargs):
+            calls.append(merge_only)
+            raise RuntimeError("Garmin unreachable")
+
+        with (
+            patch.object(server, "WEBHOOK_DELAY_SECONDS", 0),
+            patch.object(server, "WEBHOOK_RETRY_INTERVAL_SECONDS", 0),
+            patch.object(server, "_sync_one_recorded", boom),
+        ):
+            asyncio.run(server._webhook_sync())
+        assert calls == [True], "auto-sync is the safety net; don't hammer a broken backend"
+
+
+class TestServerlessDeployment:
+    """A serverless function is frozen at the response, so the staged retry
+    cannot run there. The webhook must then do something safe rather than
+    scheduling work that silently never happens."""
+
+    @pytest.fixture
+    def vercel_client(self):
+        with patch.dict(os.environ, {"CRON_SECRET": "cron-123", "VERCEL": "1"}):
+            from hevy2garmin.server import app
+            yield TestClient(app)
+
+    def test_background_work_is_not_scheduled_on_vercel(self, vercel_client) -> None:
+        from hevy2garmin import server
+
+        with (
+            patch.object(server, "load_config", lambda: {"merge_mode": True}),
+            patch("hevy2garmin.server._webhook_sync", new_callable=AsyncMock) as worker,
+        ):
+            resp = vercel_client.post(
+                "/api/cron/webhook", headers={"Authorization": "Bearer cron-123"}
+            )
+        assert resp.status_code == 200
+        worker.assert_not_called()
+
+    def test_with_the_watch_merge_on_it_defers_to_cron(self, vercel_client) -> None:
+        """Uploading now would create the duplicate the merge exists to avoid."""
+        from hevy2garmin import server
+
+        called = []
+
+        async def fake_sync(**kw):
+            called.append(kw)
+            return JSONResponse({"synced": 1})
+
+        with (
+            patch.object(server, "load_config", lambda: {"merge_mode": True}),
+            patch.object(server, "_sync_one_recorded", fake_sync),
+        ):
+            resp = vercel_client.post(
+                "/api/cron/webhook", headers={"Authorization": "Bearer cron-123"}
+            )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "deferred"
+        assert called == []
+
+    def test_with_the_watch_merge_off_it_syncs_inline(self, vercel_client) -> None:
+        """Nothing to wait for, so the webhook delivers its actual benefit."""
+        from hevy2garmin import server
+
+        called = []
+
+        async def fake_sync(**kw):
+            called.append(kw)
+            return JSONResponse({"synced": 1, "title": "Push"})
+
+        with (
+            patch.object(server, "load_config", lambda: {"merge_mode": False}),
+            patch.object(server, "_sync_one_recorded", fake_sync),
+        ):
+            resp = vercel_client.post(
+                "/api/cron/webhook", headers={"Authorization": "Bearer cron-123"}
+            )
+        assert resp.status_code == 200
+        assert resp.json()["synced"] == 1
+        assert called == [{"respect_grace": False, "trigger": "webhook"}]
+
+    def test_auth_is_still_enforced_on_serverless(self, vercel_client) -> None:
+        assert vercel_client.post("/api/cron/webhook").status_code == 401
+
+    def test_background_capability_is_derived_from_the_platform(self) -> None:
+        from hevy2garmin.server import _can_run_background_work
+
+        with patch.dict(os.environ, {"VERCEL": "1"}):
+            assert _can_run_background_work() is False
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("VERCEL", None)
+            assert _can_run_background_work() is True

--- a/tests/test_webhook.py
+++ b/tests/test_webhook.py
@@ -55,6 +55,83 @@ class TestWebhookEndpoint:
         assert resp.status_code == 200
 
 
+class TestWebhookAuthFailsClosed:
+    """No CRON_SECRET must mean unavailable, not unauthenticated.
+
+    /api/cron/webhook is internet-facing (Hevy calls it) and is exempt from the
+    dashboard cookie/CSRF middleware, so an `if secret:` guard that skips the
+    check when the secret is unset leaves an anonymous sync trigger exposed —
+    including on an instance whose owner did set a dashboard password.
+    """
+
+    def test_unset_cron_secret_refuses_instead_of_accepting(self) -> None:
+        with patch.dict(os.environ, {"HEVY2GARMIN_SECRET": "dash-password"}):
+            os.environ.pop("CRON_SECRET", None)
+            os.environ.pop("VERCEL", None)
+            from hevy2garmin.server import app
+
+            with patch("hevy2garmin.server._webhook_sync", new_callable=AsyncMock) as worker:
+                resp = TestClient(app).post("/api/cron/webhook")
+            assert resp.status_code == 503
+            assert "CRON_SECRET" in resp.json()["error"]
+            worker.assert_not_called(), "no sync may be scheduled by an unauthenticated caller"
+
+    def test_a_near_miss_token_is_rejected(self, client_with_cron_secret) -> None:
+        for bad in ("Bearer cron-12", "Bearer cron-1234", "cron-123", "Basic cron-123", ""):
+            resp = client_with_cron_secret.post(
+                "/api/cron/webhook", headers={"Authorization": bad}
+            )
+            assert resp.status_code == 401, bad
+
+    def test_correct_token_still_accepted(self, client_with_cron_secret) -> None:
+        with patch("hevy2garmin.server._webhook_sync", new_callable=AsyncMock):
+            resp = client_with_cron_secret.post(
+                "/api/cron/webhook", headers={"Authorization": "Bearer cron-123"}
+            )
+        assert resp.status_code == 200
+
+    def test_bearer_check_is_constant_time(self) -> None:
+        """A `!=` compare on the raw string leaks the secret byte by byte."""
+        import inspect
+
+        from hevy2garmin import server
+
+        src = inspect.getsource(server._bearer_ok)
+        assert "compare_digest" in src
+
+
+class TestInFlightCap:
+    """A staged sync lives ~25 min, so unbounded spawning is a pile-up vector."""
+
+    def test_beyond_the_cap_no_new_task_is_spawned(self, client_with_cron_secret) -> None:
+        from hevy2garmin import server
+
+        filler = {object() for _ in range(server.WEBHOOK_MAX_INFLIGHT)}
+        with (
+            patch.object(server, "_webhook_tasks", filler),
+            patch("hevy2garmin.server._webhook_sync", new_callable=AsyncMock) as worker,
+        ):
+            resp = client_with_cron_secret.post(
+                "/api/cron/webhook", headers={"Authorization": "Bearer cron-123"}
+            )
+        assert resp.status_code == 200, "Hevy must not be told to retry into the same wall"
+        assert resp.json()["status"] == "throttled"
+        worker.assert_not_called()
+
+    def test_under_the_cap_still_schedules(self, client_with_cron_secret) -> None:
+        from hevy2garmin import server
+
+        with (
+            patch.object(server, "_webhook_tasks", set()),
+            patch("hevy2garmin.server._webhook_sync", new_callable=AsyncMock) as worker,
+        ):
+            resp = client_with_cron_secret.post(
+                "/api/cron/webhook", headers={"Authorization": "Bearer cron-123"}
+            )
+        assert resp.json()["status"] == "accepted"
+        worker.assert_called_once()
+
+
 class TestWebhookWorker:
     """Staged retry semantics: all but the last attempt are merge_only, so a
     workout is uploaded plainly only once the watch activity clearly is not


### PR DESCRIPTION
Closes #301

> **Stacked on #306.** Its commit is the first of the two here — please merge #306 first, then this
> rebases to a single commit. Reviewing just the second commit is the useful diff.

`POST /api/cron/webhook` answers 200 straight away (Hevy times out in seconds) and schedules a
staged sync: wait `WEBHOOK_DELAY_SECONDS` (300), then up to `WEBHOOK_MAX_ATTEMPTS` (3) spaced
`WEBHOOK_RETRY_INTERVAL_SECONDS` (600) apart. Every attempt but the last is merge-only — a new
`merge_only` flag on `sync_one_workout` returns `merge_pending` instead of falling back — so a
plain FIT upload only happens once the watch activity clearly is not coming. Auto-sync stays the
safety net; retry state is in-memory and a restart simply drops it.

**Serverless is handled explicitly rather than silently doing nothing.** `_can_run_background_work()`
checks `VERCEL`, and when there is no background to schedule into the endpoint picks the only safe
option: with the watch merge on it defers to the platform cron and logs that it did; with the merge
off there is nothing to wait for, so it syncs inline. That second case is a real win on Hobby — a
sync per workout instead of one a day. **Vercel behaviour is unchanged unless someone points a
webhook at the new endpoint**, and the daily cron keeps working either way.

One bug found while testing this: a lock collision with auto-sync returns `busy`, which carries no
`merge_pending`, so a plain "did it merge?" check read it as "nothing to do" and abandoned the
staged sync — leaving the workout for the next auto-sync, i.e. exactly the delay the webhook exists
to remove. Collisions are now retried.

Auth: the existing `CRON_SECRET` bearer token, exempted from the cookie/CSRF check like
`/api/cron/sync`.

Tests: 14 cases — bearer enforcement (including on serverless), the 200-then-schedule shape, the
merge-only-until-last staging, stopping on success and on nothing-pending, the busy-retry case, a
raising attempt not hammering a broken backend, and all three serverless branches.

Running in production on arm64 Docker behind nginx; the Hevy subscription has been firing at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)