### PR TITLE
feat(web): live Hevy→Garmin upload engine — dry-run-safe, dedup-gated

### DIFF
--- a/web/app/api/sync-one/route.ts
+++ b/web/app/api/sync-one/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { syncOneWorkout } from "@/lib/sync-one";
+import { getDb } from "@/lib/db";
+import { verifySession, SESSION_COOKIE, authEnabled } from "@/lib/auth";
+
+// Reads live Hevy + Postgres (and, on the live path, Garmin) at request time.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * POST /api/sync-one  —  DRY-RUN BY DEFAULT.
+ *
+ * Runs the single-workout Hevy→Garmin upload engine (lib/sync-one). Because a
+ * bad upload creates a duplicate Garmin/Strava activity — a hard user
+ * constraint — this route is dry-run unless the request EXPLICITLY opts into a
+ * live upload AND is authorized.
+ *
+ * A live upload fires only when BOTH hold:
+ *   1. the request asks for it: `?live=1` (or body { live: 1 | true }); AND
+ *   2. the request is authorized: a valid h2g session cookie, OR an
+ *      `Authorization: Bearer <CRON_SECRET>` header matching env CRON_SECRET.
+ *
+ * Anything short of both runs a dry-run (never uploads). The response mirrors
+ * the Python sync-one shape: { status, dryRun, wouldUpload, dedupDecision,
+ * synced/skipped/remaining/deferred/error, ... }.
+ */
+
+async function isAuthorized(request: Request): Promise<boolean> {
+  // CRON_SECRET via Bearer token (for scheduled/cron invocations).
+  const cronSecret = process.env.CRON_SECRET;
+  if (cronSecret) {
+    const auth = request.headers.get("authorization") ?? "";
+    const m = auth.match(/^Bearer\s+(.+)$/i);
+    if (m && m[1] === cronSecret) return true;
+  }
+  // Session cookie (a logged-in dashboard user). When auth is disabled (no
+  // password / secret configured), the app has no session gate — treat as
+  // authorized so a local/self-hosted deploy without a password still works.
+  if (!authEnabled()) return true;
+  const store = await cookies();
+  const cookie = store.get(SESSION_COOKIE)?.value ?? null;
+  return verifySession(cookie);
+}
+
+function wantsLive(request: Request, body: Record<string, unknown>): boolean {
+  const q = new URL(request.url).searchParams.get("live");
+  if (q === "1" || q === "true") return true;
+  const b = body.live;
+  return b === 1 || b === true || b === "1" || b === "true";
+}
+
+export async function POST(request: Request) {
+  let body: Record<string, unknown> = {};
+  try {
+    const text = await request.text();
+    if (text) body = JSON.parse(text);
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const requestedLive = wantsLive(request, body);
+  const authorized = requestedLive ? await isAuthorized(request) : false;
+
+  // Live ONLY when explicitly requested AND authorized. Otherwise dry-run.
+  const dryRun = !(requestedLive && authorized);
+
+  if (requestedLive && !authorized) {
+    return NextResponse.json(
+      { error: "Unauthorized: a live upload requires a session or CRON_SECRET." },
+      { status: 401 },
+    );
+  }
+
+  let sql: ReturnType<typeof getDb>;
+  try {
+    sql = getDb();
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `DB unavailable: ${error}` }, { status: 503 });
+  }
+
+  try {
+    const result = await syncOneWorkout(sql, { dryRun });
+    return NextResponse.json(result);
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error }, { status: 500 });
+  }
+}

