### PR TITLE
feat(web): sync-engine safe half — dedup + pending store + preview [C0-safe]

### DIFF
--- a/web/app/api/pending/[hevyId]/abandon/route.ts
+++ b/web/app/api/pending/[hevyId]/abandon/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { deletePending } from "@/lib/pending-store";
+
+// Deletes from the app's own pending_uploads table at request time — never at build.
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/pending/[hevyId]/abandon
+ *
+ * Drops an in-flight pending_uploads row (e.g. a stuck 'preparing' claim), so
+ * the workout can be re-evaluated on the next preview/sync. DB-only: it does NOT
+ * touch Garmin and does NOT create a terminal synced_workouts row — the workout
+ * simply becomes a fresh candidate again.
+ *
+ * NOTE: auth-gating (session cookie / middleware) is added in the login phase;
+ * this route is intentionally unauthenticated for now.
+ */
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ hevyId: string }> },
+) {
+  const { hevyId } = await params;
+  if (!hevyId) {
+    return NextResponse.json({ error: "hevyId is required." }, { status: 400 });
+  }
+
+  let deleted: boolean;
+  try {
+    deleted = await deletePending(hevyId);
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true, hevyId, deleted });
+}

--- a/web/app/api/sync/preview/route.ts
+++ b/web/app/api/sync/preview/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { fetchAllWorkouts } from "@/lib/hevy-sync";
+import { loadSyncedIds, loadPendingIds } from "@/lib/pending-store";
+import { summarizeDedup, type DedupWorkout } from "@/lib/dedup";
+
+// Reads the live Hevy API + hevy2garmin Postgres at request time — never at build.
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/sync/preview  —  DRY RUN ONLY.
+ *
+ * Computes what a sync WOULD do without doing any of it. It:
+ *   1. reads the full Hevy workout list (READ-only Hevy call),
+ *   2. loads the synced + pending id sets from the app's own Postgres,
+ *   3. runs the pure dedup in lib/dedup to find the remaining candidates.
+ *
+ * It NEVER generates or uploads a FIT, NEVER calls Garmin, and NEVER writes to
+ * any table. It is purely a preview of the safe half of the sync decision.
+ */
+
+interface PreviewResponse {
+  totalHevy: number;
+  syncedCount: number;
+  pendingCount: number;
+  remaining: number;
+  nextUnsynced: { hevy_id: string; title: string | null; start_time: string | null } | null;
+  candidates: number;
+}
+
+function nextView(w: DedupWorkout | null): PreviewResponse["nextUnsynced"] {
+  if (!w) return null;
+  return {
+    hevy_id: w.id,
+    title: (w.title as string | null) ?? null,
+    start_time: (w.start_time as string | null) ?? null,
+  };
+}
+
+export async function GET() {
+  let workouts: DedupWorkout[];
+  try {
+    workouts = (await fetchAllWorkouts()) as DedupWorkout[];
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `Hevy read failed: ${error}` }, { status: 502 });
+  }
+
+  let syncedIds: Set<string>;
+  let pendingIds: Set<string>;
+  try {
+    [syncedIds, pendingIds] = await Promise.all([loadSyncedIds(), loadPendingIds()]);
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `DB read failed: ${error}` }, { status: 503 });
+  }
+
+  const summary = summarizeDedup(workouts, syncedIds, pendingIds);
+
+  const body: PreviewResponse = {
+    totalHevy: summary.totalHevy,
+    syncedCount: summary.syncedCount,
+    pendingCount: summary.pendingCount,
+    remaining: summary.remaining,
+    nextUnsynced: nextView(summary.nextUnsynced),
+    candidates: summary.candidates.length,
+  };
+  return NextResponse.json(body);
+}

--- a/web/app/api/unsync/[hevyId]/route.ts
+++ b/web/app/api/unsync/[hevyId]/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { unsync } from "@/lib/pending-store";
+
+// Deletes from the app's own synced_workouts table at request time — never at build.
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/unsync/[hevyId]
+ *
+ * Removes a workout's terminal synced_workouts row so it becomes a sync
+ * candidate again. DB-ONLY: this deliberately does NOT delete the corresponding
+ * Garmin activity — deleting a Garmin activity is a destructive Garmin write and
+ * is out of scope for the safe half of the engine. Only the local ledger row is
+ * removed here.
+ *
+ * NOTE: auth-gating (session cookie / middleware) is added in the login phase;
+ * this route is intentionally unauthenticated for now.
+ */
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ hevyId: string }> },
+) {
+  const { hevyId } = await params;
+  if (!hevyId) {
+    return NextResponse.json({ error: "hevyId is required." }, { status: 400 });
+  }
+
+  let removed: boolean;
+  try {
+    removed = await unsync(hevyId);
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true, hevyId, removed });
+}

