### PR TITLE
test: regression corpus from a real Hevy history

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=8.0", "pytest-mock>=3.12", "httpx>=0.27"]
+dev = ["pytest>=8.0", "pytest-mock>=3.12", "httpx>=0.27",
+       "garmin-fit-sdk>=21.0"]  # FIT ground truth for tests/test_real_workout_fixtures.py
 cloud = ["psycopg2-binary>=2.9", "pynacl>=1.5"]
 audit = ["garmin-fit-sdk>=21.0"]  # ground truth for scripts/audit_mappings.py --regenerate-catalog
 

--- a/scripts/export_workout_fixtures.py
+++ b/scripts/export_workout_fixtures.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Regenerate tests/fixtures/real_workouts.json from the live Hevy account.
+
+Fetches the complete workout history via the Hevy API and strips it down to
+what the fixture tests need, then ANONYMIZES it — the repo is public, so no
+personal training log may land in git:
+
+- workout ids/titles become synthetic ("fixture-0000" / "Workout 01"),
+- start times move to a synthetic weekly schedule (durations preserved),
+- weights are rounded to 2.5 kg.
+
+Exercise titles and template ids are Hevy's standard catalog names — they are
+the data under test and stay verbatim.
+
+Usage:
+    HEVY_API_KEY=... python scripts/export_workout_fixtures.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import requests
+
+SET_KEYS = ("index", "type", "weight_kg", "reps", "distance_meters", "duration_seconds", "rpe")
+OUT = Path(__file__).resolve().parent.parent / "tests" / "fixtures" / "real_workouts.json"
+
+
+def anonymize(workouts: list[dict]) -> list[dict]:
+    """Strip personal data while keeping every property the tests exercise."""
+    base = datetime(2025, 1, 6, 18, 0, tzinfo=timezone.utc)  # an arbitrary Monday
+    out = []
+    for i, w in enumerate(sorted(workouts, key=lambda x: x["start_time"])):
+        start = datetime.fromisoformat(w["start_time"].replace("Z", "+00:00"))
+        end = datetime.fromisoformat(w["end_time"].replace("Z", "+00:00"))
+        new_start = base + timedelta(days=7 * i)
+        exercises = []
+        for e in w["exercises"]:
+            sets = []
+            for s in e["sets"]:
+                s2 = dict(s)
+                if s2.get("weight_kg") is not None:
+                    s2["weight_kg"] = round(s2["weight_kg"] / 2.5) * 2.5
+                sets.append(s2)
+            exercises.append({**e, "sets": sets})
+        out.append(
+            {
+                "id": f"fixture-{i:04d}",
+                "title": f"Workout {i + 1:02d}",
+                "start_time": new_start.isoformat().replace("+00:00", "Z"),
+                "end_time": (new_start + (end - start)).isoformat().replace("+00:00", "Z"),
+                "exercises": exercises,
+            }
+        )
+    return out
+
+
+def main() -> int:
+    api_key = os.environ.get("HEVY_API_KEY")
+    if not api_key:
+        print("HEVY_API_KEY not set", file=sys.stderr)
+        return 1
+
+    workouts: list[dict] = []
+    page = 1
+    while True:
+        resp = requests.get(
+            "https://api.hevyapp.com/v1/workouts",
+            headers={"api-key": api_key},
+            params={"page": page, "pageSize": 10},
+            timeout=20,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        workouts.extend(data.get("workouts", []))
+        if page >= data.get("page_count", 1):
+            break
+        page += 1
+
+    sanitized = [
+        {
+            "id": w["id"],
+            "title": w["title"],
+            "start_time": w["start_time"],
+            "end_time": w["end_time"],
+            "exercises": [
+                {
+                    "index": e.get("index"),
+                    "title": e.get("title"),
+                    "exercise_template_id": e.get("exercise_template_id"),
+                    "sets": [{k: s.get(k) for k in SET_KEYS} for s in e.get("sets", [])],
+                }
+                for e in w.get("exercises", [])
+            ],
+        }
+        for w in workouts
+    ]
+    sanitized = anonymize(sanitized)
+
+    OUT.write_text(json.dumps(sanitized, indent=1, ensure_ascii=False) + "\n")
+    n_ex = sum(len(w["exercises"]) for w in sanitized)
+    print(f"wrote {OUT.relative_to(Path.cwd()) if OUT.is_relative_to(Path.cwd()) else OUT}: "
+          f"{len(sanitized)} workouts, {n_ex} exercises")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/real_workouts.json
+++ b/tests/fixtures/real_workouts.json
@@ -1,0 +1,4969 @@
+[
+ {
+  "id": "fixture-0000",
+  "title": "Workout 01",
+  "start_time": "2025-01-06T18:00:00Z",
+  "end_time": "2025-01-06T19:07:05Z",
+  "exercises": [
+   {
+    "index": 0,
+    "title": "Hip Abduction (Machine)",
+    "exercise_template_id": "F4B4C6EE",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 75.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 105.0,
+      "reps": 13,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 105.0,
+      "reps": 11,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 1,
+    "title": "Seated Leg Curl (Machine)",
+    "exercise_template_id": "11A123F3",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 2,
+    "title": "Hip Thrust (Machine)",
+    "exercise_template_id": "68CE0B9B",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 3,
+    "title": "Seated Row (Machine)",
+    "exercise_template_id": "1DF4A847",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 8,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 4,
+    "title": "Lat Pulldown (Machine)",
+    "exercise_template_id": "473CF5B8",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 8,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 7,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 5,
+    "title": "Seated Shoulder Press (Machine)",
+    "exercise_template_id": "9237BAD1",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 35.0,
+      "reps": 8,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 8,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 6,
+    "title": "Chest Fly (Machine)",
+    "exercise_template_id": "78683336",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 50.0,
+      "reps": 4,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 45.0,
+      "reps": 4,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 6,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 7,
+    "title": "Rear Delt Reverse Fly (Machine)",
+    "exercise_template_id": "D8281C62",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 7,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 8,
+    "title": "Crunch (Machine)",
+    "exercise_template_id": "EB43ADD4",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 15,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 9,
+    "title": "Back Extension (Machine)",
+    "exercise_template_id": "A05C064D",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 50.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 50.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 50.0,
+      "reps": 15,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 10,
+    "title": "Back Extension (Weighted Hyperextension)",
+    "exercise_template_id": "091737FA",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 9,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 7,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 7,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   }
+  ]
+ },
+ {
+  "id": "fixture-0001",
+  "title": "Workout 02",
+  "start_time": "2025-01-13T18:00:00Z",
+  "end_time": "2025-01-13T18:56:06Z",
+  "exercises": [
+   {
+    "index": 0,
+    "title": "Lat Pulldown (Machine)",
+    "exercise_template_id": "473CF5B8",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 9,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 1,
+    "title": "Crunch (Machine)",
+    "exercise_template_id": "EB43ADD4",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 2,
+    "title": "Hip Thrust (Machine)",
+    "exercise_template_id": "68CE0B9B",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 11,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 3,
+    "title": "Seated Row (Machine)",
+    "exercise_template_id": "1DF4A847",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 9,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 8,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 4,
+    "title": "Chest Fly (Machine)",
+    "exercise_template_id": "78683336",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 6,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 5,
+    "title": "Rear Delt Reverse Fly (Machine)",
+    "exercise_template_id": "D8281C62",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 8,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 6,
+    "title": "Leg Extension (Machine)",
+    "exercise_template_id": "75A4F6C4",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 50.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 7,
+    "title": "Chest Press (Machine)",
+    "exercise_template_id": "7EB3F7C3",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 7,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 8,
+    "title": "Back Extension (Weighted Hyperextension)",
+    "exercise_template_id": "091737FA",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 9,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 8,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   }
+  ]
+ },
+ {
+  "id": "fixture-0002",
+  "title": "Workout 03",
+  "start_time": "2025-01-20T18:00:00Z",
+  "end_time": "2025-01-20T19:12:36Z",
+  "exercises": [
+   {
+    "index": 0,
+    "title": "Chest Press (Machine)",
+    "exercise_template_id": "7EB3F7C3",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 30.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 1,
+    "title": "Overhead Press (Dumbbell)",
+    "exercise_template_id": "6AC96645",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 12.5,
+      "reps": 4,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 7,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 6,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 2,
+    "title": "Hip Thrust (Machine)",
+    "exercise_template_id": "68CE0B9B",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 45.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 45.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 45.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 3,
+    "title": "Seated Shoulder Press (Machine)",
+    "exercise_template_id": "9237BAD1",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 9,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 6,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 6,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 4,
+    "title": "Leg Press Horizontal (Machine)",
+    "exercise_template_id": "0EB695C9",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 85.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 100.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 100.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 100.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 5,
+    "title": "Back Extension (Weighted Hyperextension)",
+    "exercise_template_id": "091737FA",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 9,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 8,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 6,
+    "title": "Seated Leg Curl (Machine)",
+    "exercise_template_id": "11A123F3",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 7,
+    "title": "Farmers Walk",
+    "exercise_template_id": "50C613D0",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 25.0,
+      "reps": null,
+      "distance_meters": 40,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 25.0,
+      "reps": null,
+      "distance_meters": 40,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 25.0,
+      "reps": null,
+      "distance_meters": 40,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 8,
+    "title": "Lunge (Dumbbell)",
+    "exercise_template_id": "B537D09F",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 4,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 5,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   }
+  ]
+ },
+ {
+  "id": "fixture-0003",
+  "title": "Workout 04",
+  "start_time": "2025-01-27T18:00:00Z",
+  "end_time": "2025-01-27T18:59:14Z",
+  "exercises": [
+   {
+    "index": 0,
+    "title": "Seated Shoulder Press (Machine)",
+    "exercise_template_id": "9237BAD1",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 8,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 1,
+    "title": "Seated Row (Machine)",
+    "exercise_template_id": "1DF4A847",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 9,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 2,
+    "title": "Lat Pulldown (Machine)",
+    "exercise_template_id": "473CF5B8",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 9,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 6,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 3,
+    "title": "Back Extension (Weighted Hyperextension)",
+    "exercise_template_id": "091737FA",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 9,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 4,
+    "title": "Rear Delt Reverse Fly (Machine)",
+    "exercise_template_id": "D8281C62",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 5,
+    "title": "Chest Fly (Machine)",
+    "exercise_template_id": "78683336",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 6,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 6,
+    "title": "Crunch (Machine)",
+    "exercise_template_id": "EB43ADD4",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 7,
+    "title": "Lunge (Dumbbell)",
+    "exercise_template_id": "B537D09F",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 4,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 5,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 8,
+    "title": "Chest Press (Machine)",
+    "exercise_template_id": "7EB3F7C3",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 30.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   }
+  ]
+ },
+ {
+  "id": "fixture-0004",
+  "title": "Workout 05",
+  "start_time": "2025-02-03T18:00:00Z",
+  "end_time": "2025-02-03T18:48:34Z",
+  "exercises": [
+   {
+    "index": 0,
+    "title": "Chest Press (Machine)",
+    "exercise_template_id": "7EB3F7C3",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 30.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 1,
+    "title": "Lat Pulldown (Machine)",
+    "exercise_template_id": "473CF5B8",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 50.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 80.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 80.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 80.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 2,
+    "title": "Triceps Rope Pushdown",
+    "exercise_template_id": "94B7239B",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 25.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 25.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 25.0,
+      "reps": 11,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 3,
+    "title": "Seated Row (Machine)",
+    "exercise_template_id": "1DF4A847",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 9,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 4,
+    "title": "Bicep Curl (Dumbbell)",
+    "exercise_template_id": "37FCC2BB",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 12.5,
+      "reps": 9,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 12.5,
+      "reps": 9,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 12.5,
+      "reps": 8,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 5,
+    "title": "Cable Core Pallof Press",
+    "exercise_template_id": "CC55119B",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 20,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 6,
+    "title": "Back Extension (Weighted Hyperextension)",
+    "exercise_template_id": "091737FA",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 7,
+    "title": "Crunch (Machine)",
+    "exercise_template_id": "EB43ADD4",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 15,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 14,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   }
+  ]
+ },
+ {
+  "id": "fixture-0005",
+  "title": "Workout 06",
+  "start_time": "2025-02-10T18:00:00Z",
+  "end_time": "2025-02-10T18:40:10Z",
+  "exercises": [
+   {
+    "index": 0,
+    "title": "Lat Pulldown (Machine)",
+    "exercise_template_id": "473CF5B8",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 60.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 85.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 85.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 85.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 1,
+    "title": "Chest Press (Machine)",
+    "exercise_template_id": "7EB3F7C3",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 30.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 2,
+    "title": "Seated Shoulder Press (Machine)",
+    "exercise_template_id": "9237BAD1",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 9,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 8,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 3,
+    "title": "Chest Fly (Machine)",
+    "exercise_template_id": "78683336",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 9,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 6,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 4,
+    "title": "Rear Delt Reverse Fly (Machine)",
+    "exercise_template_id": "D8281C62",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 5,
+    "title": "Crunch (Machine)",
+    "exercise_template_id": "EB43ADD4",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 65.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 65.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 65.0,
+      "reps": 11,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 6,
+    "title": "Back Extension (Weighted Hyperextension)",
+    "exercise_template_id": "091737FA",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   }
+  ]
+ },
+ {
+  "id": "fixture-0006",
+  "title": "Workout 07",
+  "start_time": "2025-02-17T18:00:00Z",
+  "end_time": "2025-02-17T18:46:42Z",
+  "exercises": [
+   {
+    "index": 0,
+    "title": "Seated Shoulder Press (Machine)",
+    "exercise_template_id": "9237BAD1",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 20.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 1,
+    "title": "Chest Press (Machine)",
+    "exercise_template_id": "7EB3F7C3",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 30.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 2,
+    "title": "Lat Pulldown (Machine)",
+    "exercise_template_id": "473CF5B8",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 70.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 3,
+    "title": "Crunch (Machine)",
+    "exercise_template_id": "EB43ADD4",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 65.0,
+      "reps": 15,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 65.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 65.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 65.0,
+      "reps": 9,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 4,
+    "title": "Hip Thrust (Machine)",
+    "exercise_template_id": "68CE0B9B",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 50.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 50.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 50.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 5,
+    "title": "Back Extension (Weighted Hyperextension)",
+    "exercise_template_id": "091737FA",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 6,
+    "title": "Seated Row (Machine)",
+    "exercise_template_id": "1DF4A847",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   }
+  ]
+ },
+ {
+  "id": "fixture-0007",
+  "title": "Workout 08",
+  "start_time": "2025-02-24T18:00:00Z",
+  "end_time": "2025-02-24T19:09:35Z",
+  "exercises": [
+   {
+    "index": 0,
+    "title": "Lat Pulldown (Machine)",
+    "exercise_template_id": "473CF5B8",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 70.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 1,
+    "title": "Crunch (Machine)",
+    "exercise_template_id": "EB43ADD4",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 65.0,
+      "reps": 15,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 65.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 65.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 65.0,
+      "reps": 8,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 2,
+    "title": "Seated Shoulder Press (Machine)",
+    "exercise_template_id": "9237BAD1",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 25.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 8,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 3,
+    "title": "Seated Row (Machine)",
+    "exercise_template_id": "1DF4A847",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 4,
+    "title": "Back Extension (Weighted Hyperextension)",
+    "exercise_template_id": "091737FA",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 5,
+    "title": "Lunge (Dumbbell)",
+    "exercise_template_id": "B537D09F",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 4,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 5,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 6,
+    "title": "Chest Press (Machine)",
+    "exercise_template_id": "7EB3F7C3",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 30.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 7,
+    "title": "Rear Delt Reverse Fly (Machine)",
+    "exercise_template_id": "D8281C62",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 9,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 8,
+    "title": "Chest Fly (Machine)",
+    "exercise_template_id": "78683336",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 7,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   }
+  ]
+ },
+ {
+  "id": "fixture-0008",
+  "title": "Workout 09",
+  "start_time": "2025-03-03T18:00:00Z",
+  "end_time": "2025-03-03T18:49:04Z",
+  "exercises": [
+   {
+    "index": 0,
+    "title": "Lat Pulldown (Machine)",
+    "exercise_template_id": "473CF5B8",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 70.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 85.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 85.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 85.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 1,
+    "title": "Seated Shoulder Press (Machine)",
+    "exercise_template_id": "9237BAD1",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 25.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 25.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 25.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 2,
+    "title": "Crunch (Machine)",
+    "exercise_template_id": "EB43ADD4",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 65.0,
+      "reps": 13,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 65.0,
+      "reps": 11,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 65.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 65.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 3,
+    "title": "Chest Press (Machine)",
+    "exercise_template_id": "7EB3F7C3",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 4,
+    "title": "Back Extension (Weighted Hyperextension)",
+    "exercise_template_id": "091737FA",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 5,
+    "title": "Kettlebell Goblet Squat",
+    "exercise_template_id": "A127DA73",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 20.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 20.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 20.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 6,
+    "title": "Farmers Walk",
+    "exercise_template_id": "50C613D0",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 25.0,
+      "reps": null,
+      "distance_meters": 40,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 25.0,
+      "reps": null,
+      "distance_meters": 40,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 25.0,
+      "reps": null,
+      "distance_meters": 40,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   }
+  ]
+ },
+ {
+  "id": "fixture-0009",
+  "title": "Workout 10",
+  "start_time": "2025-03-10T18:00:00Z",
+  "end_time": "2025-03-10T18:56:48Z",
+  "exercises": [
+   {
+    "index": 0,
+    "title": "Lat Pulldown (Machine)",
+    "exercise_template_id": "473CF5B8",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 70.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 1,
+    "title": "Seated Shoulder Press (Machine)",
+    "exercise_template_id": "9237BAD1",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 25.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 9,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 2,
+    "title": "Crunch (Machine)",
+    "exercise_template_id": "EB43ADD4",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 70.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 70.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 70.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 70.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 3,
+    "title": "Seated Row (Machine)",
+    "exercise_template_id": "1DF4A847",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 4,
+    "title": "Chest Fly (Machine)",
+    "exercise_template_id": "78683336",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 6,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 5,
+    "title": "Rear Delt Reverse Fly (Machine)",
+    "exercise_template_id": "D8281C62",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 9,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 6,
+    "title": "Back Extension (Weighted Hyperextension)",
+    "exercise_template_id": "091737FA",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 7,
+    "title": "Farmers Walk",
+    "exercise_template_id": "50C613D0",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 25.0,
+      "reps": null,
+      "distance_meters": 40,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 25.0,
+      "reps": null,
+      "distance_meters": 40,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 25.0,
+      "reps": null,
+      "distance_meters": 40,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   }
+  ]
+ },
+ {
+  "id": "fixture-0010",
+  "title": "Workout 11",
+  "start_time": "2025-03-17T18:00:00Z",
+  "end_time": "2025-03-17T18:49:42Z",
+  "exercises": [
+   {
+    "index": 0,
+    "title": "Chest Press (Machine)",
+    "exercise_template_id": "7EB3F7C3",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 45.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 45.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 1,
+    "title": "Seated Shoulder Press (Machine)",
+    "exercise_template_id": "9237BAD1",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 25.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 2,
+    "title": "Crunch (Machine)",
+    "exercise_template_id": "EB43ADD4",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 70.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 70.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 70.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 70.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 3,
+    "title": "Seated Row (Machine)",
+    "exercise_template_id": "1DF4A847",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 4,
+    "title": "Lat Pulldown (Machine)",
+    "exercise_template_id": "473CF5B8",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 70.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 8,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 7,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 5,
+    "title": "Back Extension (Weighted Hyperextension)",
+    "exercise_template_id": "091737FA",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 6,
+    "title": "Seated Leg Curl (Machine)",
+    "exercise_template_id": "11A123F3",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 7,
+    "title": "Farmers Walk",
+    "exercise_template_id": "50C613D0",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 25.0,
+      "reps": null,
+      "distance_meters": 40,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 25.0,
+      "reps": null,
+      "distance_meters": 40,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 25.0,
+      "reps": null,
+      "distance_meters": 40,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   }
+  ]
+ },
+ {
+  "id": "fixture-0011",
+  "title": "Workout 12",
+  "start_time": "2025-03-24T18:00:00Z",
+  "end_time": "2025-03-24T19:06:19Z",
+  "exercises": [
+   {
+    "index": 0,
+    "title": "Lat Pulldown (Machine)",
+    "exercise_template_id": "473CF5B8",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 70.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 1,
+    "title": "Chest Press (Machine)",
+    "exercise_template_id": "7EB3F7C3",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 35.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 45.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 45.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 45.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 2,
+    "title": "Seated Shoulder Press (Machine)",
+    "exercise_template_id": "9237BAD1",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 25.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 9,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 3,
+    "title": "Crunch (Machine)",
+    "exercise_template_id": "EB43ADD4",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 70.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 70.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 70.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 70.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 4,
+    "title": "Seated Leg Curl (Machine)",
+    "exercise_template_id": "11A123F3",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 5,
+    "title": "Seated Row (Machine)",
+    "exercise_template_id": "1DF4A847",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 6,
+    "title": "Back Extension (Weighted Hyperextension)",
+    "exercise_template_id": "091737FA",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 7,
+    "title": "Farmers Walk",
+    "exercise_template_id": "50C613D0",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 25.0,
+      "reps": null,
+      "distance_meters": 40,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 25.0,
+      "reps": null,
+      "distance_meters": 40,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 25.0,
+      "reps": null,
+      "distance_meters": 40,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 8,
+    "title": "Walking Lunge (Sandbag)",
+    "exercise_template_id": "F30A4F01",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 25.0,
+      "reps": null,
+      "distance_meters": 40,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 25.0,
+      "reps": null,
+      "distance_meters": 40,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 25.0,
+      "reps": null,
+      "distance_meters": 40,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   }
+  ]
+ },
+ {
+  "id": "fixture-0012",
+  "title": "Workout 13",
+  "start_time": "2025-03-31T18:00:00Z",
+  "end_time": "2025-03-31T19:03:57Z",
+  "exercises": [
+   {
+    "index": 0,
+    "title": "Chest Press (Machine)",
+    "exercise_template_id": "7EB3F7C3",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 35.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 45.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 45.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 45.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 1,
+    "title": "Seated Shoulder Press (Machine)",
+    "exercise_template_id": "9237BAD1",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 25.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 2,
+    "title": "Seated Leg Curl (Machine)",
+    "exercise_template_id": "11A123F3",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 3,
+    "title": "Leg Press Horizontal (Machine)",
+    "exercise_template_id": "0EB695C9",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 52.5,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 85.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 85.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 85.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 4,
+    "title": "Lat Pulldown (Machine)",
+    "exercise_template_id": "473CF5B8",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 70.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 5,
+    "title": "Seated Row (Machine)",
+    "exercise_template_id": "1DF4A847",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 60.0,
+      "reps": 9,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 9,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 6,
+    "title": "Crunch (Machine)",
+    "exercise_template_id": "EB43ADD4",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 70.0,
+      "reps": 12,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 70.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 70.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 70.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 7,
+    "title": "Goblet Squat",
+    "exercise_template_id": "3D0C7C75",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 20.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 20.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 20.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 8,
+    "title": "Walking Lunge (Sandbag)",
+    "exercise_template_id": "F30A4F01",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": null,
+      "distance_meters": 40,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": null,
+      "distance_meters": 40,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   }
+  ]
+ },
+ {
+  "id": "fixture-0013",
+  "title": "Workout 14",
+  "start_time": "2025-04-07T18:00:00Z",
+  "end_time": "2025-04-07T18:52:10Z",
+  "exercises": [
+   {
+    "index": 0,
+    "title": "Lat Pulldown (Machine)",
+    "exercise_template_id": "473CF5B8",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 70.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 1,
+    "title": "Seated Shoulder Press (Machine)",
+    "exercise_template_id": "9237BAD1",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 25.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 2,
+    "title": "Seated Row (Machine)",
+    "exercise_template_id": "1DF4A847",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 3,
+    "title": "Crunch (Machine)",
+    "exercise_template_id": "EB43ADD4",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 70.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 70.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 70.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 70.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 4,
+    "title": "Back Extension (Weighted Hyperextension)",
+    "exercise_template_id": "091737FA",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 5,
+    "title": "Goblet Squat",
+    "exercise_template_id": "3D0C7C75",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 6,
+    "title": "Chest Press (Machine)",
+    "exercise_template_id": "7EB3F7C3",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 35.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 45.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 45.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 7,
+    "title": "Reverse Lunge (Dumbbell)",
+    "exercise_template_id": "FFDA283B",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   }
+  ]
+ },
+ {
+  "id": "fixture-0014",
+  "title": "Workout 15",
+  "start_time": "2025-04-14T18:00:00Z",
+  "end_time": "2025-04-14T19:06:16Z",
+  "exercises": [
+   {
+    "index": 0,
+    "title": "Seated Row (Machine)",
+    "exercise_template_id": "1DF4A847",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 45.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 55.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 1,
+    "title": "Chest Press (Machine)",
+    "exercise_template_id": "7EB3F7C3",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 35.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 45.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 45.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 45.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 2,
+    "title": "Seated Shoulder Press (Machine)",
+    "exercise_template_id": "9237BAD1",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 25.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 3,
+    "title": "Crunch (Machine)",
+    "exercise_template_id": "EB43ADD4",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 70.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 70.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 70.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 70.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 4,
+    "title": "Lat Pulldown (Machine)",
+    "exercise_template_id": "473CF5B8",
+    "sets": [
+     {
+      "index": 0,
+      "type": "warmup",
+      "weight_kg": 80.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 90.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 5,
+    "title": "Back Extension (Weighted Hyperextension)",
+    "exercise_template_id": "091737FA",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 10.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 6,
+    "title": "Goblet Squat",
+    "exercise_template_id": "3D0C7C75",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 7,
+    "title": "Reverse Lunge (Dumbbell)",
+    "exercise_template_id": "FFDA283B",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 3,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 4,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 5,
+      "type": "normal",
+      "weight_kg": 15.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 8,
+    "title": "Chest Fly (Machine)",
+    "exercise_template_id": "78683336",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 40.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   },
+   {
+    "index": 9,
+    "title": "Rear Delt Reverse Fly (Machine)",
+    "exercise_template_id": "D8281C62",
+    "sets": [
+     {
+      "index": 0,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 1,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     },
+     {
+      "index": 2,
+      "type": "normal",
+      "weight_kg": 30.0,
+      "reps": 10,
+      "distance_meters": null,
+      "duration_seconds": null,
+      "rpe": null
+     }
+    ]
+   }
+  ]
+ }
+]

--- a/tests/test_real_workout_fixtures.py
+++ b/tests/test_real_workout_fixtures.py
@@ -1,0 +1,91 @@
+"""Integration tests over the real (sanitized) Hevy workout history.
+
+``tests/fixtures/real_workouts.json`` is a real Hevy workout history, exported
+and anonymized (ids and titles synthetic, dates moved to a synthetic weekly
+schedule, weights rounded — see ``scripts/export_workout_fixtures.py``). What
+survives is exactly what these tests exercise: exercise titles, template ids and
+set structures. No notes, descriptions or account data.
+
+Synthetic fixtures test the mapper against the cases we thought of. This corpus
+tests it against the ones a real training log actually contains, which is where
+the mapping and FIT-generation bugs kept surfacing — a template id that maps to
+a category the FIT SDK does not define, or an exercise whose sets encode to an
+empty file.
+
+Regenerate or extend it against your own account with
+``HEVY_API_KEY=... python scripts/export_workout_fixtures.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hevy2garmin.fit import generate_fit
+from hevy2garmin.mapper import lookup_exercise
+
+FIXTURES = Path(__file__).parent / "fixtures" / "real_workouts.json"
+UNKNOWN = 65534
+
+
+def _workouts() -> list[dict]:
+    return json.loads(FIXTURES.read_text())
+
+
+def _distinct_exercises() -> list[tuple[str, str | None]]:
+    seen: dict[tuple[str, str | None], None] = {}
+    for w in _workouts():
+        for e in w["exercises"]:
+            seen.setdefault((e["title"], e.get("exercise_template_id")))
+    return list(seen)
+
+
+def test_fixture_corpus_is_nonempty() -> None:
+    ws = _workouts()
+    assert len(ws) >= 10
+    assert sum(len(w["exercises"]) for w in ws) >= 50
+
+
+@pytest.mark.parametrize(
+    ("title", "template_id"),
+    _distinct_exercises(),
+    ids=[t for t, _ in _distinct_exercises()],
+)
+def test_every_real_exercise_is_mapped(title: str, template_id: str | None) -> None:
+    cat, _sub, _ = lookup_exercise(title, template_id)
+    assert cat != UNKNOWN, f"{title!r} ({template_id}) has no Garmin mapping"
+
+
+@pytest.mark.parametrize(
+    ("title", "template_id"),
+    _distinct_exercises(),
+    ids=[t for t, _ in _distinct_exercises()],
+)
+def test_every_mapping_is_a_valid_fit_pair(title: str, template_id: str | None) -> None:
+    """Validate (category, subcategory) against the official FIT SDK catalog.
+
+    Ground truth is garmin-fit-sdk, NOT the runtime fit-tool dependency —
+    fit-tool's bundled profile is a stale snapshot (categories stop at 32) and
+    reports false invalids for every cardio-machine category.
+    """
+    garmin_fit_sdk = pytest.importorskip("garmin_fit_sdk")
+    types = garmin_fit_sdk.Profile["types"]
+
+    cat, sub, _ = lookup_exercise(title, template_id)
+    cat_name = types["exercise_category"].get(cat)
+    assert cat_name is not None, f"{title!r}: category {cat} not in FIT SDK"
+    sub_names = types.get(f"{cat_name}_exercise_name", {})
+    assert sub in sub_names, (
+        f"{title!r}: ({cat}={cat_name}, {sub}) — subcategory not in FIT SDK enum"
+    )
+
+
+def test_fit_generation_over_full_history(tmp_path: Path) -> None:
+    """Every real workout must encode to a non-trivial FIT file."""
+    for w in _workouts():
+        out = tmp_path / f"{w['id']}.fit"
+        result = generate_fit(w, hr_samples=None, output_path=str(out))
+        assert out.exists() and out.stat().st_size > 200, w["title"]
+        assert result.get("exercises", len(w["exercises"])) or True


### PR DESCRIPTION
Closes #333

Adds an anonymized corpus exported from a real Hevy history — 15 workouts, 128 exercises, 24 distinct exercises — and asserts over it that every exercise resolves to a Garmin category, every resolved `(category, subcategory)` exists in the official FIT SDK enums, and every workout encodes to a non-trivial FIT file.

The value is coverage that synthetic fixtures structurally can't give: a hand-written fixture contains the cases we thought of, and the mapping bugs that shipped (#325, #328) were the ones only a real training log contains.

### Ground truth

The `(category, subcategory)` assertion validates against `garmin-fit-sdk`, not the runtime `fit-tool` dependency. `fit-tool` 0.9.15 bundles a stale profile snapshot — categories stop at 32 — so it reports false invalids for every cardio-machine category and would make this test worse than useless. It's an `importorskip`, so the suite still passes without that extra installed.

### On the data

`scripts/export_workout_fixtures.py` is included and anonymizes on the way out: workout ids and titles become synthetic (`fixture-0000`, `Workout 01`), start times move to a synthetic weekly schedule with durations preserved, weights round to 2.5 kg. Exercise titles and template ids are Hevy's own catalog values and stay verbatim — they're the data under test. Nothing else leaves the account: no notes, descriptions, or profile fields. Anyone can regenerate it against their own history with `HEVY_API_KEY=... python scripts/export_workout_fixtures.py`.

This introduces `tests/fixtures/` (68 KB), which didn't exist before.

### The second commit is droppable

`garmin-fit-sdk` lives in `[audit]`, and CI installs `[dev]` / `[dev,cloud]` — so without a change the SDK assertions `importorskip` on every CI run and 24 of the 50 tests are silently green. The second commit moves the dep into `[dev]` (one line). If you'd rather keep the extra confined to `[audit]` and add it to the CI install step instead, drop that commit; the test skips cleanly either way.

### Verified

Both commits applied to current `main` and run against `main`'s own source (not my fork's): 682 passed / 7 skipped on 3.12, 658 passed / 31 skipped on 3.10 — both versions in your CI matrix. Nothing in the corpus depends on fork-local mappings; all 24 exercises resolve on clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)