--- a/web/lib/garmin-upload.ts
+++ b/web/lib/garmin-upload.ts
@@ -1,0 +1,98 @@
+/**
+ * Garmin upload wrappers — the DANGEROUS half of the sync engine.
+ *
+ * This module is the ONLY place in the web app that can write to Garmin
+ * Connect (upload a FIT, rename, set a description). A bad Garmin upload
+ * creates a duplicate Garmin/Strava activity, which is a hard user constraint,
+ * so every entry point here is a thin, explicit wrapper over the published
+ * `hevy2garmin` package's Garmin ops — no FIT generation, no HTTP is
+ * reimplemented, and nothing in this file decides WHETHER to upload.
+ *
+ * `getGarminClient()` READS the stored DI tokens from platform_credentials
+ * (platform='garmin_tokens') via garmin-auth. Building the client performs no
+ * activity write; it only authenticates. The functions that mutate Garmin
+ * (`upload`, `rename`, `describe`) are called by sync-one ONLY on the live path
+ * (dryRun === false). `findExistingActivity` is a READ (the 409-prevention
+ * lookup) and is always safe to call.
+ */
+import { GarminAuth, DBTokenStore, type GarminClient } from "garmin-auth";
+import {
+  uploadFit,
+  findActivityByStartTime,
+  renameActivity,
+  setDescription,
+  type UploadResult,
+} from "hevy2garmin";
+
+/** The DI tokens live in platform_credentials at this platform key. */
+export const GARMIN_TOKEN_PLATFORM = "garmin_tokens";
+
+let cachedClient: GarminClient | null = null;
+
+/**
+ * Build (and cache) an authenticated GarminClient from the DI tokens stored in
+ * Postgres. Uses garmin-auth's DBTokenStore, which reads
+ * platform_credentials.credentials->garmin_tokens (the NESTED shape the TS
+ * stack writes). Throws when DATABASE_URL is unset or the tokens are missing /
+ * need a fresh MFA login — callers surface that as a "reconnect Garmin" error.
+ *
+ * This authenticates only; it does not upload or mutate any activity.
+ */
+export async function getGarminClient(databaseUrl?: string): Promise<GarminClient> {
+  if (cachedClient) return cachedClient;
+  const url = databaseUrl ?? process.env.DATABASE_URL;
+  if (!url) throw new Error("DATABASE_URL not set (cannot load Garmin tokens)");
+  const store = new DBTokenStore(url, GARMIN_TOKEN_PLATFORM);
+  const auth = new GarminAuth({ store });
+  cachedClient = await auth.client();
+  return cachedClient;
+}
+
+/** Reset the cached client (test seam / after a token rotation). */
+export function resetGarminClient(): void {
+  cachedClient = null;
+}
+
+/**
+ * READ: is there already a Garmin activity at this start time? This is dedup
+ * layer 2 — the pre-upload lookup that prevents a duplicate (409) upload. Thin
+ * passthrough to the package's findActivityByStartTime. Returns the existing
+ * activity id, or null when the timestamp is free. Never writes.
+ */
+export async function findExistingActivity(
+  client: GarminClient,
+  startTime: string,
+): Promise<number | null> {
+  return findActivityByStartTime(client, startTime);
+}
+
+/**
+ * WRITE: upload a FIT (bytes) to Garmin. Thin passthrough to the package's
+ * uploadFit. Only ever reached on the live sync path (dryRun === false); the
+ * dry-run path returns before any wrapper here is called.
+ */
+export async function upload(
+  client: GarminClient,
+  fit: Uint8Array,
+  workoutStart?: string,
+): Promise<UploadResult> {
+  return uploadFit(client, fit, workoutStart);
+}
+
+/** WRITE: rename a Garmin activity. Thin passthrough to renameActivity. */
+export async function rename(
+  client: GarminClient,
+  activityId: number,
+  name: string,
+): Promise<void> {
+  return renameActivity(client, activityId, name);
+}
+
+/** WRITE: set a Garmin activity's description. Thin passthrough to setDescription. */
+export async function describe(
+  client: GarminClient,
+  activityId: number,
+  description: string,
+): Promise<void> {
+  return setDescription(client, activityId, description);
+}

--- a/web/lib/pending-store.ts
+++ b/web/lib/pending-store.ts
@@ -278,6 +278,66 @@ export async function resolveTerminal(
   await sql`DELETE FROM pending_uploads WHERE hevy_id = ${hevyId}`;
 }
 
