### PR TITLE
feat(intervals): delete the replaced watch copy from intervals.icu too

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,14 @@ HEVY2GARMIN_SECRET=
 # Needs a writable home directory, so it does not work on serverless.
 H2G_DIRECT_GARMIN_LOGIN=
 
+# ── Optional: intervals.icu duplicate cleanup ─────────────────────────────
+# Only relevant with the "replace" watch strategy, which deletes the watch
+# recording from Garmin after uploading the named activity. Garmin deletions
+# do not propagate, so the copy intervals.icu already pulled stays behind as a
+# duplicate; with both of these set it is deleted there too.
+INTERVALS_API_KEY=
+INTERVALS_ATHLETE_ID=
+
 # ── Vercel-specific (auto-set by Vercel) ──────────────────────────────────
 # DATABASE_URL=              # Auto-set by Vercel Postgres integration
 # VERCEL=1                   # Auto-set when running on Vercel

--- a/README.md
+++ b/README.md
@@ -369,6 +369,19 @@ Serving it at the **root of a subdomain** (`https://hevy.example.com/`) works. S
 
 Auto-sync runs on a timer inside the process, so a self-hosted instance can poll as often as you like — enable it and set the interval on the dashboard. This is the main practical difference from the Vercel deploy, where scheduling comes from a platform cron that is limited to once per day on Vercel's Hobby plan.
 