--- a/web/app/api/workout/[hevyId]/mark-synced/route.ts
+++ b/web/app/api/workout/[hevyId]/mark-synced/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { resolveTerminal } from "@/lib/pending-store";
+
+// Writes the app's own synced_workouts ledger at request time — never at build.
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/workout/[hevyId]/mark-synced
+ * Body: { garminActivityId?: string, reason?: string }
+ *
+ * Records that the user handled this workout's upload THEMSELVES: inserts a
+ * terminal 'manual' row into synced_workouts and clears any pending row. This is
+ * a DB-only bookkeeping write — it does NOT upload anything to Garmin.
+ *
+ * NOTE: auth-gating (session cookie / middleware) is added in the login phase;
+ * this route is intentionally unauthenticated for now.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ hevyId: string }> },
+) {
+  const { hevyId } = await params;
+  if (!hevyId) {
+    return NextResponse.json({ error: "hevyId is required." }, { status: 400 });
+  }
+
+  let body: { garminActivityId?: unknown; reason?: unknown } = {};
+  try {
+    const text = await request.text();
+    if (text) body = JSON.parse(text);
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const garminActivityId =
+    typeof body.garminActivityId === "string" && body.garminActivityId.trim()
+      ? body.garminActivityId.trim()
+      : null;
+  const reason = typeof body.reason === "string" && body.reason.trim() ? body.reason.trim() : null;
+
+  try {
+    await resolveTerminal(hevyId, { status: "manual", garminActivityId, reason, source: "web" });
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true, hevyId, status: "manual" });
+}

--- a/web/app/api/workout/[hevyId]/skip/route.ts
+++ b/web/app/api/workout/[hevyId]/skip/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { resolveTerminal } from "@/lib/pending-store";
+
+// Writes the app's own synced_workouts ledger at request time — never at build.
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/workout/[hevyId]/skip
+ * Body: { reason?: string }
+ *
+ * Records a deliberate skip: inserts a terminal 'skipped' row into
+ * synced_workouts (so this workout is excluded from future sync candidates) and
+ * clears any pending row. DB-only — no Garmin call, no upload.
+ *
+ * NOTE: auth-gating (session cookie / middleware) is added in the login phase;
+ * this route is intentionally unauthenticated for now.
+ */
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ hevyId: string }> },
+) {
+  const { hevyId } = await params;
+  if (!hevyId) {
+    return NextResponse.json({ error: "hevyId is required." }, { status: 400 });
+  }
+
+  let body: { reason?: unknown } = {};
+  try {
+    const text = await request.text();
+    if (text) body = JSON.parse(text);
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const reason = typeof body.reason === "string" && body.reason.trim() ? body.reason.trim() : null;
+
+  try {
+    await resolveTerminal(hevyId, { status: "skipped", reason, source: "web" });
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true, hevyId, status: "skipped" });
+}

