### PR TITLE
feat(app+web): Workouts + Mappings screens for web/app parity

### DIFF
--- a/universal/src/app/(main)/_layout.tsx
+++ b/universal/src/app/(main)/_layout.tsx
@@ -4,10 +4,10 @@ import { Ionicons } from "@expo/vector-icons";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { tabBarScreenOptions } from "soma-style";
 
-/* Bottom tab bar, matching the soma design system. hevy2garmin has three
-   sections (Sync / History / Settings). The bar's look comes from soma-style's
-   shared tabBarScreenOptions so it stays identical to soma + macro-engine;
-   routing stays app-local. */
+/* Bottom tab bar, matching the soma design system. hevy2garmin has five
+   sections (Sync / Workouts / History / Mappings / Settings). The bar's look
+   comes from soma-style's shared tabBarScreenOptions so it stays identical to
+   soma + macro-engine; routing stays app-local. */
 type IconName = React.ComponentProps<typeof Ionicons>["name"];
 const tabIcon =
   (name: IconName) =>
@@ -20,7 +20,9 @@ export default function MainLayout() {
     <SafeAreaView edges={["top"]} className="flex-1 bg-base">
       <Tabs screenOptions={tabBarScreenOptions}>
         <Tabs.Screen name="sync" options={{ title: "Sync", tabBarIcon: tabIcon("sync-outline") }} />
+        <Tabs.Screen name="workouts" options={{ title: "Workouts", tabBarIcon: tabIcon("barbell-outline") }} />
         <Tabs.Screen name="history" options={{ title: "History", tabBarIcon: tabIcon("time-outline") }} />
+        <Tabs.Screen name="mappings" options={{ title: "Mappings", tabBarIcon: tabIcon("git-compare-outline") }} />
         <Tabs.Screen name="settings" options={{ title: "Settings", tabBarIcon: tabIcon("settings-outline") }} />
       </Tabs>
     </SafeAreaView>

--- a/universal/src/app/(main)/mappings.tsx
+++ b/universal/src/app/(main)/mappings.tsx
@@ -1,0 +1,90 @@
+import { RefreshControl, ScrollView, View } from "react-native";
+import { Text, Card, Badge } from "soma-style";
+import { useMappings, usePullRefresh } from "../../lib/api";
+
+/**
+ * Exercise mappings — how Hevy exercises map to Garmin FIT categories.
+ * Custom overrides live in the DB (custom_mappings); the built-in map ships with
+ * the hevy2garmin package. Live from /api/mappings, styled like the Sync screen.
+ */
+export default function MappingsScreen() {
+  const { data, error, refetch } = useMappings();
+  const { refreshing, onRefresh } = usePullRefresh(refetch);
+  const custom = data?.custom ?? [];
+  const sample = data?.sample ?? [];
+
+  return (
+    <ScrollView
+      className="flex-1 bg-base"
+      contentContainerClassName="items-center px-5 py-6"
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor="#77c8d1" />}
+    >
+      <View className="w-full max-w-2xl gap-4">
+        <View className="flex-row items-center gap-2">
+          <Text variant="headline">Mappings</Text>
+          {data && !data.dbConfigured ? <Badge label="No DB" tone="warm" /> : null}
+        </View>
+
+        {error ? (
+          <Card><Text variant="body" className="text-danger">API: {error} — is soma running on :3456?</Text></Card>
+        ) : null}
+
+        {/* Counts */}
+        <View className="flex-row gap-3">
+          <Card className="flex-1 gap-1">
+            <Text variant="eyebrow">Custom</Text>
+            <Text variant="display" className="text-teal">{data ? data.customCount : "…"}</Text>
+            <Text variant="micro">your overrides</Text>
+          </Card>
+          <Card className="flex-1 gap-1">
+            <Text variant="eyebrow">Built-in</Text>
+            <Text variant="display" className="text-text">{data ? data.builtinCount : "…"}</Text>
+            <Text variant="micro">shipped with the package</Text>
+          </Card>
+        </View>
+
+        {/* Custom mappings — overrides win over the built-in map. */}
+        <View className="gap-2">
+          <Text variant="eyebrow">Your custom mappings</Text>
+          {custom.map((m) => (
+            <Card key={m.hevy_name} className="gap-2">
+              <View className="flex-row items-center justify-between">
+                <View className="flex-1 pr-2">
+                  <Text variant="body" className="text-text" numberOfLines={1}>{m.hevy_name}</Text>
+                  <Text variant="micro">cat {m.category} · sub {m.subcategory}</Text>
+                </View>
+                <Badge label="Override" tone="teal" />
+              </View>
+            </Card>
+          ))}
+          {data && custom.length === 0 ? (
+            <Card><Text variant="body" className="text-text-secondary">
+              No custom mappings yet. Add overrides from the web dashboard.
+            </Text></Card>
+          ) : null}
+        </View>
+
+        {/* Built-in sample */}
+        {sample.length > 0 ? (
+          <View className="gap-2">
+            <Text variant="eyebrow">Built-in map · sample</Text>
+            {sample.map((b) => (
+              <Card key={b.name} className="gap-2">
+                <View className="flex-row items-center justify-between">
+                  <View className="flex-1 pr-2">
+                    <Text variant="body" className="text-text" numberOfLines={1}>{b.name}</Text>
+                    <Text variant="micro">→ {b.categoryName} · cat {b.category}</Text>
+                  </View>
+                </View>
+              </Card>
+            ))}
+          </View>
+        ) : null}
+
+        {!data && !error ? (
+          <Card><Text variant="body" className="text-text-muted">Loading…</Text></Card>
+        ) : null}
+      </View>
+    </ScrollView>
+  );
+}

