### PR TITLE
Drive auto-sync from an asyncio task instead of threading.Timer

### DIFF
--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import contextvars
 import hmac
 import logging
@@ -242,8 +243,11 @@ async def _no_database_handler(request: Request, exc: NoWritableDatabaseError) -
 
 # ── Auto-sync state ─────────────────────────────────────────────────────────
 
-_autosync_timer: threading.Timer | None = None
-_autosync_lock = threading.Lock()
+_autosync_task: asyncio.Task | None = None
+# Still a threading.Lock, not an asyncio one: it is shared with the manual and
+# cron sync routes, and every acquire is non-blocking, so it never stalls the
+# event loop. It also has to be released from the worker thread that runs the
+# blocking sync.
 _sync_executing = threading.Lock()  # Prevents concurrent sync execution
 _sync_lock_acquired_at: float = 0  # time.time() when lock was acquired
 _SYNC_LOCK_TIMEOUT = 300  # 5 minutes — force-release if exceeded
@@ -324,18 +328,24 @@ def _get_unmapped_exercises() -> list[tuple[str, int]]:
     return _unmapped_cache
 
 
-def _run_autosync() -> None:
-    """Execute a sync and reschedule if still enabled."""
+def _run_autosync_once() -> int | None:
+    """Execute one scheduled sync.
+
+    Returns the interval (minutes) to wait before the next run, or ``None`` when
+    the loop should stop — auto-sync was turned off, or the Hevy key is invalid.
+    Blocking on purpose: the caller runs it off the event loop.
+    """
     global _last_sync_time
     config = load_config()
     auto_cfg = config.get("auto_sync", {})
     if not auto_cfg.get("enabled", False):
-        return
+        return None
+
+    interval = auto_cfg.get("interval_minutes", 30)
 
     if not _acquire_sync_lock():
         logger.info("Auto-sync: skipped — another sync is running")
-        _schedule_autosync(auto_cfg.get("interval_minutes", 30))
-        return
+        return interval
 
     logger.info("Auto-sync: running scheduled sync")
     hevy_auth_failed = False
@@ -369,33 +379,41 @@ def _run_autosync() -> None:
         _sync_executing.release()
 
     if hevy_auth_failed:
-        return  # Don't reschedule
+        return None  # Stop the loop
 
     _last_sync_time = datetime.now(timezone.utc)
     _record_sync_log(result, trigger="auto")
+    return interval
 
-    # Reschedule
-    _schedule_autosync(auto_cfg.get("interval_minutes", 30))
+
+async def _autosync_loop(interval_minutes: int) -> None:
+    """Sleep, sync, repeat until auto-sync is turned off or the task is cancelled.
+
+    The interval is re-read from the config on every pass, so changing it takes
+    effect from the next cycle without restarting the loop.
+    """
+    while True:
+        await asyncio.sleep(interval_minutes * 60)
+        next_interval = await run_in_threadpool(_run_autosync_once)
+        if next_interval is None:
+            logger.info("Auto-sync: loop stopped")
+            return
+        interval_minutes = next_interval
 
 
 def _schedule_autosync(interval_minutes: int) -> None:
-    """Schedule the next auto-sync run."""
-    global _autosync_timer
-    with _autosync_lock:
-        if _autosync_timer is not None:
-            _autosync_timer.cancel()
-        _autosync_timer = threading.Timer(interval_minutes * 60, _run_autosync)
-        _autosync_timer.daemon = True
-        _autosync_timer.start()
+    """(Re)start the auto-sync loop. Requires a running event loop."""
+    global _autosync_task
+    _stop_autosync()
+    _autosync_task = asyncio.create_task(_autosync_loop(interval_minutes))
 
 
 def _stop_autosync() -> None:
-    """Cancel any pending auto-sync timer."""
-    global _autosync_timer
-    with _autosync_lock:
-        if _autosync_timer is not None:
-            _autosync_timer.cancel()
-            _autosync_timer = None
+    """Cancel the auto-sync loop if one is running."""
+    global _autosync_task
+    if _autosync_task is not None:
+        _autosync_task.cancel()
+        _autosync_task = None
 
 
 def _record_sync_log(result: dict, trigger: str = "manual") -> None:

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -9,6 +9,7 @@ import os
 import re
 import threading
 import time