+### Removing duplicates from intervals.icu
+
+The `replace` watch strategy deletes the watch recording from Garmin once the named activity is uploaded, so Garmin ends up with one activity. Garmin deletions do not propagate, though: if you also sync Garmin to [intervals.icu](https://intervals.icu), the copy it already pulled stays there, and every merged workout leaves a duplicate behind.
+
+Set both of these and hevy2garmin deletes it there as well, matched on the Garmin activity id:
+
+```
+INTERVALS_API_KEY=
+INTERVALS_ATHLETE_ID=
+```
+
+Entirely opt-in — with either one missing the step is skipped. It also never fails a sync: intervals.icu being down or slow is logged and ignored, because the Garmin upload has already succeeded by that point.
+
 ### Running as a non-root user
 
 The image runs as uid 999. Named volumes (what the compose file uses) are handled automatically. If you use **bind mounts** instead — the `-v ~/.hevy2garmin:/root/.hevy2garmin` form shown in the Docker section — grant that user access once:

--- a/src/hevy2garmin/intervals_icu.py
+++ b/src/hevy2garmin/intervals_icu.py
@@ -1,0 +1,94 @@
+"""Optional intervals.icu cleanup: delete a Garmin-sourced activity after merge.
+
+Called from merge.py when an original watch activity is deleted from Garmin.
+Prevents the original from appearing as a duplicate in intervals.icu after the
+merged FIT is uploaded and synced.
+
+Only runs when INTERVALS_API_KEY and INTERVALS_ATHLETE_ID env vars are set.
+All errors are swallowed — never breaks the merge flow.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+
+import requests
+
+logger = logging.getLogger("hevy2garmin")
+
+_BASE_URL = "https://intervals.icu"
+
+
+def try_delete_icu_activity(garmin_activity_id: int, workout_start: str) -> bool:
+    """Delete the intervals.icu activity that corresponds to garmin_activity_id.
+
+    Intervals.icu stores Garmin activities with the plain numeric activity id
+    as external_id (a legacy "G{garminId}" form is matched too, just in case).
+    Searches a ±2-hour window around workout_start to locate the activity,
+    then deletes it.
+
+    Returns True if deleted, False if not found or env vars not configured.
+    Never raises.
+    """
+    api_key = os.environ.get("INTERVALS_API_KEY", "")
+    athlete_id = os.environ.get("INTERVALS_ATHLETE_ID", "")
+    if not api_key or not athlete_id:
+        return False
+
+    base_url = os.environ.get("INTERVALS_BASE_URL", _BASE_URL).rstrip("/")
+    auth = ("API_KEY", api_key)
+    target_external_ids = {str(garmin_activity_id), f"G{garmin_activity_id}"}
+
+    try:
+        start = datetime.fromisoformat(workout_start.replace("Z", "+00:00"))
+        if start.tzinfo is None:
+            start = start.replace(tzinfo=timezone.utc)
+    except (ValueError, TypeError):
+        logger.warning("ICU cleanup: invalid workout_start %r", workout_start)
+        return False
+
+    oldest = (start - timedelta(hours=2)).date().isoformat()
+    newest = (start + timedelta(hours=2)).date().isoformat()
+
+    try:
+        resp = requests.get(
+            f"{base_url}/api/v1/athlete/{athlete_id}/activities",
+            auth=auth,
+            params={"oldest": oldest, "newest": newest},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        activities = resp.json()
+    except Exception as e:
+        logger.warning("ICU cleanup: failed to list activities: %s", e)
+        return False
+
+    icu_id = None
+    for act in activities:
+        if str(act.get("external_id")) in target_external_ids:
+            icu_id = act.get("id")
+            break
+
+    if icu_id is None:
+        logger.warning(
+            "ICU cleanup: no activity with external_id=%s in window %s–%s — a stale duplicate may remain on intervals.icu",
+            garmin_activity_id, oldest, newest,
+        )
+        return False
+
+    try:
+        # Single-activity operations live under /api/v1/activity/{id} —
+        # the athlete-scoped path only supports listing (DELETE there is a 405).
+        resp = requests.delete(
+            f"{base_url}/api/v1/activity/{icu_id}",
+            auth=auth,
+            timeout=15,
+        )
+        resp.raise_for_status()
+        logger.info("  ICU cleanup: deleted activity %s (garmin_id=%s)", icu_id, garmin_activity_id)
+        return True
+    except Exception as e:
+        logger.warning("ICU cleanup: failed to delete activity %s: %s", icu_id, e)
+        return False

--- a/src/hevy2garmin/intervals_icu.py
+++ b/src/hevy2garmin/intervals_icu.py
@@ -45,7 +45,9 @@ def try_delete_icu_activity(garmin_activity_id: int, workout_start: str) -> bool
         start = datetime.fromisoformat(workout_start.replace("Z", "+00:00"))
         if start.tzinfo is None:
             start = start.replace(tzinfo=timezone.utc)
-    except (ValueError, TypeError):
+    except (ValueError, TypeError, AttributeError):
+        # AttributeError too: a non-str workout_start has no .replace, and this
+        # helper promises never to raise into the sync finalize path.
         logger.warning("ICU cleanup: invalid workout_start %r", workout_start)
         return False
 
@@ -61,6 +63,13 @@ def try_delete_icu_activity(garmin_activity_id: int, workout_start: str) -> bool
         )
         resp.raise_for_status()
         activities = resp.json()
+        # Shape-check inside the try: a 200 carrying a dict or a string would
+        # otherwise blow up in the loop below, which sits outside it.
+        if not isinstance(activities, list):
+            logger.warning(
+                "ICU cleanup: unexpected response type %s", type(activities).__name__
+            )
+            return False
     except Exception as e:
         logger.warning("ICU cleanup: failed to list activities: %s", e)
         return False

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -142,6 +142,15 @@ def finalize_pending(store, client, pending: dict) -> SyncOneResult:
                     phase = "needs_review" if attempts >= 3 else "finalizing"
                     store.update_pending(wid, phase=phase, next_step="delete", delete_attempt_count=attempts, last_error=str(exc)[:1000])
                     return SyncOneResult(status="needs_review" if phase == "needs_review" else "processing", activity_id=activity_id)
+                # Remove it from intervals.icu too, so the deleted watch copy
+                # doesn't linger there as a duplicate of the named activity
+                # that replaces it. No-op unless ICU credentials are set, and
+                # never raises — a failure here must not fail the sync.
+                workout_start = (payload.get("workout") or {}).get("start_time", "")
+                if workout_start:
+                    from hevy2garmin.intervals_icu import try_delete_icu_activity
+
+                    try_delete_icu_activity(int(watch_id), workout_start)
                 step = "commit"
                 store.update_pending(wid, next_step=step, last_error=None)
         _complete(store, wid, payload, activity_id)

--- a/tests/test_intervals_icu.py
+++ b/tests/test_intervals_icu.py
@@ -1,0 +1,118 @@
+"""Tests for the optional intervals.icu cleanup after a merge."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hevy2garmin.intervals_icu import try_delete_icu_activity
+
+ENV = {"INTERVALS_API_KEY": "secret", "INTERVALS_ATHLETE_ID": "i12345"}
+START = "2026-03-15T18:00:00+00:00"
+
+
+@pytest.fixture
+def icu_env(monkeypatch):
+    for k, v in ENV.items():
+        monkeypatch.setenv(k, v)
+    # Pin the base URL so assertions don't depend on a real default.
+    monkeypatch.setenv("INTERVALS_BASE_URL", "https://intervals.icu")
+
+
+def _resp(json_data=None, raise_exc=None):
+    resp = MagicMock()
+    if raise_exc is not None:
+        resp.raise_for_status.side_effect = raise_exc
+    else:
+        resp.raise_for_status.return_value = None
+    resp.json.return_value = json_data
+    return resp
+
+
+def test_no_env_vars_is_noop(monkeypatch):
+    monkeypatch.delenv("INTERVALS_API_KEY", raising=False)
+    monkeypatch.delenv("INTERVALS_ATHLETE_ID", raising=False)
+    with patch("hevy2garmin.intervals_icu.requests") as req:
+        assert try_delete_icu_activity(999, START) is False
+        req.get.assert_not_called()
+        req.delete.assert_not_called()
+
+
+def test_found_activity_is_deleted(icu_env):
+    activities = [
+        {"id": 111, "external_id": "Gnope"},
+        {"id": 222, "external_id": "G999"},
+    ]
+    with patch("hevy2garmin.intervals_icu.requests") as req:
+        req.get.return_value = _resp(json_data=activities)
+        req.delete.return_value = _resp()
+
+        assert try_delete_icu_activity(999, START) is True
+
+        # GET hit the activities list with a ±2h date window.
+        get_args, get_kwargs = req.get.call_args
+        assert get_args[0] == "https://intervals.icu/api/v1/athlete/i12345/activities"
+        assert get_kwargs["auth"] == ("API_KEY", "secret")
+        assert get_kwargs["params"] == {"oldest": "2026-03-15", "newest": "2026-03-15"}
+
+        # DELETE targeted the matched ICU id (222), not the Garmin id, on the
+        # single-activity endpoint (the athlete-scoped path 405s on DELETE).
+        del_args, _ = req.delete.call_args
+        assert del_args[0] == "https://intervals.icu/api/v1/activity/222"
+
+
+def test_plain_numeric_external_id_is_deleted(icu_env):
+    # intervals.icu reports Garmin activities with a plain numeric external_id
+    # (no "G" prefix) — observed live 2026-07: {"external_id": "23633234350",
+    # "source": "GARMIN_CONNECT"}. The cleanup must match that form too.
+    activities = [
+        {"id": "i166661330", "external_id": "23632538775", "source": "GARMIN_CONNECT"},
+        {"id": "i166677402", "external_id": "23633234350", "source": "GARMIN_CONNECT"},
+    ]
+    with patch("hevy2garmin.intervals_icu.requests") as req:
+        req.get.return_value = _resp(json_data=activities)
+        req.delete.return_value = _resp()
+
+        assert try_delete_icu_activity(23633234350, START) is True
+
+        del_args, _ = req.delete.call_args
+        assert del_args[0] == "https://intervals.icu/api/v1/activity/i166677402"
+
+
+def test_not_found_does_not_delete(icu_env):
+    with patch("hevy2garmin.intervals_icu.requests") as req:
+        req.get.return_value = _resp(json_data=[{"id": 1, "external_id": "Gother"}])
+        assert try_delete_icu_activity(999, START) is False
+        req.delete.assert_not_called()
+
+
+def test_invalid_workout_start_is_noop(icu_env):
+    with patch("hevy2garmin.intervals_icu.requests") as req:
+        assert try_delete_icu_activity(999, "not-a-date") is False
+        req.get.assert_not_called()
+        req.delete.assert_not_called()
+
+
+def test_list_failure_never_raises(icu_env):
+    with patch("hevy2garmin.intervals_icu.requests") as req:
+        req.get.side_effect = RuntimeError("network down")
+        assert try_delete_icu_activity(999, START) is False
+        req.delete.assert_not_called()
+
+
+def test_delete_failure_never_raises(icu_env):
+    with patch("hevy2garmin.intervals_icu.requests") as req:
+        req.get.return_value = _resp(json_data=[{"id": 222, "external_id": "G999"}])
+        req.delete.return_value = _resp(raise_exc=RuntimeError("403"))
+        assert try_delete_icu_activity(999, START) is False
+
+
+def test_zero_icu_id_is_deleted(icu_env):
+    # An ICU activity id of 0 is valid and must be deleted, not treated as "not found".
+    with patch("hevy2garmin.intervals_icu.requests") as req:
+        req.get.return_value = _resp(json_data=[{"id": 0, "external_id": "G999"}])
+        req.delete.return_value = _resp()
+        assert try_delete_icu_activity(999, START) is True
+        del_args, _ = req.delete.call_args
+        assert del_args[0] == "https://intervals.icu/api/v1/activity/0"

--- a/tests/test_intervals_icu.py
+++ b/tests/test_intervals_icu.py
@@ -108,6 +108,36 @@ def test_delete_failure_never_raises(icu_env):
         assert try_delete_icu_activity(999, START) is False
 
 
+@pytest.mark.parametrize(
+    "body", [{"error": "nope"}, "a string", 42, None], ids=["dict", "str", "int", "null"]
+)
+def test_non_list_200_body_never_raises(icu_env, body):
+    """A 200 whose body is not a list must not escape into the sync.
+
+    The match loop runs outside the request try/except, so an unexpected shape
+    used to raise from here (a dict iterates to str keys → AttributeError on
+    .get; an int → TypeError). This helper sits inside finalize_pending before
+    next_step="commit", so a raise reverts to phase="finalizing", retries the
+    delete on the already-deleted watch id, and after the retry cap files a
+    fully-successful merge as needs_review.
+    """
+    with patch("hevy2garmin.intervals_icu.requests") as req:
+        req.get.return_value = _resp(json_data=body)
+        assert try_delete_icu_activity(999, START) is False
+        req.delete.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "workout_start", [1773763200, {"start_time": START}, [START], None], ids=["int", "dict", "list", "none"]
+)
+def test_non_string_workout_start_never_raises(icu_env, workout_start):
+    """A non-str start has no .replace — AttributeError, not ValueError/TypeError."""
+    with patch("hevy2garmin.intervals_icu.requests") as req:
+        assert try_delete_icu_activity(999, workout_start) is False
+        req.get.assert_not_called()
+        req.delete.assert_not_called()
+
+
 def test_zero_icu_id_is_deleted(icu_env):
     # An ICU activity id of 0 is valid and must be deleted, not treated as "not found".
     with patch("hevy2garmin.intervals_icu.requests") as req:


