### PR TITLE
fix(settings): default to merge + refresh watch-strategy copy

### DIFF
--- a/src/hevy2garmin/config.py
+++ b/src/hevy2garmin/config.py
@@ -45,15 +45,15 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "enabled": True,
     },
     "merge_activity_types": ["strength_training"],
-    # What to do when a workout was recorded on a watch (Garmin will not show
-    # pushed exercise names on those). One activity in every case (#159):
-    #   "replace" (default): upload one named activity and delete the watch
-    #       recording. Named exercises, but loses watch-only metrics.
-    #   "merge": push the sets/reps/weights into the watch activity and keep it.
-    #       Keeps all watch metrics; exercise names show as "Unknown".
+    # What to do when a workout was recorded on a watch. One activity in every
+    # case (#159):
+    #   "merge" (default): push the sets/reps/weights into the watch activity and
+    #       keep it. Keeps all watch metrics AND shows the exercise names (#325).
+    #   "replace": upload one named activity and delete the watch recording.
+    #       Named exercises, but loses watch-only metrics like training effect.
     #   "describe": keep the watch activity, only list exercises in its
     #       description (no structured sets).
-    "merge_watch_strategy": "replace",
+    "merge_watch_strategy": "merge",
 }
 
 

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -1385,7 +1385,7 @@ async def settings_save(
     merge_overlap_pct: int = Form(70),
     merge_max_drift_min: int = Form(20),
     merge_extra_types: str = Form(""),
-    merge_watch_strategy: str = Form("replace"),
+    merge_watch_strategy: str = Form("merge"),
 ):
     if is_demo_mode():
         return HTMLResponse('<div class="toast toast-error">Settings are read-only in demo mode</div>')
@@ -1416,7 +1416,7 @@ async def settings_save(
     config["merge_activity_types"] = ["strength_training"] + [
         t for t in dict.fromkeys(extra_types) if t != "strength_training"
     ]
-    config["merge_watch_strategy"] = merge_watch_strategy if merge_watch_strategy in ("replace", "merge", "describe") else "replace"
+    config["merge_watch_strategy"] = merge_watch_strategy if merge_watch_strategy in ("replace", "merge", "describe") else "merge"
     save_config(config)
 
     # Persist settings to DB on cloud (filesystem is read-only on Vercel)

--- a/src/hevy2garmin/sync.py
+++ b/src/hevy2garmin/sync.py
@@ -347,7 +347,7 @@ def sync_one_workout(
     merge_overlap_pct = cfg.get("merge_overlap_pct", 70) / 100.0
     merge_max_drift_min = cfg.get("merge_max_drift_min", 20)
     merge_activity_types = set(cfg.get("merge_activity_types", ["strength_training"]))
-    merge_watch_strategy = cfg.get("merge_watch_strategy", "replace")
+    merge_watch_strategy = cfg.get("merge_watch_strategy", "merge")
     description_enabled = cfg.get("description_enabled", True)
     hr_fusion_on = cfg.get("hr_fusion", {}).get("enabled", True)
 

--- a/src/hevy2garmin/templates/settings.html
+++ b/src/hevy2garmin/templates/settings.html
@@ -231,12 +231,12 @@
                     <div class="form-group">
                         <label class="form-label" for="merge_watch_strategy">Workouts recorded on a watch</label>
                         <select class="form-input" id="merge_watch_strategy" name="merge_watch_strategy">
-                            <option value="replace" {{ 'selected' if config.get('merge_watch_strategy', 'replace') == 'replace' }}>Replace with one named activity (named exercises)</option>
-                            <option value="merge" {{ 'selected' if config.get('merge_watch_strategy', 'replace') == 'merge' }}>Merge sets into the watch activity (keeps watch metrics)</option>
-                            <option value="describe" {{ 'selected' if config.get('merge_watch_strategy', 'replace') == 'describe' }}>Keep the watch activity, list exercises in its description</option>
+                            <option value="merge" {{ 'selected' if config.get('merge_watch_strategy', 'merge') == 'merge' }}>Merge sets into the watch activity (keeps watch metrics + names, recommended)</option>
+                            <option value="replace" {{ 'selected' if config.get('merge_watch_strategy', 'merge') == 'replace' }}>Replace with one named activity (named exercises, loses watch metrics)</option>
+                            <option value="describe" {{ 'selected' if config.get('merge_watch_strategy', 'merge') == 'describe' }}>Keep the watch activity, list exercises in its description</option>
                         </select>
                         <div class="form-hint">
-                            Garmin does not show exercise names on a workout your watch recorded, so you always end up with one activity but with a tradeoff. <strong>Replace</strong> uploads one named activity (with your heart rate) and deletes the watch copy, so exercises are named, but you lose watch-only metrics like training effect. <strong>Merge sets</strong> pushes the sets, reps, and weights into the watch activity and keeps it, so you keep all watch metrics and structured set data, but the exercise names show as "Unknown". <strong>Keep + describe</strong> leaves the watch activity untouched and only lists the exercises in its description, with no structured sets.
+                            After a workout your watch recorded, all three give you a single activity, they differ in what they keep. <strong>Merge sets</strong> (recommended) pushes your sets, reps, and weights into the watch activity and keeps it, so you keep the watch's heart rate and native metrics like training effect and body battery, and your exercises show with their names and full set data. <strong>Replace</strong> uploads a fresh named activity with your heart rate and deletes the watch copy, so you get named exercises but lose the watch-only metrics. <strong>Keep + describe</strong> leaves the watch activity untouched and only lists the exercises in its description, with no structured sets.
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Follow-up to #330. Now that merge mode shows exercise names and keeps the watch's native metrics, it's the best option for a watch-recorded workout, so:

- Default watch strategy flipped `replace` -> `merge` (config.py, plus the settings form and sync fallbacks for consistency).
- Refreshed the settings copy: the old text claiming "Garmin does not show exercise names" and "merge = Unknown names" is false after #330. Merge is now listed first and marked recommended.
- Kept replace and describe as options for anyone who prefers them.

Prompted by @bojanmk1 on #325. No test pinned the default; full suite 632 passed.

Closes #331
