### PR TITLE
feat(web): read-only pages + safe routes [C3]

### DIFF
--- a/web/app/api/garmin-categories/route.ts
+++ b/web/app/api/garmin-categories/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { CATEGORY_NAMES } from "@/lib/garmin-categories";
+
+/**
+ * GET /api/garmin-categories
+ *
+ * Returns the Garmin FIT exercise category id → name map used by the mapping
+ * UI. The hevy2garmin npm package's exercise-map exports the numeric (category,
+ * subcategory) pairs but NOT the category *names*, so the map lives in
+ * lib/garmin-categories.ts, mirroring the Python dashboard's
+ * `server.py::_get_cat_names()` — the source of the original route.
+ */
+export function GET() {
+  return NextResponse.json(CATEGORY_NAMES);
+}

--- a/web/app/api/mapping/delete/route.ts
+++ b/web/app/api/mapping/delete/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+
+// Writes to the live hevy2garmin Postgres at request time — never at build.
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/mapping/delete
+ * Body: { hevy_name: string }
+ *
+ * Deletes a single custom mapping row by its primary key. Mirrors
+ * PostgresDatabase.delete_custom_mapping (db_postgres.py). Only touches
+ * `custom_mappings` — no sync/upload side effects.
+ */
+
+interface Body {
+  hevy_name?: unknown;
+}
+
+export async function POST(request: Request) {
+  let body: Body;
+  try {
+    body = (await request.json()) as Body;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const hevyName =
+    typeof body.hevy_name === "string" ? body.hevy_name.trim() : "";
+  if (!hevyName) {
+    return NextResponse.json(
+      { error: "hevy_name is required." },
+      { status: 400 },
+    );
+  }
+
+  let sql: ReturnType<typeof getDb>;
+  try {
+    sql = getDb();
+  } catch {
+    return NextResponse.json(
+      { error: "DATABASE_URL not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    await sql`DELETE FROM custom_mappings WHERE hevy_name = ${hevyName}`;
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/web/app/api/mapping/route.ts
+++ b/web/app/api/mapping/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+
+// Writes to the live hevy2garmin Postgres at request time — never at build.
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/mapping
+ * Body: { hevy_name: string, category: number, subcategory?: number }
+ *
+ * Upserts a single row into `custom_mappings` (hevy_name PK). This is the only
+ * table this web app is allowed to write to — no sync/upload side effects. The
+ * upsert mirrors PostgresDatabase.save_custom_mapping (db_postgres.py).
+ */
+
+interface Body {
+  hevy_name?: unknown;
+  category?: unknown;
+  subcategory?: unknown;
+}
+
+function toInt(value: unknown): number | null {
+  if (typeof value === "number" && Number.isInteger(value)) return value;
+  if (typeof value === "string" && /^-?\d+$/.test(value.trim())) {
+    return Number.parseInt(value.trim(), 10);
+  }
+  return null;
+}
+
+export async function POST(request: Request) {
+  let body: Body;
+  try {
+    body = (await request.json()) as Body;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const hevyName =
+    typeof body.hevy_name === "string" ? body.hevy_name.trim() : "";
+  if (!hevyName) {
+    return NextResponse.json(
+      { error: "hevy_name is required." },
+      { status: 400 },
+    );
+  }
+
+  const category = toInt(body.category);
+  if (category === null) {
+    return NextResponse.json(
+      { error: "category must be an integer." },
+      { status: 400 },
+    );
+  }
+
+  // subcategory is optional and defaults to 0 (matches the DB column default).
+  const subcategory = body.subcategory === undefined ? 0 : toInt(body.subcategory);
+  if (subcategory === null) {
+    return NextResponse.json(
+      { error: "subcategory must be an integer." },
+      { status: 400 },
+    );
+  }
+
+  let sql: ReturnType<typeof getDb>;
+  try {
+    sql = getDb();
+  } catch {
+    return NextResponse.json(
+      { error: "DATABASE_URL not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    await sql`
+      INSERT INTO custom_mappings (hevy_name, category, subcategory)
+      VALUES (${hevyName}, ${category}, ${subcategory})
+      ON CONFLICT (hevy_name) DO UPDATE SET
+        category = EXCLUDED.category,
+        subcategory = EXCLUDED.subcategory
+    `;
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/web/app/api/validate-hevy/route.ts
+++ b/web/app/api/validate-hevy/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { HevyClient } from "hevy2garmin";
+
+// Calls the live Hevy API only when invoked at runtime — never at build.
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/validate-hevy?key=<hevy-api-key>
+ *
+ * Tests a Hevy API key by asking the Hevy API for the caller's workout count.
+ * A valid key returns `{ valid: true, workout_count }`; anything else returns
+ * `{ valid: false, error }`. This never touches the database and never fires an
+ * upload — it is a read-only probe of the supplied key.
+ */
+export async function GET(request: Request) {
+  const key = new URL(request.url).searchParams.get("key")?.trim();
+  if (!key) {
+    return NextResponse.json(
+      { valid: false, error: "Missing ?key= query parameter." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const client = new HevyClient(key);
+    const workout_count = await client.getWorkoutCount();
+    return NextResponse.json({ valid: true, workout_count });
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ valid: false, error });
+  }
+}

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -84,11 +84,13 @@ async function loadDashboard(): Promise<DashboardData> {
 
   return {
     dbConfigured: true,
+    // A saved credential row is "connected" unless explicitly disconnected.
+    // The DB uses status='active' for a live connection (not 'connected').
     hevyConnected:
-      connected.some((r) => r.platform === "hevy" && r.status === "connected") ||
+      connected.some((r) => r.platform === "hevy" && r.status !== "disconnected") ||
       recent.length > 0,
     garminConnected:
-      connected.some((r) => r.platform === "garmin" && r.status === "connected") ||
+      connected.some((r) => r.platform === "garmin" && r.status !== "disconnected") ||
       recent.some((r) => r.garmin_activity_id != null),
     totalSynced: counts[0]?.total ?? 0,
     syncedThisWeek: counts[0]?.week ?? 0,

--- a/web/app/history/page.tsx
+++ b/web/app/history/page.tsx
@@ -1,0 +1,165 @@
+import { getDb } from "@/lib/db";
+
+// Queries the live hevy2garmin Postgres per request — never at build time.
+export const dynamic = "force-dynamic";
+
+interface HistoryRow {
+  hevy_id: string;
+  title: string;
+  synced_at: string | null;
+  calories: number | null;
+  avg_hr: number | null;
+  garmin_activity_id: string | null;
+  status: string;
+}
+
+interface HistoryData {
+  dbConfigured: boolean;
+  total: number;
+  rows: HistoryRow[];
+}
+
+const EMPTY: HistoryData = { dbConfigured: false, total: 0, rows: [] };
+const LIMIT = 100;
+
+async function loadHistory(): Promise<HistoryData> {
+  let sql: ReturnType<typeof getDb>;
+  try {
+    sql = getDb();
+  } catch {
+    return EMPTY;
+  }
+
+  const [counts, rows] = await Promise.all([
+    sql`SELECT count(*)::int AS total FROM synced_workouts`.catch(
+      () => [] as Array<{ total: number }>,
+    ),
+    sql`
+      SELECT hevy_id, title, synced_at, calories, avg_hr,
+             garmin_activity_id, COALESCE(status, 'success') AS status
+      FROM synced_workouts
+      ORDER BY synced_at DESC
+      LIMIT ${LIMIT}
+    `.catch(() => [] as HistoryRow[]),
+  ]);
+
+  return {
+    dbConfigured: true,
+    total: counts[0]?.total ?? 0,
+    rows: rows.map((r) => ({
+      hevy_id: r.hevy_id,
+      title: r.title ?? "",
+      synced_at: r.synced_at ?? null,
+      calories: r.calories != null ? Number(r.calories) : null,
+      avg_hr: r.avg_hr != null ? Number(r.avg_hr) : null,
+      garmin_activity_id: r.garmin_activity_id ?? null,
+      status: r.status,
+    })),
+  };
+}
+
+function fmtDate(value: string | null): string {
+  if (!value) return "—";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function statusLabel(status: string): string {
+  if (status === "manual") return "Marked as synced";
+  if (status === "skipped") return "Skipped";
+  return "Uploaded";
+}
+
+function StatusPill({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    success: "bg-success/15 text-success",
+    manual: "bg-warm/15 text-warm",
+    skipped: "bg-surface-active text-text-muted",
+    failed: "bg-danger/15 text-danger",
+  };
+  const cls = styles[status] ?? "bg-surface-active text-text-secondary";
+  return (
+    <span className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${cls}`}>
+      {statusLabel(status)}
+    </span>
+  );
+}
+
+export default async function HistoryPage() {
+  const data = await loadHistory();
+
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-8 md:px-6">
+      <header className="mb-6">
+        <h1 className="text-2xl font-bold text-text">Sync history</h1>
+        <p className="mt-1 text-sm text-text-secondary">
+          {data.total} {data.total === 1 ? "workout" : "workouts"} resolved
+          {data.total > LIMIT && <span> · showing the {LIMIT} most recent</span>}
+        </p>
+      </header>
+
+      {!data.dbConfigured && (
+        <div className="mb-6 rounded-lg border border-warm/40 bg-warm/10 p-4 text-sm text-warm">
+          No database is configured (DATABASE_URL is unset). Showing empty state.
+        </div>
+      )}
+
+      {data.rows.length === 0 ? (
+        <div className="rounded-lg border border-border bg-surface p-8 text-center">
+          <p className="text-sm font-medium text-text-secondary">
+            No workouts synced yet.
+          </p>
+          <p className="mt-1 text-xs text-text-muted">
+            Synced workouts will appear here.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-border bg-surface-elevated">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-text-muted">
+                <th className="px-4 py-2 font-medium">Synced</th>
+                <th className="px-4 py-2 font-medium">Title</th>
+                <th className="px-4 py-2 text-right font-medium">Calories</th>
+                <th className="px-4 py-2 text-right font-medium">Avg HR</th>
+                <th className="px-4 py-2 font-medium">Garmin ID</th>
+                <th className="px-4 py-2 font-medium">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {data.rows.map((r) => (
+                <tr key={r.hevy_id}>
+                  <td className="whitespace-nowrap px-4 py-2 tabular-nums text-text-muted">
+                    {fmtDate(r.synced_at)}
+                  </td>
+                  <td className="px-4 py-2 font-medium text-text">
+                    {r.title || "Untitled workout"}
+                  </td>
+                  <td className="px-4 py-2 text-right tabular-nums text-text-secondary">
+                    {r.calories ?? "—"}
+                  </td>
+                  <td className="px-4 py-2 text-right tabular-nums text-text-secondary">
+                    {r.avg_hr ?? "—"}
+                  </td>
+                  <td className="px-4 py-2 tabular-nums text-text-muted">
+                    {r.garmin_activity_id ?? "—"}
+                  </td>
+                  <td className="px-4 py-2">
+                    <StatusPill status={r.status} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/web/app/mappings/page.tsx
+++ b/web/app/mappings/page.tsx
@@ -1,0 +1,168 @@
+import { HEVY_TO_GARMIN } from "hevy2garmin";
+import { getDb } from "@/lib/db";
+import {
+  CATEGORY_OPTIONS,
+  categoryName,
+} from "@/lib/garmin-categories";
+import { DeleteMappingButton, MappingForm } from "@/components/mapping-form";
+
+// Queries the live hevy2garmin Postgres per request — never at build time.
+export const dynamic = "force-dynamic";
+
+interface CustomMapping {
+  hevy_name: string;
+  category: number;
+  subcategory: number;
+}
+
+interface MappingsData {
+  dbConfigured: boolean;
+  custom: CustomMapping[];
+  builtinCount: number;
+  builtinSample: Array<{ name: string; category: number; subcategory: number }>;
+}
+
+async function loadMappings(): Promise<MappingsData> {
+  // The built-in map ships with the package — available regardless of DB state.
+  const builtinEntries = Object.entries(HEVY_TO_GARMIN);
+  const builtinSample = builtinEntries.slice(0, 12).map(([name, pair]) => ({
+    name,
+    category: pair[0],
+    subcategory: pair[1],
+  }));
+
+  let sql: ReturnType<typeof getDb>;
+  try {
+    sql = getDb();
+  } catch {
+    return {
+      dbConfigured: false,
+      custom: [],
+      builtinCount: builtinEntries.length,
+      builtinSample,
+    };
+  }
+
+  const rows = await sql`
+    SELECT hevy_name, category, subcategory
+    FROM custom_mappings
+    ORDER BY hevy_name ASC
+  `.catch(() => [] as CustomMapping[]);
+
+  return {
+    dbConfigured: true,
+    custom: rows.map((r) => ({
+      hevy_name: r.hevy_name,
+      category: Number(r.category),
+      subcategory: Number(r.subcategory),
+    })),
+    builtinCount: builtinEntries.length,
+    builtinSample,
+  };
+}
+
+export default async function MappingsPage() {
+  const data = await loadMappings();
+
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-8 md:px-6">
+      <header className="mb-6">
+        <h1 className="text-2xl font-bold text-text">Exercise mappings</h1>
+        <p className="mt-1 text-sm text-text-secondary">
+          How Hevy exercises map to Garmin FIT exercise categories.
+        </p>
+      </header>
+
+      {!data.dbConfigured && (
+        <div className="mb-6 rounded-lg border border-warm/40 bg-warm/10 p-4 text-sm text-warm">
+          No database is configured (DATABASE_URL is unset). Custom mappings are
+          unavailable; the built-in map below still works.
+        </div>
+      )}
+
+      {/* Add a custom mapping */}
+      <section className="mb-8">
+        <h2 className="mb-3 text-lg font-semibold text-text">
+          Add a custom mapping
+        </h2>
+        <div className="rounded-xl border border-border bg-surface-elevated p-4">
+          <MappingForm categories={CATEGORY_OPTIONS} />
+          <p className="mt-3 text-xs text-text-muted">
+            A custom mapping overrides the built-in map for that exact Hevy
+            exercise name. Sub ID 0 uses the category&apos;s generic exercise.
+          </p>
+        </div>
+      </section>
+
+      {/* Custom mappings */}
+      <section className="mb-8">
+        <h2 className="mb-3 text-lg font-semibold text-text">
+          Your custom mappings ({data.custom.length})
+        </h2>
+        {data.custom.length === 0 ? (
+          <div className="rounded-lg border border-border bg-surface p-6 text-center text-sm text-text-muted">
+            No custom mappings yet. Add one above to override a built-in mapping.
+          </div>
+        ) : (
+          <ul className="divide-y divide-border overflow-hidden rounded-xl border border-border bg-surface-elevated">
+            {data.custom.map((m) => (
+              <li
+                key={m.hevy_name}
+                className="flex items-center justify-between gap-3 px-4 py-3"
+              >
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-medium text-text">
+                    {m.hevy_name}
+                  </div>
+                  <div className="mt-0.5 text-xs text-text-muted">
+                    {categoryName(m.category)} · cat {m.category} · sub{" "}
+                    {m.subcategory}
+                  </div>
+                </div>
+                <DeleteMappingButton hevyName={m.hevy_name} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {/* Built-in map */}
+      <section>
+        <h2 className="mb-1 text-lg font-semibold text-text">
+          Built-in map
+        </h2>
+        <p className="mb-3 text-sm text-text-secondary">
+          {data.builtinCount} exercises are mapped out of the box. Sample:
+        </p>
+        <div className="overflow-x-auto rounded-xl border border-border bg-surface-elevated">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-text-muted">
+                <th className="px-4 py-2 font-medium">Hevy exercise</th>
+                <th className="px-4 py-2 font-medium">Garmin category</th>
+                <th className="px-4 py-2 text-right font-medium">Cat</th>
+                <th className="px-4 py-2 text-right font-medium">Sub</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {data.builtinSample.map((b) => (
+                <tr key={b.name}>
+                  <td className="px-4 py-2 font-medium text-text">{b.name}</td>
+                  <td className="px-4 py-2 text-text-secondary">
+                    {categoryName(b.category)}
+                  </td>
+                  <td className="px-4 py-2 text-right tabular-nums text-text-muted">
+                    {b.category}
+                  </td>
+                  <td className="px-4 py-2 text-right tabular-nums text-text-muted">
+                    {b.subcategory}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/web/app/routines/page.tsx
+++ b/web/app/routines/page.tsx
@@ -1,0 +1,24 @@
+// Static placeholder — routine sync is a later phase.
+export const dynamic = "force-static";
+
+export default function RoutinesPage() {
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-8 md:px-6">
+      <header className="mb-6">
+        <h1 className="text-2xl font-bold text-text">Routines</h1>
+        <p className="mt-1 text-sm text-text-secondary">
+          Hevy routine → Garmin planned-workout sync.
+        </p>
+      </header>
+
+      <div className="rounded-lg border border-border bg-surface p-8 text-center">
+        <p className="text-sm font-medium text-text-secondary">
+          Coming in a later phase.
+        </p>
+        <p className="mt-1 text-xs text-text-muted">
+          Routine syncing isn&apos;t part of the read-only web app yet.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -1,0 +1,226 @@
+import { getDb } from "@/lib/db";
+
+// Queries the live hevy2garmin Postgres per request — never at build time.
+export const dynamic = "force-dynamic";
+
+interface PlatformRow {
+  platform: string;
+  auth_type: string;
+  status: string;
+  connected_at: string | null;
+  expires_at: string | null;
+}
+
+interface ConfigEntry {
+  key: string;
+  value: Record<string, unknown>;
+  updated_at: string | null;
+}
+
+interface SettingsData {
+  dbConfigured: boolean;
+  platforms: PlatformRow[];
+  config: ConfigEntry[];
+}
+
+const EMPTY: SettingsData = { dbConfigured: false, platforms: [], config: [] };
+
+// The user-editable config the Python app persists to app_cache (config.py).
+const CONFIG_KEYS = ["user_profile", "timing", "hr_fusion", "merge_settings", "auto_sync"];
+
+async function loadSettings(): Promise<SettingsData> {
+  let sql: ReturnType<typeof getDb>;
+  try {
+    sql = getDb();
+  } catch {
+    return EMPTY;
+  }
+
+  const [platforms, config] = await Promise.all([
+    sql`
+      SELECT platform, auth_type, status, connected_at, expires_at
+      FROM platform_credentials
+      ORDER BY platform ASC
+    `.catch(() => [] as PlatformRow[]),
+    sql`
+      SELECT key, value, updated_at
+      FROM app_cache
+      WHERE key = ANY(${CONFIG_KEYS})
+      ORDER BY key ASC
+    `.catch(() => [] as ConfigEntry[]),
+  ]);
+
+  return {
+    dbConfigured: true,
+    platforms: platforms.map((p) => ({
+      platform: p.platform,
+      auth_type: p.auth_type ?? "",
+      status: p.status ?? "disconnected",
+      connected_at: p.connected_at ?? null,
+      expires_at: p.expires_at ?? null,
+    })),
+    config: config.map((c) => ({
+      key: c.key,
+      // The postgres driver returns JSONB as a parsed object already.
+      value:
+        c.value && typeof c.value === "object"
+          ? (c.value as Record<string, unknown>)
+          : {},
+      updated_at: c.updated_at ?? null,
+    })),
+  };
+}
+
+function fmtDate(value: string | null): string {
+  if (!value) return "—";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function titleCase(key: string): string {
+  return key
+    .split("_")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+function fmtValue(value: unknown): string {
+  if (value === null || value === undefined) return "—";
+  if (typeof value === "boolean") return value ? "On" : "Off";
+  if (Array.isArray(value)) return value.length ? value.join(", ") : "—";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+function StatusPill({ status }: { status: string }) {
+  const connected = status === "connected" || status === "active";
+  return (
+    <span
+      className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${
+        connected ? "bg-success/15 text-success" : "bg-surface-active text-text-muted"
+      }`}
+    >
+      {status}
+    </span>
+  );
+}
+
+export default async function SettingsPage() {
+  const data = await loadSettings();
+
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-8 md:px-6">
+      <header className="mb-4">
+        <h1 className="text-2xl font-bold text-text">Settings</h1>
+        <p className="mt-1 text-sm text-text-secondary">
+          Current configuration and connection status.
+        </p>
+      </header>
+
+      <div className="mb-6 rounded-lg border border-border bg-surface p-4 text-sm text-text-muted">
+        Read-only for now. Editing credentials and config from the web app comes
+        in a later phase.
+      </div>
+
+      {!data.dbConfigured && (
+        <div className="mb-6 rounded-lg border border-warm/40 bg-warm/10 p-4 text-sm text-warm">
+          No database is configured (DATABASE_URL is unset). Showing empty state.
+        </div>
+      )}
+
+      {/* Connections */}
+      <section className="mb-8">
+        <h2 className="mb-3 text-lg font-semibold text-text">Connections</h2>
+        {data.platforms.length === 0 ? (
+          <div className="rounded-lg border border-border bg-surface p-6 text-center text-sm text-text-muted">
+            No platform connections recorded.
+          </div>
+        ) : (
+          <div className="overflow-x-auto rounded-xl border border-border bg-surface-elevated">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-text-muted">
+                  <th className="px-4 py-2 font-medium">Platform</th>
+                  <th className="px-4 py-2 font-medium">Auth</th>
+                  <th className="px-4 py-2 font-medium">Status</th>
+                  <th className="px-4 py-2 font-medium">Connected</th>
+                  <th className="px-4 py-2 font-medium">Expires</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border">
+                {data.platforms.map((p) => (
+                  <tr key={p.platform}>
+                    <td className="px-4 py-2 font-medium text-text">{p.platform}</td>
+                    <td className="px-4 py-2 text-text-secondary">
+                      {p.auth_type || "—"}
+                    </td>
+                    <td className="px-4 py-2">
+                      <StatusPill status={p.status} />
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-2 tabular-nums text-text-muted">
+                      {fmtDate(p.connected_at)}
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-2 tabular-nums text-text-muted">
+                      {fmtDate(p.expires_at)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      {/* Config */}
+      <section>
+        <h2 className="mb-3 text-lg font-semibold text-text">Configuration</h2>
+        {data.config.length === 0 ? (
+          <div className="rounded-lg border border-border bg-surface p-6 text-center text-sm text-text-muted">
+            No configuration stored yet (defaults are in use).
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            {data.config.map((c) => (
+              <div
+                key={c.key}
+                className="rounded-xl border border-border bg-surface-elevated p-4"
+              >
+                <div className="mb-2 flex items-baseline justify-between gap-2">
+                  <h3 className="text-sm font-semibold text-text">
+                    {titleCase(c.key)}
+                  </h3>
+                  <span className="text-xs text-text-muted">
+                    {fmtDate(c.updated_at)}
+                  </span>
+                </div>
+                <dl className="space-y-1">
+                  {Object.entries(c.value).map(([k, v]) => (
+                    <div
+                      key={k}
+                      className="flex items-baseline justify-between gap-3 text-sm"
+                    >
+                      <dt className="text-text-muted">{titleCase(k)}</dt>
+                      <dd className="text-right font-medium text-text-secondary">
+                        {fmtValue(v)}
+                      </dd>
+                    </div>
+                  ))}
+                  {Object.keys(c.value).length === 0 && (
+                    <p className="text-xs text-text-muted">Empty.</p>
+                  )}
+                </dl>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/web/app/workouts/page.tsx
+++ b/web/app/workouts/page.tsx
@@ -1,0 +1,201 @@
+import { getDb } from "@/lib/db";
+
+// Queries the live hevy2garmin Postgres per request — never at build time.
+export const dynamic = "force-dynamic";
+
+interface WorkoutItem {
+  hevy_id: string;
+  title: string;
+  when: string | null;
+  // Normalised state for the pill: terminal statuses from synced_workouts
+  // (success/manual/skipped) or a pending phase from pending_uploads.
+  state: string;
+  detail: string | null;
+  garmin_activity_id: string | null;
+  kind: "terminal" | "pending";
+}
+
+interface WorkoutsData {
+  dbConfigured: boolean;
+  items: WorkoutItem[];
+}
+
+const EMPTY: WorkoutsData = { dbConfigured: false, items: [] };
+
+async function loadWorkouts(): Promise<WorkoutsData> {
+  let sql: ReturnType<typeof getDb>;
+  try {
+    sql = getDb();
+  } catch {
+    return EMPTY;
+  }
+
+  const [terminal, pending] = await Promise.all([
+    sql`
+      SELECT hevy_id, title, synced_at, garmin_activity_id,
+             COALESCE(status, 'success') AS status
+      FROM synced_workouts
+      ORDER BY synced_at DESC
+      LIMIT 100
+    `.catch(
+      () =>
+        [] as Array<{
+          hevy_id: string;
+          title: string | null;
+          synced_at: string | null;
+          garmin_activity_id: string | null;
+          status: string;
+        }>,
+    ),
+    sql`
+      SELECT hevy_id, phase, next_step, last_error, garmin_activity_id,
+             created_at,
+             (payload ->> 'title') AS payload_title
+      FROM pending_uploads
+      ORDER BY created_at DESC
+      LIMIT 100
+    `.catch(
+      () =>
+        [] as Array<{
+          hevy_id: string;
+          phase: string | null;
+          next_step: string | null;
+          last_error: string | null;
+          garmin_activity_id: string | null;
+          created_at: string | null;
+          payload_title: string | null;
+        }>,
+    ),
+  ]);
+
+  const pendingItems: WorkoutItem[] = pending.map((p) => ({
+    hevy_id: p.hevy_id,
+    title: p.payload_title ?? "",
+    when: p.created_at ?? null,
+    state: p.phase ?? "pending",
+    detail: p.last_error ?? p.next_step ?? null,
+    garmin_activity_id: p.garmin_activity_id ?? null,
+    kind: "pending",
+  }));
+
+  const pendingIds = new Set(pendingItems.map((p) => p.hevy_id));
+
+  const terminalItems: WorkoutItem[] = terminal
+    // A hevy_id in pending_uploads is mid-flight; prefer its pending row.
+    .filter((t) => !pendingIds.has(t.hevy_id))
+    .map((t) => ({
+      hevy_id: t.hevy_id,
+      title: t.title ?? "",
+      when: t.synced_at ?? null,
+      state: t.status,
+      detail: null,
+      garmin_activity_id: t.garmin_activity_id ?? null,
+      kind: "terminal",
+    }));
+
+  // Pending first (they need attention), then terminal, each newest-first.
+  return { dbConfigured: true, items: [...pendingItems, ...terminalItems] };
+}
+
+function fmtDate(value: string | null): string {
+  if (!value) return "—";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function StatusPill({ item }: { item: WorkoutItem }) {
+  // Terminal statuses map to fixed colours; any pending phase is "warm/in-flight".
+  const terminalStyles: Record<string, { cls: string; label: string }> = {
+    success: { cls: "bg-success/15 text-success", label: "Uploaded" },
+    manual: { cls: "bg-warm/15 text-warm", label: "Marked as synced" },
+    skipped: { cls: "bg-surface-active text-text-muted", label: "Skipped" },
+    failed: { cls: "bg-danger/15 text-danger", label: "Failed" },
+  };
+
+  if (item.kind === "terminal") {
+    const s = terminalStyles[item.state] ?? {
+      cls: "bg-surface-active text-text-secondary",
+      label: item.state,
+    };
+    return (
+      <span className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${s.cls}`}>
+        {s.label}
+      </span>
+    );
+  }
+
+  // Pending — teal to distinguish from terminal states.
+  return (
+    <span className="inline-block rounded-full bg-teal/15 px-2.5 py-0.5 text-xs font-medium text-teal">
+      {item.state}
+    </span>
+  );
+}
+
+export default async function WorkoutsPage() {
+  const data = await loadWorkouts();
+
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-8 md:px-6">
+      <header className="mb-4">
+        <h1 className="text-2xl font-bold text-text">Workouts</h1>
+        <p className="mt-1 text-sm text-text-secondary">
+          Terminal and in-flight workouts recorded in the database.
+        </p>
+      </header>
+
+      <div className="mb-6 rounded-lg border border-border bg-surface p-4 text-sm text-text-muted">
+        Live Hevy fetch and per-workout sync actions come in a later phase. This
+        view is read-only and shows only what the database already knows.
+      </div>
+
+      {!data.dbConfigured && (
+        <div className="mb-6 rounded-lg border border-warm/40 bg-warm/10 p-4 text-sm text-warm">
+          No database is configured (DATABASE_URL is unset). Showing empty state.
+        </div>
+      )}
+
+      {data.items.length === 0 ? (
+        <div className="rounded-lg border border-border bg-surface p-8 text-center">
+          <p className="text-sm font-medium text-text-secondary">
+            No workouts recorded yet.
+          </p>
+          <p className="mt-1 text-xs text-text-muted">
+            Synced and pending workouts will appear here.
+          </p>
+        </div>
+      ) : (
+        <ul className="divide-y divide-border overflow-hidden rounded-xl border border-border bg-surface-elevated">
+          {data.items.map((w) => (
+            <li
+              key={w.hevy_id}
+              className="flex items-center justify-between gap-3 px-4 py-3"
+            >
+              <div className="min-w-0">
+                <div className="truncate text-sm font-medium text-text">
+                  {w.title || "Untitled workout"}
+                </div>
+                <div className="mt-0.5 text-xs text-text-muted">
+                  {fmtDate(w.when)}
+                  {w.garmin_activity_id && (
+                    <span> · Garmin {w.garmin_activity_id}</span>
+                  )}
+                  {w.detail && (
+                    <span className="text-text-secondary"> · {w.detail}</span>
+                  )}
+                </div>
+              </div>
+              <StatusPill item={w} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/web/components/mapping-form.tsx
+++ b/web/components/mapping-form.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+interface CategoryOption {
+  id: number;
+  name: string;
+}
+
+/**
+ * Inline add/edit form for a custom exercise mapping. Posts to /api/mapping and
+ * refreshes the server-rendered mappings list on success. The category dropdown
+ * is seeded from the server (which reads /api/garmin-categories' source map), so
+ * this component does no fetching of its own.
+ */
+export function MappingForm({ categories }: { categories: CategoryOption[] }) {
+  const router = useRouter();
+  const [hevyName, setHevyName] = useState("");
+  const [category, setCategory] = useState(categories[0]?.id ?? 0);
+  const [subcategory, setSubcategory] = useState("0");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    const name = hevyName.trim();
+    if (!name) {
+      setError("Enter the exact Hevy exercise name.");
+      return;
+    }
+    setBusy(true);
+    try {
+      const res = await fetch("/api/mapping", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          hevy_name: name,
+          category,
+          subcategory: Number.parseInt(subcategory || "0", 10),
+        }),
+      });
+      const data = (await res.json().catch(() => ({}))) as {
+        ok?: boolean;
+        error?: string;
+      };
+      if (!res.ok || !data.ok) {
+        setError(data.error ?? `Request failed (${res.status}).`);
+        return;
+      }
+      setHevyName("");
+      setSubcategory("0");
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form onSubmit={submit} className="flex flex-col gap-3 sm:flex-row sm:items-end">
+      <div className="flex-1">
+        <label className="mb-1 block text-xs text-text-muted" htmlFor="mf-name">
+          Hevy exercise name (exact)
+        </label>
+        <input
+          id="mf-name"
+          type="text"
+          value={hevyName}
+          onChange={(e) => setHevyName(e.target.value)}
+          placeholder="e.g. Cable Lateral Raise"
+          className="w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text placeholder:text-text-muted focus:border-teal focus:outline-none"
+        />
+      </div>
+      <div>
+        <label className="mb-1 block text-xs text-text-muted" htmlFor="mf-cat">
+          Garmin category
+        </label>
+        <select
+          id="mf-cat"
+          value={category}
+          onChange={(e) => setCategory(Number.parseInt(e.target.value, 10))}
+          className="w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text focus:border-teal focus:outline-none sm:w-48"
+        >
+          {categories.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name} ({c.id})
+            </option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className="mb-1 block text-xs text-text-muted" htmlFor="mf-sub">
+          Sub ID
+        </label>
+        <input
+          id="mf-sub"
+          type="number"
+          min={0}
+          value={subcategory}
+          onChange={(e) => setSubcategory(e.target.value)}
+          className="w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text focus:border-teal focus:outline-none sm:w-20"
+        />
+      </div>
+      <button
+        type="submit"
+        disabled={busy}
+        className="rounded-lg bg-teal/20 px-4 py-2 text-sm font-medium text-teal transition-colors hover:bg-teal/30 disabled:opacity-50"
+      >
+        {busy ? "Saving…" : "Save"}
+      </button>
+      {error && (
+        <p className="text-xs text-danger sm:self-center" role="alert">
+          {error}
+        </p>
+      )}
+    </form>
+  );
+}
+
+/**
+ * Delete button for a single custom mapping. Posts to /api/mapping/delete and
+ * refreshes the list.
+ */
+export function DeleteMappingButton({ hevyName }: { hevyName: string }) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+
+  async function remove() {
+    if (!confirm(`Delete custom mapping for "${hevyName}"?`)) return;
+    setBusy(true);
+    try {
+      await fetch("/api/mapping/delete", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ hevy_name: hevyName }),
+      });
+      router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={remove}
+      disabled={busy}
+      className="rounded-lg border border-danger/30 px-3 py-1 text-xs font-medium text-danger transition-colors hover:bg-danger/10 disabled:opacity-50"
+    >
+      {busy ? "…" : "Delete"}
+    </button>
+  );
+}

--- a/web/lib/garmin-categories.ts
+++ b/web/lib/garmin-categories.ts
@@ -1,0 +1,63 @@
+/**
+ * Garmin FIT exercise category id → display name.
+ *
+ * Single source of truth shared by the /api/garmin-categories route and the
+ * mappings page. Mirrors the canonical set the Python dashboard serves from
+ * `src/hevy2garmin/server.py::_get_cat_names()`. Keep the two in sync.
+ */
+export const CATEGORY_NAMES: Record<string, string> = {
+  "0": "Bench Press",
+  "1": "Calf Raise",
+  "2": "Cardio",
+  "3": "Carry",
+  "4": "Chop",
+  "5": "Core",
+  "6": "Crunch",
+  "7": "Curl",
+  "8": "Deadlift",
+  "9": "Flye",
+  "10": "Hip Raise",
+  "11": "Hip Stability",
+  "12": "Hip Swing",
+  "13": "Hyperextension",
+  "14": "Lateral Raise",
+  "15": "Leg Curl",
+  "16": "Leg Raise",
+  "17": "Lunge",
+  "18": "Olympic Lift",
+  "19": "Plank",
+  "20": "Plyo",
+  "21": "Pull Up",
+  "22": "Push Up",
+  "23": "Row",
+  "24": "Shoulder Press",
+  "25": "Shoulder Stability",
+  "26": "Shrug",
+  "27": "Sit Up",
+  "28": "Squat",
+  "29": "Total Body",
+  "30": "Triceps Extension",
+  "31": "Warm Up",
+  "32": "Run",
+  "33": "Cycling",
+  "36": "Yoga",
+  "38": "Battle Ropes",
+  "39": "Elliptical",
+  "41": "Indoor Bike",
+  "42": "Indoor Row",
+  "47": "Stair Machine",
+  "52": "Treadmill",
+  "65534": "Unknown",
+};
+
+/** [{ id, name }] sorted by id — convenient for dropdowns. */
+export const CATEGORY_OPTIONS: { id: number; name: string }[] = Object.entries(
+  CATEGORY_NAMES,
+)
+  .map(([id, name]) => ({ id: Number(id), name }))
+  .sort((a, b) => a.id - b.id);
+
+/** Human-readable name for a category id (falls back to "Category N"). */
+export function categoryName(id: number): string {
+  return CATEGORY_NAMES[String(id)] ?? `Category ${id}`;
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "hevy2garmin-web",
       "version": "0.1.0",
       "dependencies": {
+        "garmin-auth": "^0.4.1",
         "hevy2garmin": "^0.1.4",
         "next": "^16.1.0",
         "postgres": "^3.4.9",
@@ -3992,6 +3993,20 @@
       "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/garmin-auth": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/garmin-auth/-/garmin-auth-0.4.1.tgz",
+      "integrity": "sha512-Z3Nlh3UpoilqWpjrY4jfgQ8DImzD5vJ4yOdi5Gui3m0w7mc8ReoNESUp6GoKZD9RDzuwsekZuuqAeImTtI7ytw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "pg": {
+          "optional": true
+        }
       }
     },
     "node_modules/gensync": {

--- a/web/package.json
+++ b/web/package.json
@@ -17,6 +17,7 @@
     "e2e:mobile": "playwright test --project=mobile"
   },
   "dependencies": {
+    "garmin-auth": "^0.4.1",
     "hevy2garmin": "^0.1.4",
     "next": "^16.1.0",
     "postgres": "^3.4.9",


### PR DESCRIPTION
## What

The browsable, read-only surface of the new web dashboard (Track C, phase C3). No live Hevy/Garmin sync yet — that lands in a later phase with dry-run-first testing.

**Pages** (server components, `force-dynamic`, all queries `.catch()`-guarded):
- `/history` — terminal `synced_workouts`
- `/workouts` — `synced_workouts` + `pending_uploads` merged with status pills (DB-only, no Hevy fetch)
- `/mappings` — `custom_mappings` + the built-in `HEVY_TO_GARMIN` map, with an add form + per-row delete
- `/settings` — read-only `platform_credentials` + `app_cache` config (HR fusion, merge, timing, profile)
- `/routines` — placeholder for a later phase

**Safe API routes:**
- `GET /api/garmin-categories` (FIT category id→name)
- `GET /api/validate-hevy` (`HevyClient.getWorkoutCount`, runtime-only)
- `POST /api/mapping` + `/api/mapping/delete` (custom_mappings upsert/delete)

## Bug fixed during validation

The dashboard connection badges checked `status === "connected"`, but the DB uses `status = "active"` for a live connection — so both platforms wrongly rendered "Not connected". Changed to `status !== "disconnected"`. Confirmed via Playwright (badges now green/Connected).

## Verification
- `tsc --noEmit`: 0 errors; `next build`: succeeds (DB routes force-dynamic).
- **Playwright-validated against the real hevy2garmin DB**: /mappings (18 custom + 533 built-in, form + delete), /settings (live connections + config), /workouts + /history (correct empty states), and the fixed dashboard badges.

## Note
Adds `garmin-auth` (the hevy2garmin package's declared peer dependency) to `web/` so the package barrel resolves at build — no sync logic, just resolution.

Refs drkostas/soma#385
