### PR TITLE
Timestamp log lines

### DIFF
--- a/src/hevy2garmin/cli.py
+++ b/src/hevy2garmin/cli.py
@@ -476,7 +476,10 @@ def main() -> None:
         sys.exit(0)
 
     level = logging.DEBUG if args.verbose else (logging.CRITICAL if args.quiet else logging.INFO)
-    logging.basicConfig(format="%(message)s", level=level, force=True)
+    logging.basicConfig(
+        format="%(asctime)s %(message)s", datefmt="%Y-%m-%d %H:%M:%S",
+        level=level, force=True,
+    )
 
     try:
         if args.command == "serve":

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -2908,6 +2908,9 @@ async def cron_webhook(request: Request):
 
 def run_server(host: str = "0.0.0.0", port: int = 8000) -> None:
     import uvicorn
-    logging.basicConfig(format="%(message)s", level=logging.INFO, force=True)
+    logging.basicConfig(
+        format="%(asctime)s %(message)s", datefmt="%Y-%m-%d %H:%M:%S",
+        level=logging.INFO, force=True,
+    )
     logger.info("Starting hevy2garmin dashboard at http://localhost:%d", port)
     uvicorn.run(app, host=host, port=port, log_level="warning")


### PR DESCRIPTION
Log output is bare messages, so container logs give no way to tell when a sync ran or how long one took. This sequence is hard to read without timestamps:

```
Auto-sync: running scheduled sync
Hevy reports 239 total workouts
Authenticating with Garmin Connect...
Sync run complete: 0 synced, 10 skipped, 0 failed
```

Both entry points — the CLI and the dashboard server — now prefix records with a local-time stamp:

```
2026-08-26 09:36:02 Auto-sync: running scheduled sync
2026-08-26 09:36:02 Sync run complete: 0 synced, 10 skipped, 0 failed
```

`cli.py` writes all of its human-facing output with `print()` and never logs directly, so this only affects actual log records — interactive commands like `hevy2garmin status` are unchanged (verified by running it).

772 passed, 7 skipped.