--- a/universal/src/app/(main)/workouts.tsx
+++ b/universal/src/app/(main)/workouts.tsx
@@ -1,0 +1,109 @@
+import { RefreshControl, ScrollView, View } from "react-native";
+import { Text, Card, Badge, type BadgeTone } from "soma-style";
+import { useWorkouts, usePullRefresh, type WorkoutItem } from "../../lib/api";
+
+function fmtWhen(value: string | null): string {
+  if (!value) return "—";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+/**
+ * Status pill for a workout row. Terminal statuses map to fixed tones (mirroring
+ * the web /workouts StatusPill); any pending phase is teal / in-flight.
+ */
+function statusBadge(w: WorkoutItem): { label: string; tone: BadgeTone } {
+  if (w.kind === "pending") return { label: w.status, tone: "teal" };
+  const map: Record<string, { label: string; tone: BadgeTone }> = {
+    success: { label: "Uploaded", tone: "success" },
+    manual: { label: "Marked synced", tone: "warm" },
+    skipped: { label: "Skipped", tone: "neutral" },
+    failed: { label: "Failed", tone: "danger" },
+  };
+  return map[w.status] ?? { label: w.status, tone: "neutral" };
+}
+
+/** Synced + in-flight workouts, from /api/workouts. Styled like the Sync screen. */
+export default function WorkoutsScreen() {
+  const { data, error, refetch } = useWorkouts();
+  const { refreshing, onRefresh } = usePullRefresh(refetch);
+  const workouts = data?.workouts ?? [];
+  const pending = workouts.filter((w) => w.kind === "pending").length;
+  const synced = workouts.length - pending;
+
+  return (
+    <ScrollView
+      className="flex-1 bg-base"
+      contentContainerClassName="items-center px-5 py-6"
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor="#77c8d1" />}
+    >
+      <View className="w-full max-w-2xl gap-4">
+        <View className="flex-row items-center gap-2">
+          <Text variant="headline">Workouts</Text>
+          {data && !data.dbConfigured ? <Badge label="No DB" tone="warm" /> : null}
+        </View>
+
+        {error ? (
+          <Card><Text variant="body" className="text-danger">API: {error} — is soma running on :3456?</Text></Card>
+        ) : null}
+
+        {/* Rollup */}
+        {workouts.length > 0 ? (
+          <Card className="gap-3">
+            <View className="flex-row justify-between">
+              {[
+                ["Total", `${workouts.length}`],
+                ["Synced", `${synced}`],
+                ["Pending", `${pending}`],
+              ].map(([label, val]) => (
+                <View key={label} className="items-center gap-0.5">
+                  <Text variant="micro" className="text-text-muted">{label}</Text>
+                  <Text variant="title" className="tabular-nums text-text">{val}</Text>
+                </View>
+              ))}
+            </View>
+          </Card>
+        ) : null}
+
+        {/* List — pending first, then terminal, each newest-first (server order). */}
+        <View className="gap-2">
+          {workouts.map((w) => {
+            const s = statusBadge(w);
+            return (
+              <Card key={w.hevy_id} className="gap-2">
+                <View className="flex-row items-center justify-between">
+                  <View className="flex-1 pr-2">
+                    <Text variant="body" className="text-text" numberOfLines={1}>
+                      {w.title || "Untitled workout"}
+                    </Text>
+                    <Text variant="micro">
+                      {fmtWhen(w.synced_at)}
+                      {w.calories != null ? ` · ${w.calories} kcal` : ""}
+                      {w.avg_hr != null ? ` · ${w.avg_hr} bpm` : ""}
+                    </Text>
+                    {w.detail ? (
+                      <Text variant="micro" className="text-text-secondary" numberOfLines={1}>{w.detail}</Text>
+                    ) : null}
+                  </View>
+                  <Badge label={s.label} tone={s.tone} />
+                </View>
+              </Card>
+            );
+          })}
+          {data && workouts.length === 0 ? (
+            <Card><Text variant="body" className="text-text-secondary">No workouts recorded yet.</Text></Card>
+          ) : null}
+          {!data && !error ? (
+            <Card><Text variant="body" className="text-text-muted">Loading…</Text></Card>
+          ) : null}
+        </View>
+      </View>
+    </ScrollView>
+  );
+}