--- a/web/lib/dedup.test.ts
+++ b/web/lib/dedup.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from "vitest";
+import {
+  isUnsynced,
+  filterUnsynced,
+  pickNextUnsynced,
+  summarizeDedup,
+  type DedupWorkout,
+} from "./dedup";
+
+// Small helper: a workout is just an id (+ optional title) for these tests.
+const w = (id: string, title?: string): DedupWorkout => ({ id, title: title ?? id });
+
+describe("isUnsynced — the skip-if-synced-OR-pending rule", () => {
+  it("a fresh workout (neither synced nor pending) is a candidate", () => {
+    expect(isUnsynced(w("fresh"), new Set(), new Set())).toBe(true);
+  });
+
+  it("a workout with a terminal synced_workouts row is excluded (layer 1)", () => {
+    expect(isUnsynced(w("done"), new Set(["done"]), new Set())).toBe(false);
+  });
+
+  it("a workout with an in-flight pending_uploads row is excluded (layer 2)", () => {
+    expect(isUnsynced(w("mid"), new Set(), new Set(["mid"]))).toBe(false);
+  });
+
+  it("excluded when it is BOTH synced and pending", () => {
+    expect(isUnsynced(w("both"), new Set(["both"]), new Set(["both"]))).toBe(false);
+  });
+
+  it("a workout with no id is never a candidate", () => {
+    expect(isUnsynced({ id: "" }, new Set(), new Set())).toBe(false);
+  });
+});
+
+describe("filterUnsynced — combined dedup over a list", () => {
+  const workouts = [w("a"), w("b"), w("c"), w("d")];
+
+  it("keeps only fresh workouts, excluding synced and pending", () => {
+    const out = filterUnsynced(workouts, new Set(["a"]), new Set(["c"]));
+    expect(out.map((x) => x.id)).toEqual(["b", "d"]);
+  });
+
+  it("preserves input order of the survivors", () => {
+    const out = filterUnsynced([w("z"), w("y"), w("x")], new Set(["y"]), new Set());
+    expect(out.map((x) => x.id)).toEqual(["z", "x"]);
+  });
+
+  it("returns empty when every workout is synced", () => {
+    const out = filterUnsynced(workouts, new Set(["a", "b", "c", "d"]), new Set());
+    expect(out).toEqual([]);
+  });
+
+  it("returns empty when every workout is pending", () => {
+    const out = filterUnsynced(workouts, new Set(), new Set(["a", "b", "c", "d"]));
+    expect(out).toEqual([]);
+  });
+
+  it("returns empty when synced and pending together cover everything", () => {
+    const out = filterUnsynced(workouts, new Set(["a", "b"]), new Set(["c", "d"]));
+    expect(out).toEqual([]);
+  });
+
+  it("empty input → empty output", () => {
+    expect(filterUnsynced([], new Set(), new Set())).toEqual([]);
+  });
+});
+
+describe("pickNextUnsynced — the next workout to sync", () => {
+  const workouts = [w("first"), w("second"), w("third")];
+
+  it("picks the first unsynced workout in list order", () => {
+    expect(pickNextUnsynced(workouts, new Set(), new Set())?.id).toBe("first");
+  });
+
+  it("skips synced/pending and picks the next eligible one", () => {
+    const next = pickNextUnsynced(workouts, new Set(["first"]), new Set(["second"]));
+    expect(next?.id).toBe("third");
+  });
+
+  it("returns null when all are synced", () => {
+    expect(pickNextUnsynced(workouts, new Set(["first", "second", "third"]), new Set())).toBeNull();
+  });
+
+  it("returns null when all are pending", () => {
+    expect(pickNextUnsynced(workouts, new Set(), new Set(["first", "second", "third"]))).toBeNull();
+  });
+
+  it("returns null on empty input", () => {
+    expect(pickNextUnsynced([], new Set(), new Set())).toBeNull();
+  });
+});
+
+describe("summarizeDedup — the /preview shape", () => {
+  const workouts = [w("a"), w("b"), w("c"), w("d"), w("e")];
+
+  it("tallies synced, pending and remaining, and picks the next", () => {
+    // a,b synced; c pending; d,e fresh
+    const s = summarizeDedup(workouts, new Set(["a", "b"]), new Set(["c"]));
+    expect(s.totalHevy).toBe(5);
+    expect(s.syncedCount).toBe(2);
+    expect(s.pendingCount).toBe(1);
+    expect(s.remaining).toBe(2);
+    expect(s.candidates.map((x) => x.id)).toEqual(["d", "e"]);
+    expect(s.nextUnsynced?.id).toBe("d");
+  });
+
+  it("all synced → zero remaining, null next", () => {
+    const s = summarizeDedup(workouts, new Set(["a", "b", "c", "d", "e"]), new Set());
+    expect(s.syncedCount).toBe(5);
+    expect(s.pendingCount).toBe(0);
+    expect(s.remaining).toBe(0);
+    expect(s.candidates).toEqual([]);
+    expect(s.nextUnsynced).toBeNull();
+  });
+
+  it("all pending → zero remaining, counted as pending not synced", () => {
+    const s = summarizeDedup(workouts, new Set(), new Set(["a", "b", "c", "d", "e"]));
+    expect(s.syncedCount).toBe(0);
+    expect(s.pendingCount).toBe(5);
+    expect(s.remaining).toBe(0);
+    expect(s.nextUnsynced).toBeNull();
+  });
+
+  it("nothing synced or pending → everything remains", () => {
+    const s = summarizeDedup(workouts, new Set(), new Set());
+    expect(s.syncedCount).toBe(0);
+    expect(s.pendingCount).toBe(0);
+    expect(s.remaining).toBe(5);
+    expect(s.candidates.map((x) => x.id)).toEqual(["a", "b", "c", "d", "e"]);
+    expect(s.nextUnsynced?.id).toBe("a");
+  });
+
+  it("a workout that is both synced and pending counts once (synced wins)", () => {
+    const s = summarizeDedup([w("x")], new Set(["x"]), new Set(["x"]));
+    expect(s.syncedCount).toBe(1);
+    expect(s.pendingCount).toBe(0);
+    expect(s.remaining).toBe(0);
+  });
+
+  it("empty workout list → zeroed summary", () => {
+    const s = summarizeDedup([], new Set(["a"]), new Set(["b"]));
+    expect(s).toEqual({
+      totalHevy: 0,
+      syncedCount: 0,
+      pendingCount: 0,
+      remaining: 0,
+      candidates: [],
+      nextUnsynced: null,
+    });
+  });
+});

