### PR TITLE
fix(server): guard null daily HR in the dashboard HR endpoint (#326)

### DIFF
--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -1193,6 +1193,27 @@ async def workouts_page(request: Request):
     return _render("workouts.html", workouts=workouts, hr_fusion_enabled=hr_fusion, page=page, page_count=page_count, fetch_error=fetch_error)
 
 
+def _daily_hr_to_samples(daily_hr: object, start_ms: int, end_ms: int) -> list[dict]:
+    """Slice Garmin daily HR (``heartRateValues``) to a workout window.
+
+    Garmin returns ``{"heartRateValues": null}`` for a day with no wellness HR yet
+    (common for the current day, before all-day HR is populated), so the key is
+    present with value ``None`` and ``.get(..., [])`` does NOT fall back. Guard the
+    ``None`` before iterating so the endpoint returns an empty series instead of
+    crashing with "'NoneType' object is not iterable" (#326).
+    """
+    hr_values = daily_hr.get("heartRateValues") if isinstance(daily_hr, dict) else None
+    samples: list[dict] = []
+    for entry in hr_values or []:
+        if isinstance(entry, list) and len(entry) >= 2 and entry[1] is not None:
+            ts, bpm = entry[0], entry[1]
+            if start_ms - 60000 <= ts <= end_ms + 60000:  # ±1 min buffer
+                secs_from_start = (ts - start_ms) / 1000
+                samples.append({"time": max(0, secs_from_start), "hr": bpm})
+    samples.sort(key=lambda x: x["time"])
+    return samples
+
+
 @app.get("/api/workout/{hevy_id}/hr", response_class=HTMLResponse)
 async def api_workout_hr(request: Request, hevy_id: str):
     """Fetch HR data for a workout's matched Garmin activity. Returns JSON for Chart.js.
@@ -1252,17 +1273,7 @@ async def api_workout_hr(request: Request, hevy_id: str):
         # Fetch daily HR data and slice to workout window
         date_str = w_start[:10]
         daily_hr = limiter.call(garmin_client.get_heart_rates, date_str)
-        hr_values = daily_hr.get("heartRateValues", []) if isinstance(daily_hr, dict) else []
-
-        hr_samples = []
-        for entry in hr_values:
-            if isinstance(entry, list) and len(entry) >= 2 and entry[1] is not None:
-                ts, bpm = entry[0], entry[1]
-                if start_ms - 60000 <= ts <= end_ms + 60000:  # ±1 min buffer
-                    secs_from_start = (ts - start_ms) / 1000
-                    hr_samples.append({"time": max(0, secs_from_start), "hr": bpm})
-
-        hr_samples.sort(key=lambda x: x["time"])
+        hr_samples = _daily_hr_to_samples(daily_hr, start_ms, end_ms)
 
         # Build exercise segments — proportional to actual workout duration
         exercises = workout.get("exercises", [])

--- a/tests/test_hr_endpoint.py
+++ b/tests/test_hr_endpoint.py
@@ -1,0 +1,40 @@
+"""Tests for the dashboard HR endpoint's daily-HR slicing (#326).
+
+Garmin returns ``{"heartRateValues": null}`` for a day with no wellness HR yet
+(the current day, before all-day HR is populated). The endpoint used to iterate
+that value directly and crash with "'NoneType' object is not iterable"; these
+tests lock in the guard.
+"""
+
+from __future__ import annotations
+
+from hevy2garmin.server import _daily_hr_to_samples
+
+
+class TestDailyHrToSamples:
+    def test_null_heart_rate_values_returns_empty(self) -> None:
+        # Regression for #326: key present but value None must not crash.
+        assert _daily_hr_to_samples({"heartRateValues": None}, 0, 60_000) == []
+
+    def test_missing_key_returns_empty(self) -> None:
+        assert _daily_hr_to_samples({}, 0, 60_000) == []
+
+    def test_non_dict_returns_empty(self) -> None:
+        assert _daily_hr_to_samples(None, 0, 60_000) == []
+
+    def test_slices_to_window_and_skips_none_bpm(self) -> None:
+        start_ms, end_ms = 1_000_000, 1_060_000  # 60s window
+        daily_hr = {
+            "heartRateValues": [
+                [start_ms - 120_000, 70],   # before window (−2 min) → excluded
+                [start_ms + 10_000, 110],   # in window → included, t=10s
+                [start_ms + 30_000, None],  # None bpm → skipped
+                [start_ms + 50_000, 120],   # in window → included, t=50s
+                [end_ms + 120_000, 80],     # after window (+2 min) → excluded
+            ]
+        }
+        out = _daily_hr_to_samples(daily_hr, start_ms, end_ms)
+        assert out == [{"time": 10.0, "hr": 110}, {"time": 50.0, "hr": 120}]
+
+    def test_empty_list_returns_empty(self) -> None:
+        assert _daily_hr_to_samples({"heartRateValues": []}, 0, 60_000) == []


### PR DESCRIPTION
Fixes the dashboard HR crash reported in #326: "No HR data available: 'NoneType' object is not iterable" on the most recent workout, while older workouts show the benign "No HR samples found."

## Root cause

`/api/workout/{id}/hr` (the HR-fusion preview) fetches Garmin's daily/all-day HR and slices it to the workout window. For a day with no wellness HR yet (typically the current day, before all-day HR is populated), Garmin returns `{"heartRateValues": null}` — the key is present with value `null`, so `daily_hr.get("heartRateValues", [])` returns `None`, not the `[]` default. The next line iterates it (`for entry in hr_values`) and raises `'NoneType' object is not iterable`. That's exactly why the latest workout crashes and older days (which return a real list) don't.

The library HR path (`hr.py:116`) already guards this with `or []`; the dashboard endpoint's copy did not.

## Fix

Extract the slice into a small pure helper `_daily_hr_to_samples(daily_hr, start_ms, end_ms)` that guards the `None` (`for entry in hr_values or []`) before iterating. The endpoint now returns 200 with an empty series, so the UI shows the benign "No HR samples found for this workout." instead of the 500.

## Tests

New `tests/test_hr_endpoint.py` (5 cases): null `heartRateValues`, missing key, non-dict input, empty list, and a window-slice that skips out-of-window and null-bpm entries. Reproduced the original `TypeError` on the old code first, confirmed the helper returns `[]`. Full suite: 630 passed, 7 skipped.

Closes #326
