### PR TITLE
Drop unused get_synced_ids from the Postgres backend

### DIFF
--- a/src/hevy2garmin/db_postgres.py
+++ b/src/hevy2garmin/db_postgres.py
@@ -155,18 +155,6 @@ class PostgresDatabase(Database):
                 cur.execute("SELECT 1 FROM synced_workouts WHERE hevy_id = %s", (hevy_id,))
                 return cur.fetchone() is not None
 
-    def get_synced_ids(self, hevy_ids: list[str]) -> dict[str, str | None]:
-        """Batch check sync status. Returns {hevy_id: garmin_activity_id} for synced ones."""
-        if not hevy_ids:
-            return {}
-        with self._get_conn() as conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    "SELECT hevy_id, garmin_activity_id FROM synced_workouts WHERE hevy_id = ANY(%s)",
-                    (hevy_ids,)
-                )
-                return {r["hevy_id"]: r["garmin_activity_id"] for r in cur.fetchall()}
-
     def get_garmin_id(self, hevy_id: str) -> str | None:
         with self._get_conn() as conn:
             with conn.cursor() as cur:


### PR DESCRIPTION
## What

Removes `PostgresDatabase.get_synced_ids`.

## Why

It was added in f304cb4 as a batch-query optimisation but never wired up. `get_workout_states` covers batch state fetching and is what callers actually use.

It has no callers anywhere in the repo — static or via `getattr` — and no counterpart on the SQLite backend, which made it the only method where the two backends diverged. `Database` in `db_interface.py` never declared it, so nothing was enforcing parity either.

## Testing

Full suite green — 658 passed, 31 skipped. `PostgresDatabase.__abstractmethods__` stays empty, so the backend still satisfies the interface.