--- a/web/lib/dedup.ts
+++ b/web/lib/dedup.ts
@@ -1,0 +1,113 @@
+/**
+ * Pure dedup decision logic — the SAFE half of the sync engine.
+ *
+ * These functions decide WHICH Hevy workouts still need syncing. They take
+ * plain data (a workout list + the sets of already-synced and pending hevy_ids)
+ * and return candidates / the next pick. They perform NO IO: no DB, no Hevy, and
+ * crucially no Garmin upload. They are the TS analogue of sync.py's per-workout
+ * skip logic (`skip_existing and store.is_synced(wid)` + `pending_by_id.get(wid)`).
+ *
+ * The three-layer never-duplicate concept (from soma's hevy-upload.ts) maps onto
+ * hevy2garmin's schema as:
+ *   Layer 1 (already resolved): a terminal `synced_workouts` row exists
+ *            (status success/manual/skipped) → excluded via `syncedIds`.
+ *   Layer 2 (in flight): a `pending_uploads` row exists (an upload was claimed
+ *            or is mid-flight) → excluded via `pendingIds`, so we never
+ *            double-claim / double-upload the same workout.
+ *   Layer 3 (Garmin 409 on duplicate FIT) lives in the UPLOAD half and is out of
+ *            scope here; the pure layer only encodes layers 1 and 2.
+ *
+ * "Skip if synced OR pending" is the single rule these functions enforce.
+ */
+
+/** Minimal shape a workout needs for dedup. `id` is the Hevy workout id (PK). */
+export interface DedupWorkout {
+  id: string;
+  title?: string | null;
+  start_time?: string | null;
+  [key: string]: unknown;
+}
+
+/**
+ * True when a workout is NOT yet resolved and NOT in flight — i.e. a real sync
+ * candidate. Pure predicate; mirrors the skip rule in sync.py's main loop.
+ */
+export function isUnsynced(
+  workout: DedupWorkout,
+  syncedIds: ReadonlySet<string>,
+  pendingIds: ReadonlySet<string>,
+): boolean {
+  const id = workout.id;
+  if (!id) return false;
+  return !syncedIds.has(id) && !pendingIds.has(id);
+}
+
+/**
+ * Filter a workout list to the ones still needing a sync: excludes anything with
+ * a terminal `synced_workouts` row (layer 1) OR an in-flight `pending_uploads`
+ * row (layer 2). Input order is preserved. Pure.
+ */
+export function filterUnsynced(
+  workouts: readonly DedupWorkout[],
+  syncedIds: ReadonlySet<string>,
+  pendingIds: ReadonlySet<string>,
+): DedupWorkout[] {
+  return workouts.filter((w) => isUnsynced(w, syncedIds, pendingIds));
+}
+
+/**
+ * Pick the next workout to sync from a list, applying the same skip rule.
+ *
+ * Ordering follows the Python pipeline: the first unsynced workout in the given
+ * list order is the next one to process (`fetch_workouts` yields newest-first;
+ * the loop takes them in that order). Returns null when nothing remains. Pure.
+ */
+export function pickNextUnsynced(
+  workouts: readonly DedupWorkout[],
+  syncedIds: ReadonlySet<string>,
+  pendingIds: ReadonlySet<string>,
+): DedupWorkout | null {
+  for (const w of workouts) {
+    if (isUnsynced(w, syncedIds, pendingIds)) return w;
+  }
+  return null;
+}
+
+/** A full preview of the dedup decision over a workout list. Pure. */
+export interface DedupSummary {
+  totalHevy: number;
+  syncedCount: number;
+  pendingCount: number;
+  remaining: number;
+  candidates: DedupWorkout[];
+  nextUnsynced: DedupWorkout | null;
+}
+
+/**
+ * Compute the full dedup decision in one pass: the candidate list and the next
+ * pick, plus tallies. `syncedCount`/`pendingCount` reflect how many of THESE
+ * workouts are already resolved / in flight (intersection with the id sets), so
+ * the numbers add up against `totalHevy`. Pure — feeds the /preview route.
+ */
+export function summarizeDedup(
+  workouts: readonly DedupWorkout[],
+  syncedIds: ReadonlySet<string>,
+  pendingIds: ReadonlySet<string>,
+): DedupSummary {
+  const candidates = filterUnsynced(workouts, syncedIds, pendingIds);
+  let syncedCount = 0;
+  let pendingCount = 0;
+  for (const w of workouts) {
+    if (!w.id) continue;
+    if (syncedIds.has(w.id)) syncedCount++;
+    else if (pendingIds.has(w.id)) pendingCount++;
+  }
+  return {
+    totalHevy: workouts.length,
+    syncedCount,
+    pendingCount,
+    remaining: candidates.length,
+    candidates,
+    nextUnsynced: candidates[0] ?? null,
+  };
+}

