### PR TITLE
fix(merge): send probability 100 so Connect renders pushed exercise names (#325)

### DIFF
--- a/src/hevy2garmin/merge.py
+++ b/src/hevy2garmin/merge.py
@@ -338,8 +338,10 @@ def build_exercise_sets_payload(
         reps = s.get("reps")
         weight_kg = s.get("weight_kg")
 
+        # probability must be non-zero: Connect renders any exercise whose stored
+        # confidence is 0 as "Unknown" (#325). The web UI's own edits send 100.
         active_set: dict = {
-            "exercises": [{"category": cat_str, "name": sub_name, "probability": None}],
+            "exercises": [{"category": cat_str, "name": sub_name, "probability": 100}],
             "duration": round(scaled_dur, 3),
             "repetitionCount": int(reps) if reps is not None else 0,
             "weight": float(round(weight_kg * 1000)) if weight_kg else 0.0,

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -261,6 +261,9 @@ class TestBuildPayload:
                 continue
             for ex in s["exercises"]:
                 assert set(ex) == {"category", "name", "probability"}
+                # 0/null confidence makes Connect render the exercise as "Unknown"
+                # on watch-recorded activities (#325); the web UI's edits send 100
+                assert ex["probability"] == 100
                 assert isinstance(ex["category"], str) and ex["category"] != "UNKNOWN"
                 assert ex["name"] is None or isinstance(ex["name"], str)
                 # name must never echo the parent or the TOTAL_BODY placeholder


### PR DESCRIPTION
Closes #325.

## Fix

One line in `build_exercise_sets_payload`. It was sending `"probability": None`, Garmin stores that as 0, and Connect won't show a name it has 0 confidence in. Now it sends 100, same as what the web UI sends when you pick an exercise by hand.

Concerning [your comment](https://github.com/drkostas/hevy2garmin/issues/325#issuecomment-5376402298) about null-name generics, I went with 100 for those too. A generic set has no name for Garmin to be confidently wrong about, the confidence only applies to the category, and hiding the category behind the threshold is how a mapped-on-purpose generic like Pendlay Row `(23, 65535)` would end up showing "Unknown" instead of "Row". Garmin already does this with its own data, the auto-detected row that kicked off #328 was stored as category ROW, name null, probability 98.8, and displayed as "Row". Fair warning that I only tested named sets live, my repaired workout doesn't have a generic in it.

## Tests

The existing payload-shape test now also asserts probability is 100 on every active exercise, and it fails on the old code. Full suite: 630 passed, 7 skipped.

@frankzotynia10 said he was gonna post his results tomorrow morning, so it's probably best to wait for that before merging.