--- a/universal/src/lib/api.ts
+++ b/universal/src/lib/api.ts
@@ -30,19 +30,79 @@ export interface HevyStatus {
   recent: HevyWorkout[];
 }
 
-export function useHevyStatus() {
-  const [data, setData] = useState<HevyStatus | null>(null);
+/**
+ * Small GET-JSON hook shared by every screen. Fetches `path` off API_BASE with
+ * the auth header, exposes { data, error, refetch }, and cancels in-flight state
+ * updates on unmount so a late response can't set state on a dead screen.
+ */
+function useApiGet<T>(path: string) {
+  const [data, setData] = useState<T | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [reload, setReload] = useState(0);
   useEffect(() => {
     let alive = true;
-    fetch(`${API_BASE}/api/hevy/status`, { headers: AUTH_HEADERS })
+    fetch(`${API_BASE}${path}`, { headers: AUTH_HEADERS })
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
-      .then((d: HevyStatus) => alive && (setData(d), setError(null)))
+      .then((d: T) => alive && (setData(d), setError(null)))
       .catch((e) => alive && setError(String(e.message ?? e)));
     return () => { alive = false; };
-  }, [reload]);
+  }, [path, reload]);
   return { data, error, refetch: () => setReload((n) => n + 1) };
+}
+
+export function useHevyStatus() {
+  return useApiGet<HevyStatus>("/api/hevy/status");
+}
+
+/** One custom exercise mapping (overrides the built-in map for that name). */
+export interface CustomMapping {
+  hevy_name: string;
+  category: number;
+  subcategory: number;
+}
+
+/** A sampled entry from the built-in HEVY_TO_GARMIN map. */
+export interface BuiltinMappingSample {
+  name: string;
+  category: number;
+  categoryName: string;
+}
+
+export interface MappingsData {
+  dbConfigured: boolean;
+  customCount: number;
+  builtinCount: number;
+  custom: CustomMapping[];
+  sample: BuiltinMappingSample[];
+}
+
+/** Exercise-mapping summary — custom overrides + built-in map, from /api/mappings. */
+export function useMappings() {
+  return useApiGet<MappingsData>("/api/mappings");
+}
+
+/** One synced (terminal) or in-flight (pending) workout row. */
+export interface WorkoutItem {
+  hevy_id: string;
+  title: string;
+  synced_at: string | null;
+  calories: number | null;
+  avg_hr: number | null;
+  garmin_activity_id: string | null;
+  /** Terminal status (success/manual/skipped) or a pending phase. */
+  status: string;
+  kind: "terminal" | "pending";
+  detail: string | null;
+}
+
+export interface WorkoutsData {
+  dbConfigured: boolean;
+  workouts: WorkoutItem[];
+}
+
+/** Synced + pending workouts, newest-first, from /api/workouts. */
+export function useWorkouts() {
+  return useApiGet<WorkoutsData>("/api/workouts");
 }
 
 /**

--- a/web/app/api/mappings/route.ts
+++ b/web/app/api/mappings/route.ts
@@ -1,0 +1,94 @@
+import { NextResponse } from "next/server";
+import { HEVY_TO_GARMIN } from "hevy2garmin";
+import { getDb } from "@/lib/db";
+import { categoryName } from "@/lib/garmin-categories";
+
+// Reads the live hevy2garmin Postgres at request time — never at build.
+export const dynamic = "force-dynamic";
+
+/**
+ * Exercise-mapping summary, mirroring the /mappings page but as JSON so the
+ * Expo companion app can render its own Mappings screen.
+ *
+ * Reads custom_mappings from the hevy2garmin Postgres (same table the web page
+ * uses) and counts the package's built-in HEVY_TO_GARMIN map. Shape matches
+ * `MappingsResponse` in hevy2garmin/universal/src/lib/api.ts.
+ *
+ * A read-only GET, kept consistent with /api/hevy/status (no extra auth of its
+ * own — the personal-token gate in front of /api/* covers the prod host).
+ */
+
+interface CustomMapping {
+  hevy_name: string;
+  category: number;
+  subcategory: number;
+}
+
+interface BuiltinSample {
+  name: string;
+  category: number;
+  categoryName: string;
+}
+
+interface MappingsResponse {
+  dbConfigured: boolean;
+  customCount: number;
+  builtinCount: number;
+  custom: CustomMapping[];
+  sample: BuiltinSample[];
+}
+
+export async function GET() {
+  // The built-in map ships with the package — available regardless of DB state.
+  const builtinEntries = Object.entries(HEVY_TO_GARMIN);
+  const sample: BuiltinSample[] = builtinEntries.slice(0, 12).map(([name, pair]) => ({
+    name,
+    category: pair[0],
+    categoryName: categoryName(pair[0]),
+  }));
+
+  const base: Omit<MappingsResponse, "dbConfigured" | "custom"> = {
+    customCount: 0,
+    builtinCount: builtinEntries.length,
+    sample,
+  };
+
+  let sql: ReturnType<typeof getDb>;
+  try {
+    sql = getDb();
+  } catch {
+    // No DATABASE_URL configured — built-in map still works, no custom rows.
+    return NextResponse.json({ dbConfigured: false, custom: [], ...base } satisfies MappingsResponse);
+  }
+
+  // `.catch` guards a missing custom_mappings table (fresh deploy that hasn't
+  // run the Python schema bootstrap yet).
+  const rows = await sql`
+    SELECT hevy_name, category, subcategory
+    FROM custom_mappings
+    ORDER BY hevy_name ASC
+  `.catch(
+    () =>
+      [] as Array<{
+        hevy_name: string;
+        category: number | string;
+        subcategory: number | string;
+      }>,
+  );
+
+  const custom: CustomMapping[] = rows.map((r) => ({
+    hevy_name: r.hevy_name,
+    category: Number(r.category),
+    subcategory: Number(r.subcategory),
+  }));
+
+  const body: MappingsResponse = {
+    dbConfigured: true,
+    customCount: custom.length,
+    builtinCount: base.builtinCount,
+    custom,
+    sample,
+  };
+
+  return NextResponse.json(body);
+}