--- a/web/lib/hevy-sync.ts
+++ b/web/lib/hevy-sync.ts
@@ -1,0 +1,83 @@
+/**
+ * Hevy READ wrappers — the SAFE half of the sync engine.
+ *
+ * This module ONLY reads from the Hevy API (workout count + full workout list).
+ * It never writes to Hevy, never touches Garmin, and never uploads a FIT. The
+ * upload half of the pipeline (generateFit / uploadFit / rename / delete) lives
+ * elsewhere and is deliberately excluded here — a bad Garmin upload creates a
+ * duplicate Garmin/Strava activity, a hard user constraint, so the read side is
+ * kept isolated and testable.
+ *
+ * The Hevy API key is resolved (in order):
+ *   1. the `key` argument, if given;
+ *   2. process.env.HEVY_API_KEY;
+ *   3. the `platform_credentials` row where platform='hevy' (credentials.api_key),
+ *      matching how the Python config.py resolves it.
+ */
+import { HevyClient } from "hevy2garmin";
+import { getDb } from "./db";
+
+/** Read the stored Hevy API key from platform_credentials (platform='hevy'). */
+async function keyFromDb(): Promise<string | null> {
+  let sql: ReturnType<typeof getDb>;
+  try {
+    sql = getDb();
+  } catch {
+    return null;
+  }
+  const rows = await sql`
+    SELECT credentials
+    FROM platform_credentials
+    WHERE platform = 'hevy'
+    LIMIT 1
+  `.catch(() => [] as Array<{ credentials: unknown }>);
+  const creds = rows[0]?.credentials;
+  const parsed =
+    typeof creds === "string" ? (JSON.parse(creds) as Record<string, unknown>) : (creds as Record<string, unknown> | undefined);
+  const apiKey = parsed?.api_key;
+  return typeof apiKey === "string" && apiKey.trim() ? apiKey.trim() : null;
+}
+
+/**
+ * Build a HevyClient. Resolves the API key from the argument, then the
+ * HEVY_API_KEY env var, then the platform_credentials table. Throws when no key
+ * can be found so callers can surface a clear "connect Hevy first" error.
+ */
+export async function getHevyClient(key?: string | null): Promise<HevyClient> {
+  const explicit = key?.trim();
+  const fromEnv = process.env.HEVY_API_KEY?.trim();
+  const apiKey = explicit || fromEnv || (await keyFromDb());
+  if (!apiKey) {
+    throw new Error("No Hevy API key available (arg, HEVY_API_KEY, or platform_credentials).");
+  }
+  return new HevyClient(apiKey);
+}
+
+/** READ-only: total number of workouts Hevy reports for this account. */
+export async function fetchWorkoutCount(key?: string | null): Promise<number> {
+  const client = await getHevyClient(key);
+  return client.getWorkoutCount();
+}
+
+/**
+ * READ-only: fetch the full paginated workout history from Hevy.
+ * Thin passthrough to HevyClient.getAllWorkouts, which walks every page.
+ */
+export async function fetchAllWorkouts(key?: string | null): Promise<HevyWorkout[]> {
+  const client = await getHevyClient(key);
+  return (await client.getAllWorkouts()) as HevyWorkout[];
+}
+
+/**
+ * The subset of a raw Hevy workout the SAFE sync side reads. Hevy returns many
+ * more fields; only `id` is required for dedup, the rest are best-effort display.
+ */
+export interface HevyWorkout {
+  id: string;
+  title?: string | null;
+  start_time?: string | null;
+  end_time?: string | null;
+  updated_at?: string | null;
+  // Hevy payloads carry additional fields we don't type here.
+  [key: string]: unknown;
+}