+/** Fields written when recording a successful upload. Mirrors mark_synced(). */
+export interface MarkSyncedOpts {
+  garminActivityId?: string | null;
+  title?: string | null;
+  calories?: number | null;
+  avgHr?: number | null;
+  hevyUpdatedAt?: string | null;
+  syncMethod?: string;
+}
+
+/**
+ * Record a workout as terminally synced (status='success') in synced_workouts.
+ * Mirrors db_postgres.mark_synced(): UPSERT on hevy_id, always setting
+ * status='success' and synced_at=NOW().
+ *
+ * This is a LOCAL ledger write only — it does NOT upload to Garmin. The caller
+ * (sync-one) invokes it AFTER a real Garmin upload has already landed, to record
+ * the terminal state so the workout is never re-uploaded (dedup layer 1).
+ */
+export async function markSynced(
+  hevyId: string,
+  opts: MarkSyncedOpts = {},
+  sql: Sql = getDb(),
+): Promise<void> {
+  const garminId = opts.garminActivityId ?? null;
+  const title = opts.title ?? "";
+  const calories = opts.calories ?? null;
+  const avgHr = opts.avgHr ?? null;
+  const hevyUpdatedAt = opts.hevyUpdatedAt ?? null;
+  const syncMethod = opts.syncMethod ?? "upload";
+  await sql`
+    INSERT INTO synced_workouts
+      (hevy_id, garmin_activity_id, title, calories, avg_hr, hevy_updated_at, sync_method, status)
+    VALUES (${hevyId}, ${garminId}, ${title}, ${calories}, ${avgHr}, ${hevyUpdatedAt}, ${syncMethod}, 'success')
+    ON CONFLICT (hevy_id) DO UPDATE SET
+      garmin_activity_id = EXCLUDED.garmin_activity_id,
+      title = EXCLUDED.title,
+      calories = EXCLUDED.calories,
+      avg_hr = EXCLUDED.avg_hr,
+      hevy_updated_at = EXCLUDED.hevy_updated_at,
+      sync_method = EXCLUDED.sync_method,
+      status = 'success',
+      synced_at = NOW()
+  `;
+}
+
+/**
+ * Complete a claimed upload: write the terminal success row AND clear the
+ * in-flight pending row, atomically w.r.t. the two statements. Mirrors
+ * db_postgres.complete_pending(). LOCAL ledger only — no Garmin write.
+ */
+export async function completePending(
+  hevyId: string,
+  opts: MarkSyncedOpts = {},
+  sql: Sql = getDb(),
+): Promise<void> {
+  await markSynced(hevyId, opts, sql);
+  await sql`DELETE FROM pending_uploads WHERE hevy_id = ${hevyId}`;
+}
+
 /**
  * Delete a workout's terminal row so it becomes eligible for sync again.
  * Mirrors unsync(). DB-ONLY: this does NOT delete the Garmin activity — that

--- a/web/lib/sync-one.test.ts
+++ b/web/lib/sync-one.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Unit tests for the LIVE Hevy→Garmin upload engine (lib/sync-one).
+ *
+ * The central safety property under test: in dryRun (the DEFAULT) NO Garmin
+ * write and NO DB mutation are reachable. We mock every DB helper and the FIT
+ * generator, and inject the Hevy fetch + Garmin client so no network is
+ * touched. The Garmin write wrappers (upload/rename/describe) and the mutating
+ * ledger helpers (claimPending/completePending/markSynced/updatePending) are
+ * spies, and we assert they are NEVER called on the dry-run path.
+ */
+
+// --- Mock the package: generateFit is deterministic; the Garmin ops are spies. ---
+const uploadFit = vi.fn();
+const findActivityByStartTime = vi.fn();
+const renameActivity = vi.fn();
+const setDescription = vi.fn();
+vi.mock("hevy2garmin", () => ({
+  generateFit: vi.fn(() => ({
+    fit: new Uint8Array([1, 2, 3]),
+    exercises: 2,
+    total_sets: 6,
+    hr_samples: 0,
+    calories: 321,
+    avg_hr: null,
+    duration_s: 3600,
+  })),
+  uploadFit: (...a: unknown[]) => uploadFit(...a),
+  findActivityByStartTime: (...a: unknown[]) => findActivityByStartTime(...a),
+  renameActivity: (...a: unknown[]) => renameActivity(...a),
+  setDescription: (...a: unknown[]) => setDescription(...a),
+}));
+
+// --- Mock garmin-auth so importing garmin-upload never builds a real client. ---
+vi.mock("garmin-auth", () => ({
+  GarminAuth: class {
+    async client() {
+      return { domain: "garmin.com", di_token: "x" };
+    }
+  },
+  DBTokenStore: class {
+    constructor(..._a: unknown[]) {}
+  },
+}));
+
+// --- Mock the DB ledger helpers. Reads return controllable sets; writes are spies. ---
+const isSynced = vi.fn();
+const claimPending = vi.fn();
+const updatePending = vi.fn();
+const deletePending = vi.fn();
+const completePending = vi.fn();
+const markSynced = vi.fn();
+const loadSyncedIds = vi.fn();
+const loadPendingIds = vi.fn();
+vi.mock("./pending-store", () => ({
+  isSynced: (...a: unknown[]) => isSynced(...a),
+  claimPending: (...a: unknown[]) => claimPending(...a),
+  updatePending: (...a: unknown[]) => updatePending(...a),
+  deletePending: (...a: unknown[]) => deletePending(...a),
+  completePending: (...a: unknown[]) => completePending(...a),
+  markSynced: (...a: unknown[]) => markSynced(...a),
+  loadSyncedIds: (...a: unknown[]) => loadSyncedIds(...a),
+  loadPendingIds: (...a: unknown[]) => loadPendingIds(...a),
+}));
+
+// getDb is imported for the Sql type; give it a harmless stub.
+vi.mock("./db", () => ({ getDb: () => ({}) }));
+
+import { syncOneWorkout } from "./sync-one";
+import type { GarminClient } from "garmin-auth";
+
+const sql = {} as ReturnType<typeof import("./db").getDb>;
+
+// A fake Garmin client — findExistingActivity/upload/etc. are the mocked
+// package fns above, so this object only needs to exist.
+const fakeClient = { domain: "garmin.com", di_token: "x" } as unknown as GarminClient;
+const garminClientFactory = vi.fn(async () => fakeClient);
+
+const WORKOUT = {
+  id: "hevy-1",
+  title: "Push Day",
+  start_time: "2026-08-01T10:00:00Z",
+  end_time: "2026-08-01T11:00:00Z",
+  updated_at: "2026-08-01T11:05:00Z",
+  exercises: [
+    { title: "Bench Press", sets: [{ type: "normal", weight_kg: 80, reps: 5 }] },
+  ],
+};
+
+function fetchOne() {
+  return async () => [WORKOUT];
+}
+
+/** Assert that NOTHING wrote to Garmin or mutated the DB ledger. */
+function expectNoWrites() {
+  expect(uploadFit).not.toHaveBeenCalled();
+  expect(renameActivity).not.toHaveBeenCalled();
+  expect(setDescription).not.toHaveBeenCalled();
+  expect(claimPending).not.toHaveBeenCalled();
+  expect(completePending).not.toHaveBeenCalled();
+  expect(markSynced).not.toHaveBeenCalled();
+  expect(updatePending).not.toHaveBeenCalled();
+  expect(deletePending).not.toHaveBeenCalled();
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: empty ledgers (fresh workout), Garmin has nothing at the timestamp.
+  loadSyncedIds.mockResolvedValue(new Set<string>());
+  loadPendingIds.mockResolvedValue(new Set<string>());
+  isSynced.mockResolvedValue(false);
+  findActivityByStartTime.mockResolvedValue(null);
+  claimPending.mockResolvedValue(true);
+  uploadFit.mockResolvedValue({ uploadId: 99, activityId: 555 });
+});
+
+describe("syncOneWorkout — dry-run is the DEFAULT and never writes", () => {
+  it("defaults to dryRun when no option is passed (fresh → wouldUpload, no writes)", async () => {
+    const res = await syncOneWorkout(sql, {
+      fetchWorkouts: fetchOne(),
+      garminClientFactory,
+    });
+    expect(res.dryRun).toBe(true);
+    expect(res.status).toBe("dry_run");
+    expect(res.wouldUpload).toBe(true);
+    expect(res.dedupDecision).toBe("would_upload");
+    expect(res.workout?.hevy_id).toBe("hevy-1");
+    expect(res.fitStats?.calories).toBe(321);
+    // The layer-2 read IS allowed (it's a read), but NO write happens.
+    expect(findActivityByStartTime).toHaveBeenCalledTimes(1);
+    expectNoWrites();
+  });
+
+  it("explicit dryRun:true also performs zero writes", async () => {
+    const res = await syncOneWorkout(sql, {
+      dryRun: true,
+      fetchWorkouts: fetchOne(),
+      garminClientFactory,
+    });
+    expect(res.dryRun).toBe(true);
+    expect(res.wouldUpload).toBe(true);
+    expectNoWrites();
+  });
+});
+
+describe("dedup layer 1 — already-synced is skipped, never uploaded", () => {
+  it("id-set marks it synced → filtered out → no_candidates", async () => {
+    loadSyncedIds.mockResolvedValue(new Set(["hevy-1"]));
+    const res = await syncOneWorkout(sql, {
+      fetchWorkouts: fetchOne(),
+      garminClientFactory,
+    });
+    expect(res.status).toBe("none");
+    expect(res.dedupDecision).toBe("no_candidates");
+    expect(res.wouldUpload).toBe(false);
+    // Garmin was never even consulted.
+    expect(findActivityByStartTime).not.toHaveBeenCalled();
+    expectNoWrites();
+  });
+
+  it("live re-check: isSynced true for the picked id → skipped, no upload", async () => {
+    // Passes the id-set filter but the live ledger says it's already synced
+    // (a concurrent sync resolved it). Must skip, not upload.
+    isSynced.mockResolvedValue(true);
+    const res = await syncOneWorkout(sql, {
+      dryRun: false,
+      fetchWorkouts: fetchOne(),
+      garminClientFactory,
+    });
+    expect(res.status).toBe("skipped");
+    expect(res.dedupDecision).toBe("already_synced");
+    expectNoWrites();
+  });
+});
+
+describe("dedup layer 2 — existing Garmin activity → match, NOT upload", () => {
+  it("dry-run: reports the match, no writes", async () => {
+    findActivityByStartTime.mockResolvedValue(4242);
+    const res = await syncOneWorkout(sql, {
+      fetchWorkouts: fetchOne(),
+      garminClientFactory,
+    });
+    expect(res.dryRun).toBe(true);
+    expect(res.dedupDecision).toBe("existing_garmin_activity");
+    expect(res.wouldUpload).toBe(false);
+    expect(res.existingGarminActivityId).toBe(4242);
+    expect(res.syncMethod).toBe("match");
+    expect(uploadFit).not.toHaveBeenCalled();
+    expectNoWrites();
+  });
+
+  it("live: matches + renames the existing activity, NEVER uploads a FIT", async () => {
+    findActivityByStartTime.mockResolvedValue(4242);
+    const res = await syncOneWorkout(sql, {
+      dryRun: false,
+      fetchWorkouts: fetchOne(),
+      garminClientFactory,
+    });
+    expect(res.status).toBe("synced");
+    expect(res.dedupDecision).toBe("existing_garmin_activity");
+    expect(res.garminActivityId).toBe(4242);
+    // The upload path is unreachable — the whole point of layer 2.
+    expect(uploadFit).not.toHaveBeenCalled();
+    // It DID rename/describe the existing activity and record a terminal row.
+    expect(renameActivity).toHaveBeenCalledWith(fakeClient, 4242, "Push Day");
+    expect(setDescription).toHaveBeenCalledTimes(1);
+    expect(markSynced).toHaveBeenCalledTimes(1);
+    // No fresh claim/upload was made.
+    expect(claimPending).not.toHaveBeenCalled();
+  });
+});
+
+describe("dedup layer 3 + live upload — fresh workout on the live path", () => {
+  it("claims, uploads, finalizes, and completes the pending row", async () => {
+    const res = await syncOneWorkout(sql, {
+      dryRun: false,
+      fetchWorkouts: fetchOne(),
+      garminClientFactory,
+    });
+    expect(res.status).toBe("synced");
+    expect(res.dedupDecision).toBe("would_upload");
+    expect(res.garminActivityId).toBe(555);
+    // Layer 3 claim happened before the upload.
+    expect(claimPending).toHaveBeenCalledTimes(1);
+    expect(uploadFit).toHaveBeenCalledTimes(1);
+    expect(renameActivity).toHaveBeenCalledWith(fakeClient, 555, "Push Day");
+    expect(setDescription).toHaveBeenCalledTimes(1);
+    expect(completePending).toHaveBeenCalledTimes(1);
+  });
+
+  it("claim lost (another worker holds it) → deferred, NO upload", async () => {
+    claimPending.mockResolvedValue(false);
+    const res = await syncOneWorkout(sql, {
+      dryRun: false,
+      fetchWorkouts: fetchOne(),
+      garminClientFactory,
+    });
+    expect(res.status).toBe("deferred");
+    expect(res.dedupDecision).toBe("claim_lost");
+    expect(uploadFit).not.toHaveBeenCalled();
+    expect(completePending).not.toHaveBeenCalled();
+    expect(markSynced).not.toHaveBeenCalled();
+  });
+
+  it("upload throws → parks pending as processing with the error, no completion", async () => {
+    uploadFit.mockRejectedValue(new Error("Garmin upload failed (500)"));
+    const res = await syncOneWorkout(sql, {
+      dryRun: false,
+      fetchWorkouts: fetchOne(),
+      garminClientFactory,
+    });
+    expect(res.status).toBe("error");
+    expect(res.error).toContain("Garmin upload failed");
+    expect(claimPending).toHaveBeenCalledTimes(1);
+    // Parked, not completed — never blindly re-uploaded.
+    expect(updatePending).toHaveBeenCalledWith(
+      "hevy-1",
+      expect.objectContaining({ phase: "processing" }),
+      sql,
+    );
+    expect(completePending).not.toHaveBeenCalled();
+  });
+});
+
+describe("empty + edge inputs", () => {
+  it("no workouts at all → none / no_candidates, no writes", async () => {
+    const res = await syncOneWorkout(sql, {
+      fetchWorkouts: async () => [],
+      garminClientFactory,
+    });
+    expect(res.status).toBe("none");
+    expect(res.dedupDecision).toBe("no_candidates");
+    expect(garminClientFactory).not.toHaveBeenCalled();
+    expectNoWrites();
+  });
+
+  it("workout without a start_time → refuses to upload (dry_run), no writes", async () => {
+    const noStart = { ...WORKOUT, start_time: null };
+    const res = await syncOneWorkout(sql, {
+      dryRun: true,
+      fetchWorkouts: async () => [noStart],
+      garminClientFactory,
+    });
+    expect(res.dedupDecision).toBe("no_start_time");
+    expect(res.wouldUpload).toBe(false);
+    // Never consulted Garmin (no start time to look up).
+    expect(garminClientFactory).not.toHaveBeenCalled();
+    expectNoWrites();
+  });
+});

