### PR TITLE
feat(web): shared-password auth gate — proxy + login [C-auth]

### DIFF
--- a/web/app/api/login/route.ts
+++ b/web/app/api/login/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { checkPassword, signSession, SESSION_COOKIE, authEnabled } from "@/lib/auth";
+
+export const runtime = "nodejs";
+
+/** POST { password } → set the h2g_session cookie on success. */
+export async function POST(req: Request) {
+  // If auth isn't configured, there's nothing to log into.
+  if (!authEnabled()) {
+    return NextResponse.json({ ok: true, note: "auth disabled" });
+  }
+  const body = (await req.json().catch(() => ({}))) as { password?: string };
+  if (!body.password || !checkPassword(body.password)) {
+    return NextResponse.json({ error: "Incorrect password" }, { status: 401 });
+  }
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set(SESSION_COOKIE, await signSession(), {
+    httpOnly: true,
+    sameSite: "strict",
+    secure: process.env.NODE_ENV === "production",
+    maxAge: 30 * 24 * 60 * 60,
+    path: "/",
+  });
+  return res;
+}

--- a/web/app/api/logout/route.ts
+++ b/web/app/api/logout/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+import { SESSION_COOKIE } from "@/lib/auth";
+
+/** POST → clear the session cookie. */
+export async function POST() {
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set(SESSION_COOKIE, "", { maxAge: 0, path: "/" });
+  return res;
+}

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function LoginPage() {
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError("");
+    try {
+      const res = await fetch("/api/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password }),
+      });
+      if (res.ok) {
+        router.push("/dashboard");
+        router.refresh();
+      } else {
+        setError("Incorrect password");
+        setLoading(false);
+      }
+    } catch {
+      setError("Something went wrong. Try again.");
+      setLoading(false);
+    }
+  }
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-sm flex-col justify-center px-6">
+      <h1 className="mb-1 text-2xl font-bold text-text">hevy2garmin</h1>
+      <p className="mb-6 text-sm text-text-secondary">Enter your dashboard password.</p>
+      <form onSubmit={onSubmit} className="flex flex-col gap-3">
+        <input
+          type="password"
+          autoFocus
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+          className="rounded-lg border border-border bg-surface px-4 py-3 text-text outline-none focus:border-teal"
+        />
+        {error && <p className="text-sm text-danger">{error}</p>}
+        <button
+          type="submit"
+          disabled={loading || password.length === 0}
+          className="rounded-lg bg-teal px-4 py-3 font-medium text-black transition-opacity disabled:opacity-50"
+        >
+          {loading ? "Signing in…" : "Sign in"}
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-import "./.next/types/root-params.d.ts";
+import "./.next/dev/types/routes.d.ts";
+import "./.next/dev/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -1,0 +1,105 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+/* Session verify is INLINED here (not imported from @/lib/auth) because Vercel's
+   proxy bundler rejects a cross-module reference from the proxy even when the
+   module is edge-safe. The logic is identical to lib/auth.ts (pure Web Crypto):
+   key = HEVY2GARMIN_SECRET raw bytes, else SHA-256("h2g-session-" + H2G_PASSWORD);
+   cookie = v1.<ts>.<hmac-sha256(v1.<ts>) hex truncated to 32>. The API routes
+   still import from @/lib/auth — they run on the Node serverless runtime. */
+const SESSION_COOKIE = "h2g_session";
+const SESSION_TTL_SECONDS = 30 * 24 * 60 * 60;
+const CLOCK_SKEW_SECONDS = 300;
+
+function toHex(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf);
+  let out = "";
+  for (const b of bytes) out += b.toString(16).padStart(2, "0");
+  return out;
+}
+
+let cachedKey: { material: string; key: CryptoKey } | null = null;
+
+async function getKey(): Promise<CryptoKey> {
+  const secret = process.env.HEVY2GARMIN_SECRET;
+  const password = process.env.H2G_PASSWORD;
+  let material: string;
+  let rawKey: Uint8Array;
+  if (secret) {
+    material = `secret:${secret}`;
+    rawKey = new TextEncoder().encode(secret);
+  } else {
+    if (!password) throw new Error("no auth secret");
+    material = `password:${password}`;
+    const digest = await crypto.subtle.digest(
+      "SHA-256",
+      new TextEncoder().encode(`h2g-session-${password}`),
+    );
+    rawKey = new Uint8Array(digest);
+  }
+  if (cachedKey && cachedKey.material === material) return cachedKey.key;
+  const key = await crypto.subtle.importKey(
+    "raw",
+    rawKey as unknown as ArrayBuffer,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"],
+  );
+  cachedKey = { material, key };
+  return key;
+}
+
+async function hmacHex32(data: string): Promise<string> {
+  const key = await getKey();
+  const sig = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(data));
+  return toHex(sig).slice(0, 32);
+}
+
+async function verifySession(cookie: string | null): Promise<boolean> {
+  if (!cookie) return false;
+  const m = cookie.match(/^v1\.(\d+)\.([0-9a-f]{32})$/);
+  if (!m) return false;
+  const ts = Number(m[1]);
+  const sig = m[2];
+  const now = Math.floor(Date.now() / 1000);
+  if (now - ts > SESSION_TTL_SECONDS) return false;
+  if (ts > now + CLOCK_SKEW_SECONDS) return false;
+  try {
+    const expected = await hmacHex32(`v1.${ts}`);
+    if (sig.length !== expected.length) return false;
+    let diff = 0;
+    for (let i = 0; i < sig.length; i++) diff |= sig.charCodeAt(i) ^ expected.charCodeAt(i);
+    return diff === 0;
+  } catch {
+    return false;
+  }
+}
+
+function authEnabled(): boolean {
+  return Boolean(process.env.HEVY2GARMIN_SECRET || process.env.H2G_PASSWORD);
+}
+
+const PUBLIC_PATHS = ["/login", "/api/login", "/api/logout"];
+const STATIC_PREFIX = /^\/(_next|favicon|manifest|icons|robots|sitemap)/;
+
+/** Gate every page + API route behind the shared-password session (mirrors auth.py).
+    When no secret/password is set, auth is disabled and everything is open. */
+export async function proxy(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+  if (STATIC_PREFIX.test(pathname)) return NextResponse.next();
+  if (!authEnabled()) return NextResponse.next();
+  if (PUBLIC_PATHS.some((p) => pathname === p || pathname.startsWith(`${p}/`))) {
+    return NextResponse.next();
+  }
+  const cookie = req.cookies.get(SESSION_COOKIE)?.value ?? null;
+  if (await verifySession(cookie)) return NextResponse.next();
+  if (pathname.startsWith("/api/")) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+  const url = req.nextUrl.clone();
+  url.pathname = "/login";
+  return NextResponse.redirect(url);
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};


### PR DESCRIPTION
## What

A shared-password auth gate for the web app — the prerequisite for deploying it publicly (the DB-mutation record routes from #316 must not be open).

- `proxy.ts` — Next 16 proxy (Node runtime). Verifies the `h2g_session` cookie; unauthenticated pages redirect to `/login`, `/api/*` return 401. **Session-verify is inlined** (Vercel's proxy bundler rejects a cross-module import even when edge-safe — learned from macro-engine/web's `proxy.ts`). Auth is disabled when no secret/password is set (matches `auth.py`).
- `app/login/page.tsx` — password form.
- `app/api/login` — POST checks `H2G_PASSWORD`, sets the signed `h2g_session` cookie (30-day, httpOnly, sameSite strict).
- `app/api/logout` — POST clears it.

The cookie format is wire-compatible with the Python dashboard, so a session minted by either verifies against the other.

## Verification
- `tsc --noEmit`: 0 errors; `next build`: clean (proxy builds, no deprecation warning).
- **Playwright-validated end-to-end**: unauthenticated `/dashboard` → redirect to `/login`; correct password → cookie set → lands on `/dashboard`.

Refs drkostas/soma#385