--- a/web/app/api/workouts/route.ts
+++ b/web/app/api/workouts/route.ts
@@ -1,0 +1,121 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+
+// Reads the live hevy2garmin Postgres at request time — never at build.
+export const dynamic = "force-dynamic";
+
+/**
+ * Synced + in-flight workouts as JSON, mirroring the /workouts page query so the
+ * Expo companion app can render its own Workouts screen.
+ *
+ * Reads synced_workouts (terminal) and pending_uploads (in-flight) from the
+ * hevy2garmin Postgres — the same two tables the web /workouts page reads. Shape
+ * matches `WorkoutsResponse` in hevy2garmin/universal/src/lib/api.ts.
+ *
+ * A read-only GET, kept consistent with /api/hevy/status (the personal-token
+ * gate in front of /api/* covers the prod host).
+ */
+
+interface WorkoutItem {
+  hevy_id: string;
+  title: string;
+  synced_at: string | null;
+  calories: number | null;
+  avg_hr: number | null;
+  garmin_activity_id: string | null;
+  // Terminal status (success/manual/skipped) or a pending phase.
+  status: string;
+  kind: "terminal" | "pending";
+  detail: string | null;
+}
+
+interface WorkoutsResponse {
+  dbConfigured: boolean;
+  workouts: WorkoutItem[];
+}
+
+const EMPTY: WorkoutsResponse = { dbConfigured: false, workouts: [] };
+
+export async function GET() {
+  let sql: ReturnType<typeof getDb>;
+  try {
+    sql = getDb();
+  } catch {
+    // No DATABASE_URL configured — return sane defaults rather than a 500.
+    return NextResponse.json(EMPTY);
+  }
+
+  const [terminal, pending] = await Promise.all([
+    sql`
+      SELECT hevy_id, title, synced_at, calories, avg_hr, garmin_activity_id,
+             COALESCE(status, 'success') AS status
+      FROM synced_workouts
+      ORDER BY synced_at DESC
+      LIMIT 50
+    `.catch(
+      () =>
+        [] as Array<{
+          hevy_id: string;
+          title: string | null;
+          synced_at: string | null;
+          calories: number | null;
+          avg_hr: number | null;
+          garmin_activity_id: string | null;
+          status: string;
+        }>,
+    ),
+    sql`
+      SELECT hevy_id, phase, next_step, last_error, garmin_activity_id,
+             created_at,
+             (payload ->> 'title') AS payload_title
+      FROM pending_uploads
+      ORDER BY created_at DESC
+      LIMIT 50
+    `.catch(
+      () =>
+        [] as Array<{
+          hevy_id: string;
+          phase: string | null;
+          next_step: string | null;
+          last_error: string | null;
+          garmin_activity_id: string | null;
+          created_at: string | null;
+          payload_title: string | null;
+        }>,
+    ),
+  ]);
+
+  const pendingItems: WorkoutItem[] = pending.map((p) => ({
+    hevy_id: p.hevy_id,
+    title: p.payload_title ?? "",
+    synced_at: p.created_at ?? null,
+    calories: null,
+    avg_hr: null,
+    garmin_activity_id: p.garmin_activity_id ?? null,
+    status: p.phase ?? "pending",
+    kind: "pending",
+    detail: p.last_error ?? p.next_step ?? null,
+  }));
+
+  const pendingIds = new Set(pendingItems.map((p) => p.hevy_id));
+
+  const terminalItems: WorkoutItem[] = terminal
+    // A hevy_id in pending_uploads is mid-flight; prefer its pending row.
+    .filter((t) => !pendingIds.has(t.hevy_id))
+    .map((t) => ({
+      hevy_id: t.hevy_id,
+      title: t.title ?? "",
+      synced_at: t.synced_at ?? null,
+      calories: t.calories != null ? Number(t.calories) : null,
+      avg_hr: t.avg_hr != null ? Number(t.avg_hr) : null,
+      garmin_activity_id: t.garmin_activity_id ?? null,
+      status: t.status,
+      kind: "terminal",
+      detail: null,
+    }));
+
+  // Pending first (they need attention), then terminal, each newest-first.
+  const workouts = [...pendingItems, ...terminalItems].slice(0, 50);
+
+  return NextResponse.json({ dbConfigured: true, workouts } satisfies WorkoutsResponse);
+}


### PR DESCRIPTION
Adds Workouts + Mappings screens to the companion app (now 5 screens) + the /api/workouts + /api/mappings web endpoints they consume (mirror the web pages, .catch-guarded). web tsc 0 + next build clean (routes present); universal tsc 0 + expo export renders both. Closes #322