--- a/web/lib/pending-store.ts
+++ b/web/lib/pending-store.ts
@@ -1,0 +1,304 @@
+/**
+ * Sync-bookkeeping DB helpers — the SAFE half of the sync engine.
+ *
+ * Every function here reads/writes ONLY the hevy2garmin app's own tables:
+ *   - `synced_workouts`  (terminal state: uploaded | manual | skipped)
+ *   - `pending_uploads`  (in-flight durable checkpoints)
+ * These are local sync bookkeeping, not user-facing platform state. NOTHING in
+ * this module calls Garmin, uploads a FIT, or mutates Hevy. `unsync` and
+ * `resolveTerminal` only delete/insert the LOCAL ledger row — they never delete
+ * the corresponding Garmin activity.
+ *
+ * The SQL mirrors PostgresDatabase in src/hevy2garmin/db_postgres.py so the
+ * TS web app and the Python pipeline agree on the schema and semantics.
+ */
+import { getDb } from "./db";
+
+type Sql = ReturnType<typeof getDb>;
+
+/** Terminal statuses stored in synced_workouts.status. */
+export type TerminalStatus = "success" | "manual" | "skipped";
+
+/** A resolved (terminal) row from synced_workouts. */
+export interface SyncedRow {
+  hevy_id: string;
+  garmin_activity_id: string | null;
+  title: string | null;
+  synced_at: string | null;
+  status: string | null;
+}
+
+/** An in-flight row from pending_uploads. */
+export interface PendingRow {
+  hevy_id: string;
+  phase: string;
+  next_step: string | null;
+  upload_id: string | null;
+  garmin_activity_id: string | null;
+  watch_activity_id: string | null;
+  pre_upload_ids: unknown[];
+  payload: Record<string, unknown>;
+  resolution_source: string | null;
+  attempt_count: number;
+  delete_attempt_count: number;
+  last_error: string | null;
+  locked_until: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+/** Terminal-state tallies, matching db_postgres.get_terminal_counts(). */
+export interface TerminalCounts {
+  uploaded: number;
+  manual: number;
+  skipped: number;
+  terminal: number;
+}
+
+function jsonField<T>(value: unknown, empty: T): T {
+  if (value == null) return empty;
+  if (typeof value === "string") {
+    try {
+      return JSON.parse(value) as T;
+    } catch {
+      return empty;
+    }
+  }
+  return value as T;
+}
+
+/** Normalize a raw pending_uploads row into a PendingRow (JSONB parsed). */
+function toPending(row: Record<string, unknown>): PendingRow {
+  return {
+    hevy_id: String(row.hevy_id),
+    phase: String(row.phase ?? ""),
+    next_step: (row.next_step as string | null) ?? null,
+    upload_id: (row.upload_id as string | null) ?? null,
+    garmin_activity_id: (row.garmin_activity_id as string | null) ?? null,
+    watch_activity_id: (row.watch_activity_id as string | null) ?? null,
+    pre_upload_ids: jsonField<unknown[]>(row.pre_upload_ids, []),
+    payload: jsonField<Record<string, unknown>>(row.payload, {}),
+    resolution_source: (row.resolution_source as string | null) ?? null,
+    attempt_count: Number(row.attempt_count ?? 0),
+    delete_attempt_count: Number(row.delete_attempt_count ?? 0),
+    last_error: (row.last_error as string | null) ?? null,
+    locked_until: (row.locked_until as string | null) ?? null,
+    created_at: (row.created_at as string | null) ?? null,
+    updated_at: (row.updated_at as string | null) ?? null,
+  };
+}
+
+/** True when the workout already has a terminal row. Mirrors is_synced(). */
+export async function isSynced(hevyId: string, sql: Sql = getDb()): Promise<boolean> {
+  const rows = await sql`SELECT 1 FROM synced_workouts WHERE hevy_id = ${hevyId} LIMIT 1`;
+  return rows.length > 0;
+}
+
+/** COUNT(*) over synced_workouts. Mirrors get_synced_count(). */
+export async function getSyncedCount(sql: Sql = getDb()): Promise<number> {
+  const rows = await sql`SELECT COUNT(*)::int AS cnt FROM synced_workouts`;
+  return Number(rows[0]?.cnt ?? 0);
+}
+
+/**
+ * Terminal-state tallies grouped by status. Mirrors get_terminal_counts():
+ * 'success' → uploaded, plus manual + skipped, and their sum as `terminal`.
+ */
+export async function getTerminalCounts(sql: Sql = getDb()): Promise<TerminalCounts> {
+  const rows = await sql`
+    SELECT COALESCE(status, 'success') AS status, COUNT(*)::int AS count
+    FROM synced_workouts
+    GROUP BY COALESCE(status, 'success')
+  `;
+  const raw: Record<string, number> = {};
+  for (const r of rows) raw[String(r.status)] = Number(r.count);
+  const uploaded = raw.success ?? 0;
+  const manual = raw.manual ?? 0;
+  const skipped = raw.skipped ?? 0;
+  return { uploaded, manual, skipped, terminal: uploaded + manual + skipped };
+}
+
+/** All in-flight pending rows, newest first. Mirrors list_pending(). */
+export async function listPending(sql: Sql = getDb()): Promise<PendingRow[]> {
+  const rows = await sql`SELECT * FROM pending_uploads ORDER BY created_at DESC`;
+  return rows.map((r) => toPending(r as Record<string, unknown>));
+}
+
+/** One pending row by id, or null. Mirrors get_pending(). */
+export async function getPending(hevyId: string, sql: Sql = getDb()): Promise<PendingRow | null> {
+  const rows = await sql`SELECT * FROM pending_uploads WHERE hevy_id = ${hevyId}`;
+  const row = rows[0];
+  return row ? toPending(row as Record<string, unknown>) : null;
+}
+
+/**
+ * Atomically claim a workout by inserting a 'preparing' pending row. Returns
+ * true when THIS caller inserted the row (won the race), false when a row
+ * already existed. Mirrors claim_pending() (INSERT ... ON CONFLICT DO NOTHING).
+ *
+ * NOTE: claiming is pure bookkeeping — it does NOT begin a Garmin upload.
+ */
+export async function claimPending(
+  hevyId: string,
+  payload: Record<string, unknown>,
+  sql: Sql = getDb(),
+): Promise<boolean> {
+  const rows = await sql`
+    INSERT INTO pending_uploads (hevy_id, phase, payload)
+    VALUES (${hevyId}, 'preparing', ${sql.json(payload)})
+    ON CONFLICT (hevy_id) DO NOTHING
+    RETURNING hevy_id
+  `;
+  return rows.length === 1;
+}
+
+/**
+ * Fields update_pending() is allowed to change (mirrors the Python allow-list).
+ * pre_upload_ids/payload are JSONB; everything else is a scalar column.
+ */
+export interface PendingUpdate {
+  phase?: string;
+  next_step?: string | null;
+  upload_id?: string | null;
+  garmin_activity_id?: string | null;
+  watch_activity_id?: string | null;
+  pre_upload_ids?: unknown[];
+  payload?: Record<string, unknown>;
+  resolution_source?: string | null;
+  attempt_count?: number;
+  delete_attempt_count?: number;
+  last_error?: string | null;
+  locked_until?: string | null;
+}
+
+const PENDING_UPDATE_FIELDS: ReadonlyArray<keyof PendingUpdate> = [
+  "phase",
+  "next_step",
+  "upload_id",
+  "garmin_activity_id",
+  "watch_activity_id",
+  "pre_upload_ids",
+  "payload",
+  "resolution_source",
+  "attempt_count",
+  "delete_attempt_count",
+  "last_error",
+  "locked_until",
+];
+
+/**
+ * Update a pending row's bookkeeping fields (filtered to the allow-list) and
+ * bump updated_at. Mirrors update_pending(): only the keys the caller supplies
+ * are changed, and a supplied key may set the column to NULL (e.g. clearing
+ * last_error). No-op when nothing in the allow-list is provided.
+ *
+ * Every column is written with a `provided` guard so the statement is fully
+ * parameterized (no dynamic identifier interpolation): each column keeps its
+ * current value unless the caller passed that field. This never fires an
+ * upload — it only records checkpoint state.
+ */
+export async function updatePending(
+  hevyId: string,
+  fields: PendingUpdate,
+  sql: Sql = getDb(),
+): Promise<void> {
+  const has = (k: keyof PendingUpdate): boolean =>
+    Object.prototype.hasOwnProperty.call(fields, k) && fields[k] !== undefined;
+  if (!PENDING_UPDATE_FIELDS.some(has)) return;
+
+  // pre_upload_ids / payload are JSONB — wrap with sql.json so they are sent as
+  // a JSONB payload (never a double-encoded string). See db.ts.
+  const preUploadIds = has("pre_upload_ids") ? sql.json(fields.pre_upload_ids) : null;
+  const payload = has("payload") ? sql.json(fields.payload) : null;
+
+  await sql`
+    UPDATE pending_uploads SET
+      phase              = CASE WHEN ${has("phase")}              THEN ${fields.phase ?? null}              ELSE phase              END,
+      next_step          = CASE WHEN ${has("next_step")}          THEN ${fields.next_step ?? null}          ELSE next_step          END,
+      upload_id          = CASE WHEN ${has("upload_id")}          THEN ${fields.upload_id ?? null}          ELSE upload_id          END,
+      garmin_activity_id = CASE WHEN ${has("garmin_activity_id")} THEN ${fields.garmin_activity_id ?? null} ELSE garmin_activity_id END,
+      watch_activity_id  = CASE WHEN ${has("watch_activity_id")}  THEN ${fields.watch_activity_id ?? null}  ELSE watch_activity_id  END,
+      pre_upload_ids     = CASE WHEN ${has("pre_upload_ids")}     THEN ${preUploadIds}                       ELSE pre_upload_ids     END,
+      payload            = CASE WHEN ${has("payload")}            THEN ${payload}                           ELSE payload            END,
+      resolution_source  = CASE WHEN ${has("resolution_source")}  THEN ${fields.resolution_source ?? null}  ELSE resolution_source  END,
+      attempt_count      = CASE WHEN ${has("attempt_count")}      THEN ${fields.attempt_count ?? null}      ELSE attempt_count      END,
+      delete_attempt_count = CASE WHEN ${has("delete_attempt_count")} THEN ${fields.delete_attempt_count ?? null} ELSE delete_attempt_count END,
+      last_error         = CASE WHEN ${has("last_error")}         THEN ${fields.last_error ?? null}         ELSE last_error         END,
+      locked_until       = CASE WHEN ${has("locked_until")}       THEN ${fields.locked_until ?? null}       ELSE locked_until       END,
+      updated_at         = NOW()
+    WHERE hevy_id = ${hevyId}
+  `;
+}
+
+/** Delete a pending row. Returns whether a row was removed. Mirrors delete_pending(). */
+export async function deletePending(hevyId: string, sql: Sql = getDb()): Promise<boolean> {
+  const rows = await sql`
+    DELETE FROM pending_uploads WHERE hevy_id = ${hevyId} RETURNING hevy_id
+  `;
+  return rows.length > 0;
+}
+
+/** Options for resolveTerminal (a manual / skipped resolution). */
+export interface ResolveTerminalOpts {
+  status: "manual" | "skipped";
+  garminActivityId?: string | null;
+  reason?: string | null;
+  source?: string | null;
+}
+
+/**
+ * Manually resolve a workout to a terminal state ('manual' or 'skipped') and
+ * clear any pending row. Mirrors resolve_terminal(). This writes ONLY the local
+ * ledger — 'manual' records that the user handled the upload themselves, it does
+ * NOT upload anything to Garmin; 'skipped' records a deliberate skip.
+ */
+export async function resolveTerminal(
+  hevyId: string,
+  opts: ResolveTerminalOpts,
+  sql: Sql = getDb(),
+): Promise<void> {
+  if (opts.status !== "manual" && opts.status !== "skipped") {
+    throw new Error("manual resolution status must be 'manual' or 'skipped'");
+  }
+  const garminId = opts.garminActivityId ?? null;
+  const reason = opts.reason ?? null;
+  const source = opts.source ?? null;
+  await sql`
+    INSERT INTO synced_workouts
+      (hevy_id, garmin_activity_id, status, resolution_reason, resolved_at, resolution_source)
+    VALUES (${hevyId}, ${garminId}, ${opts.status}, ${reason}, NOW(), ${source})
+    ON CONFLICT (hevy_id) DO UPDATE SET
+      garmin_activity_id = EXCLUDED.garmin_activity_id,
+      status = EXCLUDED.status,
+      resolution_reason = EXCLUDED.resolution_reason,
+      resolved_at = NOW(),
+      resolution_source = EXCLUDED.resolution_source,
+      synced_at = NOW()
+  `;
+  await sql`DELETE FROM pending_uploads WHERE hevy_id = ${hevyId}`;
+}
+
+/**
+ * Delete a workout's terminal row so it becomes eligible for sync again.
+ * Mirrors unsync(). DB-ONLY: this does NOT delete the Garmin activity — that
+ * would be a destructive Garmin write and is out of scope for the safe half.
+ * Returns whether a row was removed.
+ */
+export async function unsync(hevyId: string, sql: Sql = getDb()): Promise<boolean> {
+  const rows = await sql`
+    DELETE FROM synced_workouts WHERE hevy_id = ${hevyId} RETURNING hevy_id
+  `;
+  return rows.length > 0;
+}
+
+/** Set of hevy_ids with a terminal (synced_workouts) row. Batch read for dedup. */
+export async function loadSyncedIds(sql: Sql = getDb()): Promise<Set<string>> {
+  const rows = await sql`SELECT hevy_id FROM synced_workouts`;
+  return new Set(rows.map((r) => String(r.hevy_id)));
+}
+
+/** Set of hevy_ids with an in-flight (pending_uploads) row. Batch read for dedup. */
+export async function loadPendingIds(sql: Sql = getDb()): Promise<Set<string>> {
+  const rows = await sql`SELECT hevy_id FROM pending_uploads`;
+  return new Set(rows.map((r) => String(r.hevy_id)));
+}

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-import "./.next/dev/types/root-params.d.ts";
+import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+// Minimal config: resolve the `@/` path alias (matches tsconfig) so route
+// handlers and libs that import `@/lib/*` can be unit-tested. Test discovery
+// and all other behaviour stay on the vitest defaults. `.test.ts` files next to
+// the code they cover (e.g. lib/dedup.test.ts) are picked up automatically.
+export default defineConfig({
+  resolve: {
+    alias: { "@": path.resolve(__dirname, ".") },
+  },
+});


### PR DESCRIPTION
## What

The **safe half** of the sync engine (Track C) — read, decide, and bookkeep. It contains **no Garmin write/upload code path**; the actual upload firing is a later phase that needs a real workout + the verify-before-fire playbook (the never-duplicate constraint).

- `lib/dedup.ts` — pure dedup decision: skip a workout if a terminal `synced_workouts` row (layer 1) OR an in-flight `pending_uploads` row (layer 2) exists. Layer 3 (Garmin 409 on a duplicate FIT) is explicitly deferred to the upload half. **22 unit tests.**
- `lib/hevy-sync.ts` — read-only HevyClient wrappers (count + paginated fetch).
- `lib/pending-store.ts` — `synced_workouts` / `pending_uploads` DB helpers mirroring `db_postgres.py` (isSynced, counts, list/get/claim/update/delete pending, resolveTerminal manual|skipped, unsync — DB only, no Garmin delete).
- `app/api/sync/preview` — GET dry-run: `{ totalHevy, syncedCount, pendingCount, remaining, nextUnsynced }`, no upload.
- Record-management routes (DB only): `workout/[id]/mark-synced`, `workout/[id]/skip`, `pending/[id]/abandon`, `unsync/[id]`.

## Verification
- `tsc --noEmit`: 0 errors
- `vitest run`: 22/22 (the dedup logic)
- `next build`: clean
- grep-confirmed: no `uploadFit`/`rename`/`delete`/`schedule` Garmin calls anywhere in the new code (the one match is a comment noting the upload half lives elsewhere).

Auth-gating the mutation routes comes with the login/middleware phase (before the additive deploy).

Refs drkostas/soma#385