+from contextlib import asynccontextmanager
 from datetime import date, datetime, timezone
 from html import escape
 from math import ceil
@@ -183,7 +184,28 @@ def _render(template_name: str, **ctx) -> HTMLResponse:
     return HTMLResponse(_apply_prefix(t.render(**ctx), prefix))
 
 
-app = FastAPI(title="hevy2garmin", docs_url=None, redoc_url=None)
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Start the auto-sync timer if configured, and cancel it on shutdown.
+
+    The helpers below are defined later in this module; the body only runs at
+    startup, so the names resolve by then.
+    """
+    config = load_config()
+    auto_cfg = config.get("auto_sync", {})
+    if auto_cfg.get("enabled", False):
+        interval = auto_cfg.get("interval_minutes", 30)
+        logger.info("Auto-sync enabled on startup: every %d min", interval)
+        _schedule_autosync(interval)
+    try:
+        yield
+    finally:
+        # Without this a pending timer survives reload/shutdown and can fire a
+        # sync against a half-torn-down process.
+        _stop_autosync()
+
+
+app = FastAPI(title="hevy2garmin", docs_url=None, redoc_url=None, lifespan=lifespan)
 app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
 
 
@@ -446,17 +468,6 @@ def _get_autosync_status() -> dict[str, Any]:
                 status["next_sync"] = f"in {remaining // 60}h {remaining % 60}m"
 
     return status
-
-
-@app.on_event("startup")
-async def _startup_autosync() -> None:
-    """Start auto-sync timer on server startup if enabled."""
-    config = load_config()
-    auto_cfg = config.get("auto_sync", {})
-    if auto_cfg.get("enabled", False):
-        interval = auto_cfg.get("interval_minutes", 30)
-        logger.info("Auto-sync enabled on startup: every %d min", interval)
-        _schedule_autosync(interval)
 
 
 def client_ip(request: Request) -> str:

--- a/tests/test_autosync.py
+++ b/tests/test_autosync.py
@@ -180,3 +180,128 @@ class TestLifespanAutosync:
     def test_shutdown_cancels_even_when_autosync_disabled(self) -> None:
         _, stopped = self._run({"auto_sync": {"enabled": False}})
         assert stopped == [1]
+
+
+class TestAutosyncLoop:
+    """The loop is an asyncio task (it used to be a chain of threading.Timers),
+    so sleeping, rescheduling and stopping are all driven from the event loop."""
+
+    @staticmethod
+    def _run_loop(returns: list[int | None], sleeps: list[float]) -> None:
+        """Drive _autosync_loop with instant sleeps and canned sync results."""
+        pending = list(returns)
+
+        async def fake_sleep(seconds):
+            sleeps.append(seconds)
+
+        async def fake_threadpool(fn):
+            return pending.pop(0)
+
+        with patch.object(server.asyncio, "sleep", fake_sleep), \
+             patch.object(server, "run_in_threadpool", fake_threadpool):
+            asyncio.run(server._autosync_loop(30))
+
+    def test_sleeps_the_interval_before_first_sync(self) -> None:
+        sleeps: list[float] = []
+        self._run_loop([None], sleeps)
+        assert sleeps == [30 * 60]
+
+    def test_stops_when_sync_returns_none(self) -> None:
+        """None means auto-sync was disabled or the Hevy key is invalid."""
+        sleeps: list[float] = []
+        self._run_loop([None], sleeps)
+        assert len(sleeps) == 1  # did not loop again
+
+    def test_keeps_looping_while_sync_returns_an_interval(self) -> None:
+        sleeps: list[float] = []
+        self._run_loop([30, 30, None], sleeps)
+        assert sleeps == [1800, 1800, 1800]
+
+    def test_picks_up_a_changed_interval(self) -> None:
+        """A new interval from the config applies to the next sleep."""
+        sleeps: list[float] = []
+        self._run_loop([120, None], sleeps)
+        assert sleeps == [30 * 60, 120 * 60]
+
+    def test_cancellation_stops_the_loop(self) -> None:
+        async def scenario():
+            task = asyncio.create_task(server._autosync_loop(60))
+            await asyncio.sleep(0)  # let it reach the first await
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        asyncio.run(scenario())
+
+
+def _really_acquire() -> bool:
+    """Stand in for _acquire_sync_lock but take the real lock, so the
+    ``finally: release()`` under test has something to release."""
+    return server._sync_executing.acquire(blocking=False)
+
+
+class TestRunAutosyncOnce:
+    """_run_autosync_once returns the next interval, or None to stop the loop."""
+
+    def test_returns_none_when_disabled(self) -> None:
+        with patch.object(server, "load_config", lambda: {"auto_sync": {"enabled": False}}):
+            assert server._run_autosync_once() is None
+
+    def test_returns_none_when_config_missing(self) -> None:
+        with patch.object(server, "load_config", lambda: {}):
+            assert server._run_autosync_once() is None
+
+    def test_returns_interval_without_syncing_when_lock_held(self) -> None:
+        """A sync already in flight must not be joined, but the loop continues."""
+        cfg = {"auto_sync": {"enabled": True, "interval_minutes": 45}}
+        called = []
+        with patch.object(server, "load_config", lambda: cfg), \
+             patch.object(server, "_acquire_sync_lock", lambda: False), \
+             patch.object(server, "sync", lambda **kw: called.append(kw)):
+            assert server._run_autosync_once() == 45
+        assert called == []
+
+    def test_returns_interval_after_a_successful_sync(self) -> None:
+        cfg = {"auto_sync": {"enabled": True, "interval_minutes": 90}}
+        result = {"synced": 2, "skipped": 0, "failed": 0}
+        with patch.object(server, "load_config", lambda: cfg), \
+             patch.object(server, "_acquire_sync_lock", _really_acquire), \
+             patch.object(server, "sync", lambda **kw: result), \
+             patch.object(server, "_record_sync_log", lambda *a, **k: None):
+            assert server._run_autosync_once() == 90
+        # the lock must be free again for the next run
+        assert server._sync_executing.acquire(blocking=False)
+        server._sync_executing.release()
+
+    def test_releases_lock_when_sync_raises(self) -> None:
+        cfg = {"auto_sync": {"enabled": True, "interval_minutes": 30}}
+
+        def boom(**kw):
+            raise RuntimeError("hevy down")
+
+        with patch.object(server, "load_config", lambda: cfg), \
+             patch.object(server, "_acquire_sync_lock", _really_acquire), \
+             patch.object(server, "sync", boom), \
+             patch.object(server, "_record_sync_log", lambda *a, **k: None):
+            assert server._run_autosync_once() == 30
+        assert server._sync_executing.acquire(blocking=False)
+        server._sync_executing.release()
+
+    def test_stops_loop_when_hevy_key_is_invalid(self) -> None:
+        """A bad key would fail every cycle, so the loop must stop, not spin."""
+        from hevy2garmin.hevy import HevyAuthError
+
+        cfg = {"auto_sync": {"enabled": True, "interval_minutes": 30}}
+        saved: list[dict] = []
+
+        def boom(**kw):
+            raise HevyAuthError("401")
+
+        with patch.object(server, "load_config", lambda: cfg), \
+             patch.object(server, "_acquire_sync_lock", _really_acquire), \
+             patch.object(server, "sync", boom), \
+             patch.object(server, "save_config", saved.append), \
+             patch.object(server.db, "get_database_url", lambda: None), \
+             patch.object(server, "_record_sync_log", lambda *a, **k: None):
+            assert server._run_autosync_once() is None
+        assert saved and saved[0]["auto_sync"]["enabled"] is False

--- a/tests/test_autosync.py
+++ b/tests/test_autosync.py
@@ -138,3 +138,45 @@ class TestBuildSyncWorkflowYaml:
         assert "actions/setup-python@v6" in yml
         assert "actions/checkout@v4" not in yml
         assert "actions/setup-python@v5" not in yml
+
+
+class TestLifespanAutosync:
+    """The startup/shutdown hook lives in the app's lifespan (FastAPI dropped
+    on_event), so it only fires when TestClient is used as a context manager."""
+
+    def _run(self, config: dict) -> tuple[list[int], list[int]]:
+        from fastapi.testclient import TestClient
+
+        scheduled: list[int] = []
+        stopped: list[int] = []
+        with patch.object(server, "load_config", lambda: config), \
+             patch.object(server, "_schedule_autosync", scheduled.append), \
+             patch.object(server, "_stop_autosync", lambda: stopped.append(1)):
+            with TestClient(server.app):
+                pass
+        return scheduled, stopped
+
+    def test_enabled_schedules_configured_interval(self) -> None:
+        scheduled, _ = self._run({"auto_sync": {"enabled": True, "interval_minutes": 45}})
+        assert scheduled == [45]
+
+    def test_enabled_without_interval_defaults_to_30(self) -> None:
+        scheduled, _ = self._run({"auto_sync": {"enabled": True}})
+        assert scheduled == [30]
+
+    def test_disabled_schedules_nothing(self) -> None:
+        scheduled, _ = self._run({"auto_sync": {"enabled": False}})
+        assert scheduled == []
+
+    def test_missing_config_schedules_nothing(self) -> None:
+        scheduled, _ = self._run({})
+        assert scheduled == []
+
+    def test_shutdown_cancels_timer(self) -> None:
+        """A surviving timer could fire a sync against a torn-down process."""
+        _, stopped = self._run({"auto_sync": {"enabled": True, "interval_minutes": 60}})
+        assert stopped == [1]
+
+    def test_shutdown_cancels_even_when_autosync_disabled(self) -> None:
+        _, stopped = self._run({"auto_sync": {"enabled": False}})
+        assert stopped == [1]


### PR DESCRIPTION
## What

Two related commits, reviewable separately:

1. **`on_event` → `lifespan`** — replace the deprecated startup hook
2. **`threading.Timer` → asyncio task** — replace the auto-sync scheduler

## Why

**Commit 1.** `@app.on_event` has been deprecated since FastAPI 0.93 and emitted a `DeprecationWarning` on every test run. Moving to an `asynccontextmanager` lifespan also makes room for a shutdown half, which `on_event("startup")` never had: a pending timer previously survived shutdown and could fire a sync against a half-torn-down process. It now calls the existing `_stop_autosync()`.

**Commit 2.** The scheduler was a self-perpetuating chain of daemon `threading.Timer`s inside an otherwise fully async app. Each run re-armed the next from the timer thread, so scheduling state was mutated off the event loop and needed its own `threading.Lock` to stay consistent.

Replacing it with a single asyncio task that sleeps, syncs and repeats makes the control flow explicit. `_run_autosync` becomes `_run_autosync_once` and returns the next interval (or `None` to stop) rather than re-arming itself. The blocking `sync()` runs via `run_in_threadpool` so it stays off the event loop, and `_autosync_lock` is gone since the task is only created or cancelled from the loop.

### Deliberately unchanged

`_sync_executing` stays a `threading.Lock`: it is shared with the manual and cron sync routes, every acquire is non-blocking so it never stalls the loop, and it has to be released from the worker thread running the sync. The `_SYNC_LOCK_TIMEOUT` force-release also stays — a cancelled task mid-sync can still strand the lock, so the guard is not specific to threading.

## Behaviour preserved

- Interval is re-read from config each pass, so changes apply from the next cycle
- A sync already in flight is skipped, and the loop continues
- An invalid Hevy key disables auto-sync, persists that, and stops the loop
- Auto-sync starts on boot when enabled, and the toggle route starts/stops it

## Testing

Adds 17 tests (`TestLifespanAutosync`, `TestAutosyncLoop`, `TestRunAutosyncOnce`) covering both halves — startup scheduling and shutdown cancellation, loop sleep/repeat/stop/cancel and interval changes, plus `_run_autosync_once` return values and lock release on success, on error, and on an invalid key. This path had no coverage before.

Full suite green — 675 passed, 31 skipped. Also verified against a real `TestClient` lifespan (unpatched): the task is created on startup, the server serves requests, and the task is cancelled on shutdown with no leak.