--- a/web/lib/sync-one.ts
+++ b/web/lib/sync-one.ts
@@ -1,0 +1,440 @@
+/**
+ * syncOneWorkout — the LIVE Hevy→Garmin upload engine for the web app.
+ *
+ * DRY-RUN BY DEFAULT. This is the piece that makes the modern web capable of
+ * actually syncing (the rest of the web app only reads). Because a bad upload
+ * creates a duplicate Garmin/Strava activity — a hard user constraint — the
+ * default is dryRun=true and NO Garmin write and NO DB mutation happen unless
+ * the caller explicitly passes { dryRun: false }.
+ *
+ * The three-layer never-duplicate contract (ported from sync.py):
+ *
+ *   Layer 1 — already resolved: if a terminal `synced_workouts` row exists for
+ *     the workout (isSynced / the dedup id-set), it is SKIPPED. The pure dedup
+ *     in lib/dedup already excludes these when picking the next candidate; this
+ *     module re-checks the picked workout so a concurrent sync can't slip a
+ *     just-synced id through.
+ *
+ *   Layer 2 — Garmin already has it: BEFORE uploading, findActivityByStartTime
+ *     asks Garmin whether an activity already exists at the workout's start
+ *     time. If one does, we DO NOT upload (409 prevention) — we match it and
+ *     rename/describe the existing activity instead.
+ *
+ *   Layer 3 — in-flight ledger: claimPending atomically inserts a
+ *     pending_uploads row (INSERT ... ON CONFLICT DO NOTHING). If another
+ *     process already claimed the workout, our claim loses and we defer, so two
+ *     workers never double-upload the same workout.
+ *
+ * ALL THREE gate the upload. In dryRun mode we run layers 1 and 2 (reads only)
+ * to compute the decision, but perform NO claim, NO upload, NO finalize, and NO
+ * ledger write.
+ */
+import {
+  isSynced,
+  claimPending,
+  updatePending,
+  deletePending,
+  completePending,
+  markSynced,
+} from "./pending-store";
+import { getHevyClient, type HevyWorkout } from "./hevy-sync";
+import { filterUnsynced, type DedupWorkout } from "./dedup";
+import { loadSyncedIds, loadPendingIds } from "./pending-store";
+import {
+  getGarminClient,
+  findExistingActivity,
+  upload,
+  rename,
+  describe,
+} from "./garmin-upload";
+import { generateFit, type HevyWorkout as FitWorkout, type FitResult } from "hevy2garmin";
+import type { GarminClient } from "garmin-auth";
+import { getDb } from "./db";
+
+type Sql = ReturnType<typeof getDb>;
+
+/** What the dedup gate decided for this workout. */
+export type DedupDecision =
+  | "would_upload" // fresh: no terminal row, no existing Garmin activity — a real upload
+  | "already_synced" // layer 1: terminal synced_workouts row exists — skip
+  | "existing_garmin_activity" // layer 2: Garmin already has an activity at this start time — match, do NOT upload
+  | "claim_lost" // layer 3: another worker holds the pending claim — deferred
+  | "no_candidates" // nothing left to sync
+  | "no_start_time"; // workout has no start_time; can't run the layer-2 lookup safely
+
+/** Compact FIT stats surfaced to the caller (no bytes). */
+export interface FitStats {
+  exercises: number;
+  totalSets: number;
+  calories: number;
+  avgHr: number | null;
+  durationS: number;
+}
+
+/** Result shape, aligned with the Python sync-one status vocabulary. */
+export interface SyncOneResult {
+  /** synced | skipped | deferred | dry_run | none | error */
+  status: "synced" | "skipped" | "deferred" | "dry_run" | "none" | "error";
+  dryRun: boolean;
+  /** In dry-run: true when a live run WOULD upload a fresh FIT. */
+  wouldUpload: boolean;
+  dedupDecision: DedupDecision;
+  workout: { hevy_id: string; title: string | null; start_time: string | null } | null;
+  fitStats: FitStats | null;
+  /** The matched/created Garmin activity id, when known. */
+  existingGarminActivityId: number | null;
+  garminActivityId: number | null;
+  /** How many candidates remained after dedup (context for the caller). */
+  remaining: number;
+  syncMethod: "upload" | "match" | null;
+  error: string | null;
+}
+
+/** Options controlling syncOneWorkout. dryRun defaults to TRUE (safe). */
+export interface SyncOneOptions {
+  /** DEFAULT true. When true: NO Garmin write and NO DB mutation happen. */
+  dryRun?: boolean;
+  /** Injectable Hevy fetch (tests). Defaults to the live Hevy read. */
+  fetchWorkouts?: () => Promise<HevyWorkout[]>;
+  /** Injectable Garmin client factory (tests). Defaults to getGarminClient. */
+  garminClientFactory?: () => Promise<GarminClient>;
+  /** Whether to attach a text description on the activity. Default true. */
+  descriptionEnabled?: boolean;
+}
+
+function fitStatsOf(r: FitResult): FitStats {
+  return {
+    exercises: r.exercises,
+    totalSets: r.total_sets,
+    calories: r.calories,
+    avgHr: r.avg_hr,
+    durationS: r.duration_s,
+  };
+}
+
+function workoutView(w: DedupWorkout): SyncOneResult["workout"] {
+  return {
+    hevy_id: w.id,
+    title: (w.title as string | null) ?? null,
+    start_time: (w.start_time as string | null) ?? null,
+  };
+}
+
+/**
+ * Text description for a synced gym workout. Ported from garmin.py
+ * generate_description so the web upload and the Python pipeline produce the
+ * same body. Pure/local — builds a string, no network.
+ */
+export function generateDescription(
+  workout: Record<string, unknown>,
+  calories: number | null,
+  avgHr: number | null,
+): string {
+  const lines: string[] = [];
+  const title = (workout.title as string) || "Workout";
+  const start = (workout.start_time as string) || (workout.startTime as string) || "";
+  const end = (workout.end_time as string) || (workout.endTime as string) || "";
+  let durationS = 0;
+  if (start && end) {
+    const t0 = Date.parse(start.replace(" ", "T"));
+    const t1 = Date.parse(end.replace(" ", "T"));
+    if (!Number.isNaN(t0) && !Number.isNaN(t1)) durationS = Math.floor((t1 - t0) / 1000);
+  }
+
+  lines.push(`🏋️ ${title}`);
+  if (durationS > 0) lines.push(`⏱️ ${Math.floor(durationS / 60)} min`);
+  if (calories) lines.push(`🔥 ${calories} kcal`);
+  if (avgHr) lines.push(`❤️ avg ${avgHr} bpm`);
+
+  const exercises = (workout.exercises as Array<Record<string, unknown>>) || [];
+  if (exercises.length) {
+    lines.push("");
+    for (const ex of exercises) {
+      const name = (ex.title as string) || (ex.name as string) || "Unknown";
+      const allSets = (ex.sets as Array<Record<string, unknown>>) || [];
+      const normal = allSets.filter((s) => s.type === "normal");
+      const warmup = allSets.filter((s) => s.type === "warmup");
+      if (normal.length) {
+        const nLabel = normal.length === 1 ? "set" : "sets";
+        const hasDistance = normal.some((s) => s.distance_meters);
+        const hasDuration = normal.some((s) => s.duration_seconds);
+        const hasWeight = normal.some((s) => s.weight_kg || s.weight);
+        if (hasDistance || (hasDuration && !hasWeight)) {
+          const totalDist = normal.reduce((a, s) => a + (Number(s.distance_meters) || 0), 0);
+          const totalDur = normal.reduce((a, s) => a + (Number(s.duration_seconds) || 0), 0);
+          const parts = [`${normal.length} ${nLabel}`];
+          if (totalDist > 0) parts.push(`${(totalDist / 1000).toFixed(1)}km`);
+          if (totalDur > 0) parts.push(`${Math.floor(totalDur / 60)}min`);
+          lines.push(`• ${name}: ${parts.join(" · ")}`);
+        } else {
+          const weights = normal
+            .map((s) => (s.weight_kg ?? s.weight) as number | undefined)
+            .filter((w): w is number => w != null);
+          const reps = normal
+            .map((s) => s.reps as number | undefined)
+            .filter((r): r is number => r != null);
+          const topWeight = weights.length ? Math.max(...weights) : 0;
+          const topReps = reps.length ? Math.max(...reps) : 0;
+          lines.push(`• ${name}: ${normal.length} ${nLabel} · ${topWeight.toFixed(1)}kg × ${topReps}`);
+        }
+      } else if (warmup.length) {
+        const sLabel = warmup.length === 1 ? "set" : "sets";
+        lines.push(`• ${name}: ${warmup.length} warmup ${sLabel}`);
+      }
+    }
+  }
+
+  lines.push("\n— synced by hevy2garmin");
+  return lines.join("\n");
+}
+
+/** Build the "nothing to do" result. */
+function emptyResult(dryRun: boolean, decision: DedupDecision, remaining: number): SyncOneResult {
+  return {
+    status: "none",
+    dryRun,
+    wouldUpload: false,
+    dedupDecision: decision,
+    workout: null,
+    fitStats: null,
+    existingGarminActivityId: null,
+    garminActivityId: null,
+    remaining,
+    syncMethod: null,
+    error: null,
+  };
+}
+
+/**
+ * Sync the single next unsynced Hevy workout to Garmin.
+ *
+ * DEFAULT dryRun=true → computes the decision (fetch next unsynced, generate the
+ * FIT, run layers 1 & 2) and returns { wouldUpload, workout, fitStats,
+ * dedupDecision, existingGarminActivityId } WITHOUT any Garmin write or DB
+ * mutation. Only when dryRun=false does it claim → upload → finalize → mark
+ * synced.
+ */
+export async function syncOneWorkout(
+  sql: Sql,
+  options: SyncOneOptions = {},
+): Promise<SyncOneResult> {
+  const dryRun = options.dryRun ?? true; // SAFE DEFAULT
+  const descriptionEnabled = options.descriptionEnabled ?? true;
+
+  // 1) Fetch the Hevy workout list + the dedup id-sets, then pick the next
+  //    unsynced candidate (dedup layer 1, pure). Reads only.
+  const fetchWorkouts =
+    options.fetchWorkouts ?? (async () => {
+      const client = await getHevyClient();
+      return (await client.getAllWorkouts()) as HevyWorkout[];
+    });
+
+  const workouts = (await fetchWorkouts()) as DedupWorkout[];
+  const [syncedIds, pendingIds] = await Promise.all([
+    loadSyncedIds(sql),
+    loadPendingIds(sql),
+  ]);
+  const candidates = filterUnsynced(workouts, syncedIds, pendingIds);
+  const remaining = candidates.length;
+  const workout = candidates[0] ?? null;
+
+  if (!workout) {
+    return emptyResult(dryRun, "no_candidates", 0);
+  }
+
+  const wid = workout.id;
+  const title = (workout.title as string | null) ?? "Workout";
+  const startTime = (workout.start_time as string | null) ?? null;
+
+  // Re-confirm layer 1 against the live ledger for the picked id (guards a
+  // concurrent sync that resolved this id after the id-set snapshot).
+  if (await isSynced(wid, sql)) {
+    return {
+      ...emptyResult(dryRun, "already_synced", remaining),
+      status: "skipped",
+      workout: workoutView(workout),
+    };
+  }
+
+  // 2) Generate the FIT (pure/in-memory; the package returns bytes + stats).
+  //    No IO, no upload. Runs in dry-run too, so the preview shows real stats.
+  const fitResult = generateFit(workout as unknown as FitWorkout, null);
+  const fitStats = fitStatsOf(fitResult);
+
+  // Without a start_time we cannot run the layer-2 lookup, so we refuse to
+  // upload rather than risk a duplicate. (The Python path also keys dedup on
+  // start_time.)
+  if (!startTime) {
+    return {
+      ...emptyResult(dryRun, "no_start_time", remaining),
+      status: dryRun ? "dry_run" : "deferred",
+      wouldUpload: false,
+      workout: workoutView(workout),
+      fitStats,
+    };
+  }
+
+  // 3) Layer 2 — ask Garmin whether an activity already exists at this start
+  //    time (409 prevention). This is a READ; it runs in dry-run too so the
+  //    preview reflects the real decision.
+  const garminClientFactory = options.garminClientFactory ?? (() => getGarminClient());
+  const client = await garminClientFactory();
+  const existingId = await findExistingActivity(client, startTime);
+
+  if (existingId) {
+    // Garmin already has this workout. NEVER upload — match it. In a live run
+    // we rename/describe the existing activity and record a terminal row; in
+    // dry-run we report the match and touch nothing.
+    if (dryRun) {
+      return {
+        status: "dry_run",
+        dryRun: true,
+        wouldUpload: false,
+        dedupDecision: "existing_garmin_activity",
+        workout: workoutView(workout),
+        fitStats,
+        existingGarminActivityId: existingId,
+        garminActivityId: existingId,
+        remaining,
+        syncMethod: "match",
+        error: null,
+      };
+    }
+    await rename(client, existingId, title);
+    if (descriptionEnabled) {
+      await describe(
+        client,
+        existingId,
+        generateDescription(workout, fitStats.calories, fitStats.avgHr),
+      );
+    }
+    await markSynced(wid, {
+      garminActivityId: String(existingId),
+      title,
+      calories: fitStats.calories,
+      avgHr: fitStats.avgHr,
+      hevyUpdatedAt: (workout.updated_at as string | null) ?? null,
+      syncMethod: "upload_fallback",
+    }, sql);
+    return {
+      status: "synced",
+      dryRun: false,
+      wouldUpload: false,
+      dedupDecision: "existing_garmin_activity",
+      workout: workoutView(workout),
+      fitStats,
+      existingGarminActivityId: existingId,
+      garminActivityId: existingId,
+      remaining,
+      syncMethod: "match",
+      error: null,
+    };
+  }
+
+  // 4) Fresh workout — a real upload WOULD happen. In dry-run STOP HERE: no
+  //    claim, no upload, no finalize, no ledger write.
+  if (dryRun) {
+    return {
+      status: "dry_run",
+      dryRun: true,
+      wouldUpload: true,
+      dedupDecision: "would_upload",
+      workout: workoutView(workout),
+      fitStats,
+      existingGarminActivityId: null,
+      garminActivityId: null,
+      remaining,
+      syncMethod: "upload",
+      error: null,
+    };
+  }
+
+  // ---- LIVE PATH (dryRun === false only) ----
+
+  // Layer 3 — atomically claim the workout in pending_uploads. If we lose the
+  // race, another worker owns it; defer.
+  const payload = {
+    workout,
+    title,
+    calories: fitStats.calories,
+    avg_hr: fitStats.avgHr,
+    hevy_updated_at: (workout.updated_at as string | null) ?? null,
+    sync_method: "upload",
+  };
+  const claimed = await claimPending(wid, payload, sql);
+  if (!claimed) {
+    return {
+      ...emptyResult(false, "claim_lost", remaining),
+      status: "deferred",
+      workout: workoutView(workout),
+      fitStats,
+    };
+  }
+
+  try {
+    await updatePending(wid, { phase: "processing", attempt_count: 1 }, sql);
+
+    const uploadResult = await upload(client, fitResult.fit, startTime);
+    const activityId = uploadResult.activityId;
+
+    // Finalize: rename + describe, then write the terminal success row and
+    // clear the pending claim.
+    if (activityId) {
+      await rename(client, activityId, title);
+      if (descriptionEnabled) {
+        await describe(
+          client,
+          activityId,
+          generateDescription(workout, fitStats.calories, fitStats.avgHr),
+        );
+      }
+    }
+    await completePending(wid, {
+      garminActivityId: activityId != null ? String(activityId) : null,
+      title,
+      calories: fitStats.calories,
+      avgHr: fitStats.avgHr,
+      hevyUpdatedAt: (workout.updated_at as string | null) ?? null,
+      syncMethod: "upload",
+    }, sql);
+
+    return {
+      status: "synced",
+      dryRun: false,
+      wouldUpload: true,
+      dedupDecision: "would_upload",
+      workout: workoutView(workout),
+      fitStats,
+      existingGarminActivityId: null,
+      garminActivityId: activityId,
+      remaining,
+      syncMethod: "upload",
+      error: null,
+    };
+  } catch (err) {
+    // The upload may or may not have reached Garmin. Park the pending row in
+    // 'processing' with the error (mirrors sync.py) rather than deleting it, so
+    // it is never blindly re-uploaded — reconciliation resolves it later.
+    const message = err instanceof Error ? err.message : String(err);
+    try {
+      await updatePending(wid, { phase: "processing", last_error: message.slice(0, 1000) }, sql);
+    } catch {
+      // If even the checkpoint write fails, drop the claim so the workout can
+      // be re-evaluated rather than being wedged in a bad state.
+      await deletePending(wid, sql).catch(() => {});
+    }
+    return {
+      status: "error",
+      dryRun: false,
+      wouldUpload: true,
+      dedupDecision: "would_upload",
+      workout: workoutView(workout),
+      fitStats,
+      existingGarminActivityId: null,
+      garminActivityId: null,
+      remaining,
+      syncMethod: "upload",
+      error: message,
+    };
+  }
+}


### PR DESCRIPTION
Adds the live upload engine to the modern web — DRY-RUN by default, 3-layer never-duplicate dedup gates every upload (already-synced / existing-Garmin-activity / pending ledger). Reuses the hevy2garmin package + garmin-auth. Live fire only via ?live=1 + auth. tsc 0, vitest 33/33, next build clean; no live upload fired. Closes #320