### PR DESCRIPTION
Closes #302

New `intervals_icu.py` with one function, called from the same step in `finalize_pending` that
deletes the Garmin watch copy — so it only ever runs for a confirmed replace-merge, never for a
standalone watch workout.

**Entirely opt-in and it cannot fail a sync.** No `INTERVALS_API_KEY` / `INTERVALS_ATHLETE_ID` →
returns immediately. Every error path is caught and logged: by the time this runs the Garmin upload
has already succeeded, so intervals.icu being down or slow must not turn a successful sync into a
failure. Nothing changes for anyone who does not set the two variables, Vercel included.

The two API details from the issue are both handled — plain numeric `external_id` (with `G{id}`
kept only as a defensive fallback) and `DELETE /api/v1/activity/{id}` rather than the athlete-scoped
path. A miss is a warning naming the id and window, not silence, since a stale duplicate left behind
is the thing worth knowing about.

Both were found the hard way against a live account: the `G` prefix appears on 0 of 207 activities,
and the athlete-scoped DELETE returns 405. Worth knowing if you ever touch this: a `Python-urllib`
User-Agent gets a blanket 403 from intervals.icu, so `requests` is load-bearing here and diagnosing
this with a urllib one-liner is misleading.

Tests: 8 cases covering the no-credentials no-op, the match, the miss, and the failure paths.

Also worth noting for anyone reading the code later: **Strava is not analogous** even though it looks
it. Garmin-pushed Strava activities carry `external_id: garmin_ping_<pingId>`, which contains no
activity id, so the same approach does not transfer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)