### PR TITLE
feat(app): add Android package + eas.json to the Expo app

### DIFF
--- a/universal/app.json
+++ b/universal/app.json
@@ -8,9 +8,11 @@
     "scheme": "universal",
     "userInterfaceStyle": "automatic",
     "ios": {
+      "bundleIdentifier": "dev.gkos.hevy2garmin",
       "icon": "./assets/expo.icon"
     },
     "android": {
+      "package": "dev.gkos.hevy2garmin",
       "adaptiveIcon": {
         "backgroundColor": "#E6F4FE",
         "foregroundImage": "./assets/images/android-icon-foreground.png",

--- a/universal/eas.json
+++ b/universal/eas.json
@@ -1,0 +1,26 @@
+{
+  "cli": {
+    "version": ">= 12.0.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "ios": { "simulator": true },
+      "android": { "buildType": "apk" }
+    },
+    "preview": {
+      "distribution": "internal",
+      "ios": { "simulator": true },
+      "android": { "buildType": "apk" }
+    },
+    "production": {
+      "autoIncrement": true,
+      "android": { "buildType": "app-bundle" }
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}


### PR DESCRIPTION
Adds `android.package` (dev.gkos.hevy2garmin) + `ios.bundleIdentifier` + `eas.json` so the Expo app can build for Android (same gap the soma app had, now fixed there too). Native dirs stay gitignored. Closes #318
