### PR TITLE
Move psycopg2-binary to the optional cloud extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,13 @@ from hevy2garmin.fit import generate_fit
 result = generate_fit(hevy_workout_dict, hr_samples=None, output_path="workout.fit")
 ```
 
-For cloud deployments (Vercel, CI/CD), install with Postgres support:
+For self-hosted installs (Docker, local), the base install is sufficient — SQLite is used automatically with no extra dependencies:
+
+```bash
+pip install hevy2garmin
+```
+
+For cloud deployments (Vercel, CI/CD) that need Postgres support:
 
 ```bash
 pip install hevy2garmin[cloud]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "uvicorn>=0.29",
     "jinja2>=3.1",
     "python-multipart>=0.0.9",
-    "psycopg2-binary>=2.9",
     "pynacl>=1.5",
 ]
 


### PR DESCRIPTION
## What

`psycopg2-binary` is listed in `[project.dependencies]`, so every install pulls it in. It is only needed when a Postgres backend is actually used.

## Why

`db_postgres.py` already lazy-imports `psycopg2` inside `_get_conn`, and `db.get_db()` only selects the Postgres backend when `DATABASE_URL` is set. Self-hosted installs (Docker, NAS, local) run entirely on SQLite and never touch it — they just pay for a compiled C extension that needs build tools on some platforms.

It is already declared in `[project.optional-dependencies] cloud`, so Vercel/CI installs via `hevy2garmin[cloud]` are unaffected.

## Changes

- Remove `psycopg2-binary` from `[project.dependencies]` (it stays in the `cloud` extra)
- README: state explicitly that the base install is enough for self-hosted, before the cloud section

## Testing

Full suite green with the base install (SQLite) — 658 passed, 31 skipped.