### PR TITLE
Extract the auto-sync loop and shared sync state from server.py

### DIFF
--- a/src/hevy2garmin/autosync.py
+++ b/src/hevy2garmin/autosync.py
@@ -1,0 +1,164 @@
+"""The scheduled auto-sync loop: sleep, sync, repeat.
+
+Takes the shared sync lock from :mod:`hevy2garmin.syncstate`, so a scheduled
+sync can never overlap a manual or cron one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi.concurrency import run_in_threadpool
+
+from hevy2garmin import db, syncstate
+from hevy2garmin.config import load_config, save_config
+from hevy2garmin.sync import sync
+
+logger = logging.getLogger("hevy2garmin")
+
+_autosync_task: asyncio.Task | None = None
+
+
+def run_once() -> int | None:
+    """Execute one scheduled sync.
+
+    Returns the interval (minutes) to wait before the next run, or ``None`` when
+    the loop should stop — auto-sync was turned off, or the Hevy key is invalid.
+    Blocking on purpose: the caller runs it off the event loop.
+    """
+    config = load_config()
+    auto_cfg = config.get("auto_sync", {})
+    if not auto_cfg.get("enabled", False):
+        return None
+
+    interval = auto_cfg.get("interval_minutes", 30)
+
+    if not syncstate.acquire_sync_lock():
+        logger.info("Auto-sync: skipped — another sync is running")
+        return interval
+
+    logger.info("Auto-sync: running scheduled sync")
+    hevy_auth_failed = False
+    try:
+        result = sync(limit=10, dry_run=False, record_log=False, respect_grace=True)
+    except Exception as e:
+        from hevy2garmin.hevy import HevyAuthError
+        if isinstance(e, HevyAuthError):
+            logger.error("Auto-sync: Hevy API key invalid — disabling auto-sync. %s", e)
+            config["auto_sync"]["enabled"] = False
+            save_config(config)
+            # Also persist to DB (Vercel filesystem is read-only)
+            if db.get_database_url():
+                try:
+                    import json as _json
+                    _db = db.get_db()
+                    if hasattr(_db, '_get_conn'):
+                        with _db._get_conn() as conn:
+                            with conn.cursor() as cur:
+                                cur.execute("""
+                                    INSERT INTO platform_credentials (platform, auth_type, credentials, status)
+                                    VALUES ('auto_sync', 'config', %s, 'active')
+                                    ON CONFLICT (platform) DO UPDATE SET credentials = EXCLUDED.credentials
+                                """, (_json.dumps({"enabled": False, "interval_minutes": config.get("auto_sync", {}).get("interval_minutes", 120)}),))
+                            conn.commit()
+                except Exception:
+                    pass
+            hevy_auth_failed = True
+        result = {"synced": 0, "skipped": 0, "failed": 1, "error": str(e)}
+    finally:
+        syncstate.release_sync_lock()
+
+    if hevy_auth_failed:
+        return None  # Stop the loop
+
+    syncstate.mark_synced()
+    syncstate.record_sync_log(result, trigger="auto")
+    return interval
+
+
+async def _loop(interval_minutes: int) -> None:
+    """Sleep, sync, repeat until auto-sync is turned off or the task is cancelled.
+
+    The interval is re-read from the config on every pass, so changing it takes
+    effect from the next cycle without restarting the loop.
+    """
+    while True:
+        await asyncio.sleep(interval_minutes * 60)
+        next_interval = await run_in_threadpool(run_once)
+        if next_interval is None:
+            logger.info("Auto-sync: loop stopped")
+            return
+        interval_minutes = next_interval
+
+
+def schedule(interval_minutes: int) -> None:
+    """(Re)start the auto-sync loop. Requires a running event loop."""
+    global _autosync_task
+    stop()
+    _autosync_task = asyncio.create_task(_loop(interval_minutes))
+
+
+def stop() -> None:
+    """Cancel the auto-sync loop if one is running."""
+    global _autosync_task
+    if _autosync_task is not None:
+        _autosync_task.cancel()
+        _autosync_task = None
+
+
+def status() -> dict[str, Any]:
+    """Build auto-sync status dict for templates."""
+    config = load_config()
+    auto_cfg = config.get("auto_sync", {})
+    enabled = auto_cfg.get("enabled", False)
+    interval = auto_cfg.get("interval_minutes", 30)
+
+    # On cloud, read persisted state from DB (filesystem config doesn't persist)
+    if db.get_database_url():
+        try:
+            import json as _json
+            _db = db.get_db()
+            if hasattr(_db, '_get_conn'):
+                with _db._get_conn() as conn:
+                    with conn.cursor() as cur:
+                        cur.execute("SELECT credentials FROM platform_credentials WHERE platform = 'auto_sync' LIMIT 1")
+                        row = cur.fetchone()
+                        if row and row.get("credentials"):
+                            creds = row["credentials"] if isinstance(row["credentials"], dict) else _json.loads(row["credentials"])
+                            enabled = creds.get("enabled", False)
+                            interval = creds.get("interval_minutes", 120)
+        except Exception:
+            pass
+
+    status_dict: dict[str, Any] = {
+        "enabled": enabled,
+        "interval_minutes": interval,
+        "last_sync": None,
+        "next_sync": None,
+    }
+
+    last_sync_time = syncstate.get_last_sync_time()
+    if last_sync_time:
+        elapsed = datetime.now(timezone.utc) - last_sync_time
+        minutes_ago = int(elapsed.total_seconds() / 60)
+        if minutes_ago < 1:
+            status_dict["last_sync"] = "just now"
+        elif minutes_ago < 60:
+            status_dict["last_sync"] = f"{minutes_ago} min ago"
+        else:
+            hours_ago = minutes_ago // 60
+            status_dict["last_sync"] = f"{hours_ago}h {minutes_ago % 60}m ago"
+
+        if enabled:
+            remaining = interval - minutes_ago
+            if remaining <= 0:
+                status_dict["next_sync"] = "soon"
+            elif remaining < 60:
+                status_dict["next_sync"] = f"in {remaining} min"
+            else:
+                status_dict["next_sync"] = f"in {remaining // 60}h {remaining % 60}m"
+
+    return status_dict

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -8,7 +8,6 @@ import hmac
 import logging
 import os
 import re
-import threading
 import time
 from contextlib import asynccontextmanager
 from datetime import date, datetime, timezone
@@ -23,7 +22,7 @@ from fastapi.concurrency import run_in_threadpool
 from fastapi.staticfiles import StaticFiles
 from jinja2 import Environment, FileSystemLoader
 
-from hevy2garmin import db, garmin_login, login_ratelimit, __version__
+from hevy2garmin import autosync, db, garmin_login, login_ratelimit, syncstate, __version__
 from hevy2garmin.db_interface import NoWritableDatabaseError
 from hevy2garmin.auth import (
     auth_enabled, verify_session, sign_session, check_password, SESSION_COOKIE, session_ttl,
@@ -197,13 +196,13 @@ async def lifespan(app: FastAPI):
     if auto_cfg.get("enabled", False):
         interval = auto_cfg.get("interval_minutes", 30)
         logger.info("Auto-sync enabled on startup: every %d min", interval)
-        _schedule_autosync(interval)
+        autosync.schedule(interval)
     try:
         yield
     finally:
         # Without this a pending timer survives reload/shutdown and can fire a
         # sync against a half-torn-down process.
-        _stop_autosync()
+        autosync.stop()
 
 
 app = FastAPI(title="hevy2garmin", docs_url=None, redoc_url=None, lifespan=lifespan)
@@ -241,39 +240,15 @@ async def _no_database_handler(request: Request, exc: NoWritableDatabaseError) -
     return HTMLResponse(_NO_DB_PAGE, status_code=503)
 
 
-# ── Auto-sync state ─────────────────────────────────────────────────────────
+# ── Sync-session caches ─────────────────────────────────────────────────────
+# The shared sync lock and the last-sync timestamp live in
+# ``hevy2garmin.syncstate``; the auto-sync loop lives in
+# ``hevy2garmin.autosync``. What is left here is the exercise-mapping cache and
+# the per-session failed-upload set, which only this module's routes touch.
 
-_autosync_task: asyncio.Task | None = None
-# Still a threading.Lock, not an asyncio one: it is shared with the manual and
-# cron sync routes, and every acquire is non-blocking, so it never stalls the
-# event loop. It also has to be released from the worker thread that runs the
-# blocking sync.
-_sync_executing = threading.Lock()  # Prevents concurrent sync execution
-_sync_lock_acquired_at: float = 0  # time.time() when lock was acquired
-_SYNC_LOCK_TIMEOUT = 300  # 5 minutes — force-release if exceeded
-_last_sync_time: datetime | None = None
 _unmapped_cache: list[tuple[str, int]] | None = None
 _unmapped_cache_time: float = 0
 _failed_ids: set[str] = set()  # Workouts that failed upload this session (retried next session)
-
-
-def _acquire_sync_lock() -> bool:
-    """Try to acquire the sync lock. Force-release if held too long (hung sync)."""
-    global _sync_lock_acquired_at
-    if _sync_executing.acquire(blocking=False):
-        _sync_lock_acquired_at = time.time()
-        return True
-    # Check if the lock has been held too long (hung sync)
-    if _sync_lock_acquired_at and (time.time() - _sync_lock_acquired_at) > _SYNC_LOCK_TIMEOUT:
-        logger.warning("Sync lock held for >%ds — force-releasing (likely hung)", _SYNC_LOCK_TIMEOUT)
-        try:
-            _sync_executing.release()
-        except RuntimeError:
-            pass
-        if _sync_executing.acquire(blocking=False):
-            _sync_lock_acquired_at = time.time()
-            return True
-    return False
 
 
 def _get_unmapped_exercises() -> list[tuple[str, int]]:
@@ -326,166 +301,6 @@ def _get_unmapped_exercises() -> list[tuple[str, int]]:
     _unmapped_cache = sorted(unmapped.items(), key=lambda x: -x[1])
     _unmapped_cache_time = _t.time()
     return _unmapped_cache
-
-
-def _run_autosync_once() -> int | None:
-    """Execute one scheduled sync.
-
-    Returns the interval (minutes) to wait before the next run, or ``None`` when
-    the loop should stop — auto-sync was turned off, or the Hevy key is invalid.
-    Blocking on purpose: the caller runs it off the event loop.
-    """
-    global _last_sync_time
-    config = load_config()
-    auto_cfg = config.get("auto_sync", {})
-    if not auto_cfg.get("enabled", False):
-        return None
-
-    interval = auto_cfg.get("interval_minutes", 30)
-
-    if not _acquire_sync_lock():
-        logger.info("Auto-sync: skipped — another sync is running")
-        return interval
-
-    logger.info("Auto-sync: running scheduled sync")
-    hevy_auth_failed = False
-    try:
-        result = sync(limit=10, dry_run=False, record_log=False, respect_grace=True)
-    except Exception as e:
-        from hevy2garmin.hevy import HevyAuthError
-        if isinstance(e, HevyAuthError):
-            logger.error("Auto-sync: Hevy API key invalid — disabling auto-sync. %s", e)
-            config["auto_sync"]["enabled"] = False
-            save_config(config)
-            # Also persist to DB (Vercel filesystem is read-only)
-            if db.get_database_url():
-                try:
-                    import json as _json
-                    _db = db.get_db()
-                    if hasattr(_db, '_get_conn'):
-                        with _db._get_conn() as conn:
-                            with conn.cursor() as cur:
-                                cur.execute("""
-                                    INSERT INTO platform_credentials (platform, auth_type, credentials, status)
-                                    VALUES ('auto_sync', 'config', %s, 'active')
-                                    ON CONFLICT (platform) DO UPDATE SET credentials = EXCLUDED.credentials
-                                """, (_json.dumps({"enabled": False, "interval_minutes": config.get("auto_sync", {}).get("interval_minutes", 120)}),))
-                            conn.commit()
-                except Exception:
-                    pass
-            hevy_auth_failed = True
-        result = {"synced": 0, "skipped": 0, "failed": 1, "error": str(e)}
-    finally:
-        _sync_executing.release()
-
-    if hevy_auth_failed:
-        return None  # Stop the loop
-
-    _last_sync_time = datetime.now(timezone.utc)
-    _record_sync_log(result, trigger="auto")
-    return interval
-
-
-async def _autosync_loop(interval_minutes: int) -> None:
-    """Sleep, sync, repeat until auto-sync is turned off or the task is cancelled.
-
-    The interval is re-read from the config on every pass, so changing it takes
-    effect from the next cycle without restarting the loop.
-    """
-    while True:
-        await asyncio.sleep(interval_minutes * 60)
-        next_interval = await run_in_threadpool(_run_autosync_once)
-        if next_interval is None:
-            logger.info("Auto-sync: loop stopped")
-            return
-        interval_minutes = next_interval
-
-
-def _schedule_autosync(interval_minutes: int) -> None:
-    """(Re)start the auto-sync loop. Requires a running event loop."""
-    global _autosync_task
-    _stop_autosync()
-    _autosync_task = asyncio.create_task(_autosync_loop(interval_minutes))
-
-
-def _stop_autosync() -> None:
-    """Cancel the auto-sync loop if one is running."""
-    global _autosync_task
-    if _autosync_task is not None:
-        _autosync_task.cancel()
-        _autosync_task = None
-
-
-def _record_sync_log(result: dict, trigger: str = "manual") -> None:
-    """Record a sync result to SQLite. Best-effort — never breaks a sync.
-
-    Now that failure paths record too, this runs from inside exception
-    handlers; a DB write raising there would replace a handled error with a
-    500. The log is diagnostic, so losing a row is always the lesser loss.
-    """
-    try:
-        db.record_sync_log(
-            synced=result.get("synced", 0),
-            skipped=result.get("skipped", 0),
-            failed=result.get("failed", 0),
-            trigger=trigger,
-        )
-    except Exception:
-        logger.debug("sync_log record failed (trigger=%s)", trigger, exc_info=True)
-
-
-def _get_autosync_status() -> dict[str, Any]:
-    """Build auto-sync status dict for templates."""
-    config = load_config()
-    auto_cfg = config.get("auto_sync", {})
-    enabled = auto_cfg.get("enabled", False)
-    interval = auto_cfg.get("interval_minutes", 30)
-
-    # On cloud, read persisted state from DB (filesystem config doesn't persist)
-    if db.get_database_url():
-        try:
-            import json as _json
-            _db = db.get_db()
-            if hasattr(_db, '_get_conn'):
-                with _db._get_conn() as conn:
-                    with conn.cursor() as cur:
-                        cur.execute("SELECT credentials FROM platform_credentials WHERE platform = 'auto_sync' LIMIT 1")
-                        row = cur.fetchone()
-                        if row and row.get("credentials"):
-                            creds = row["credentials"] if isinstance(row["credentials"], dict) else _json.loads(row["credentials"])
-                            enabled = creds.get("enabled", False)
-                            interval = creds.get("interval_minutes", 120)
-        except Exception:
-            pass
-
-    status: dict[str, Any] = {
-        "enabled": enabled,
-        "interval_minutes": interval,
-        "last_sync": None,
-        "next_sync": None,
-    }
-
-    if _last_sync_time:
-        elapsed = datetime.now(timezone.utc) - _last_sync_time
-        minutes_ago = int(elapsed.total_seconds() / 60)
-        if minutes_ago < 1:
-            status["last_sync"] = "just now"
-        elif minutes_ago < 60:
-            status["last_sync"] = f"{minutes_ago} min ago"
-        else:
-            hours_ago = minutes_ago // 60
-            status["last_sync"] = f"{hours_ago}h {minutes_ago % 60}m ago"
-
-        if enabled:
-            remaining = interval - minutes_ago
-            if remaining <= 0:
-                status["next_sync"] = "soon"
-            elif remaining < 60:
-                status["next_sync"] = f"in {remaining} min"
-            else:
-                status["next_sync"] = f"in {remaining // 60}h {remaining % 60}m"
-
-    return status
 
 
 def client_ip(request: Request) -> str:
@@ -829,7 +644,7 @@ async def dashboard(request: Request):
         skipped_count=terminal_counts["skipped"],
         hevy_total=hevy_total,
         recent=recent,
-        auto_sync=_get_autosync_status(),
+        auto_sync=autosync.status(),
         sync_log=db.get_sync_log(10),
         mapping_count=mapping_count,
         garmin_connected=garmin_connected,
@@ -1644,8 +1459,6 @@ async def api_pull_garmin_profile(request: Request):
 
 @app.post("/api/sync", response_class=HTMLResponse)
 async def api_sync(request: Request):
-    global _last_sync_time
-
     if is_demo_mode():
         from fastapi.responses import JSONResponse
         return JSONResponse({"status": "demo", "message": "Sync disabled in demo mode"})
@@ -1699,7 +1512,7 @@ async def api_sync(request: Request):
         sync_kwargs["since"] = since_dt.strftime("%Y-%m-%dT%H:%M:%S+00:00")
         sync_kwargs["fetch_all"] = True  # paginate until we hit the date
 
-    if not _acquire_sync_lock():
+    if not syncstate.acquire_sync_lock():
         return HTMLResponse('<div class="toast toast-error">Another sync is already running. Please wait.</div>')
 
     try:
@@ -1707,9 +1520,9 @@ async def api_sync(request: Request):
     except Exception as e:
         result = {"synced": 0, "skipped": 0, "failed": 1, "unmapped": [], "error": str(e)}
     finally:
-        _sync_executing.release()
-    _last_sync_time = datetime.now(timezone.utc)
-    _record_sync_log(result, trigger=f"manual ({scope})")
+        syncstate.release_sync_lock()
+    syncstate.mark_synced()
+    syncstate.record_sync_log(result, trigger=f"manual ({scope})")
     return _render("partials/sync_result.html", result=result)
 
 
@@ -1886,7 +1699,7 @@ async def api_routines_sync(request: Request):
     form = await request.form()
     force = form.get("force") in ("1", "true", "on")
 
-    if not _acquire_sync_lock():
+    if not syncstate.acquire_sync_lock():
         return HTMLResponse('<div class="toast toast-error">Another sync is already running. Please wait.</div>')
 
     try:
@@ -1895,7 +1708,7 @@ async def api_routines_sync(request: Request):
         logger.exception("Routine sync failed")
         return HTMLResponse('<div class="toast toast-error">Routine sync failed. Check the logs for details.</div>')
     finally:
-        _sync_executing.release()
+        syncstate.release_sync_lock()
 
     msg = (
         f"{result['created']} created, {result['updated']} updated, "
@@ -1919,7 +1732,7 @@ async def api_routine_sync_one(request: Request, hevy_routine_id: str):
     form = await request.form()
     force = form.get("force") in ("1", "true", "on")
 
-    if not _acquire_sync_lock():
+    if not syncstate.acquire_sync_lock():
         return HTMLResponse('<div class="toast toast-error">Another sync is already running. Please wait.</div>')
 
     try:
@@ -1928,7 +1741,7 @@ async def api_routine_sync_one(request: Request, hevy_routine_id: str):
         logger.exception("Routine %s sync failed", hevy_routine_id)
         return HTMLResponse('<div class="toast toast-error">Routine sync failed. Check the logs for details.</div>')
     finally:
-        _sync_executing.release()
+        syncstate.release_sync_lock()
 
     outcome = result["outcome"]
     # The routine title is user-controlled (Hevy account data), so escape it before
@@ -1963,7 +1776,7 @@ async def api_routine_schedule(request: Request, hevy_routine_id: str):
     except (ValueError, TypeError) as e:
         return HTMLResponse(f'<div class="toast toast-error">Invalid schedule: {e}</div>')
 
-    if not _acquire_sync_lock():
+    if not syncstate.acquire_sync_lock():
         return HTMLResponse('<div class="toast toast-error">Another sync is already running. Please wait.</div>')
 
     try:
@@ -1974,7 +1787,7 @@ async def api_routine_schedule(request: Request, hevy_routine_id: str):
         logger.exception("Scheduling routine %s failed", hevy_routine_id)
         return HTMLResponse('<div class="toast toast-error">Scheduling failed. Check the logs for details.</div>')
     finally:
-        _sync_executing.release()
+        syncstate.release_sync_lock()
 
     n = result["scheduled"]
     span = f" ({result['dates'][0]} → {result['dates'][-1]})" if n > 1 else f" on {result['dates'][0]}"
@@ -1995,7 +1808,7 @@ async def api_routine_unschedule(
     if is_demo_mode():
         return HTMLResponse('<div class="toast toast-success">Unscheduling disabled in demo mode.</div>')
 
-    if not _acquire_sync_lock():
+    if not syncstate.acquire_sync_lock():
         return HTMLResponse('<div class="toast toast-error">Another sync is already running. Please wait.</div>')
 
     try:
@@ -2004,7 +1817,7 @@ async def api_routine_unschedule(
         logger.exception("Unscheduling routine %s entry %s failed", hevy_routine_id, schedule_id)
         return HTMLResponse('<div class="toast toast-error">Could not remove the scheduled workout. Check the logs.</div>')
     finally:
-        _sync_executing.release()
+        syncstate.release_sync_lock()
 
     return _render("routine_schedules.html", **_schedules_context(page, start, q, size))
 
@@ -2037,7 +1850,7 @@ async def api_sync_single(request: Request, workout_id: str):
             respect_grace=False,
             database=db.get_db(),
         )
-        _record_sync_log(
+        syncstate.record_sync_log(
             {"synced": 1 if one.status == "synced" else 0,
              "failed": 1 if one.status == "failed" else 0},
             trigger="manual (single)",
@@ -2046,7 +1859,7 @@ async def api_sync_single(request: Request, workout_id: str):
         start = (workout.get("start_time") or "")[:16]
         return HTMLResponse(f'<tr><td><span class="badge badge-success">✓ Synced</span></td><td>{start}</td><td><strong>{workout["title"]}</strong></td><td>{len(workout.get("exercises", []))}</td><td></td></tr>')
     except Exception as e:
-        _record_sync_log({"failed": 1}, trigger="manual (single)")
+        syncstate.record_sync_log({"failed": 1}, trigger="manual (single)")
         return HTMLResponse(f'<td colspan="5" style="color: var(--pico-del-color);">Failed: {e}</td>')
 
 
@@ -2276,10 +2089,10 @@ async def api_toggle_autosync(request: Request):
             else:
                 logger.warning("Failed to set up GitHub Actions: %s", msg)
         else:
-            _schedule_autosync(interval)
+            autosync.schedule(interval)
         logger.info("Auto-sync enabled: every %d min", interval)
     else:
-        _stop_autosync()
+        autosync.stop()
         # On Vercel: delete the sync workflow to stop the cron
         if os.environ.get("VERCEL") and os.environ.get("GITHUB_PAT"):
             try:
@@ -2298,7 +2111,7 @@ async def api_toggle_autosync(request: Request):
                 logger.warning("Failed to delete sync workflow: %s", e)
         logger.info("Auto-sync disabled")
 
-    auto_sync = _get_autosync_status()
+    auto_sync = autosync.status()
     return _render("partials/autosync_status.html", auto_sync=auto_sync)
 
 
@@ -2527,7 +2340,7 @@ async def _sync_one_recorded(
     if is_demo_mode():
         return JSONResponse({"status": "demo", "message": "Sync disabled in demo mode"})
 
-    if not _acquire_sync_lock():
+    if not syncstate.acquire_sync_lock():
         return JSONResponse({"error": "Sync already running", "busy": True})
 
     try:
@@ -2536,10 +2349,10 @@ async def _sync_one_recorded(
         # Record before re-raising, so a crash mid-sync is not the one failure
         # mode that leaves /history looking healthy. The per-row and auto paths
         # both record on exception; this makes cron and Sync Now agree.
-        _record_sync_log({"failed": 1}, trigger=trigger)
+        syncstate.record_sync_log({"failed": 1}, trigger=trigger)
         raise
     finally:
-        _sync_executing.release()
+        syncstate.release_sync_lock()
 
     try:
         data = _json.loads(bytes(resp.body))
@@ -2549,7 +2362,7 @@ async def _sync_one_recorded(
         # exact ambiguity this is meant to remove. error/skipped_error are the
         # hard-stop shapes. needs_review/processing stay 0/0: still in flight.
         failed = 1 if (data.get("error") or data.get("skipped_error") or data.get("failed")) else 0
-        _record_sync_log({"synced": data.get("synced", 0), "failed": failed}, trigger=trigger)
+        syncstate.record_sync_log({"synced": data.get("synced", 0), "failed": failed}, trigger=trigger)
     except Exception:
         logger.debug("sync_log record failed", exc_info=True)
     return resp
@@ -2593,7 +2406,7 @@ def _scan_for_unsynced(hevy, is_synced, total_count, failed_ids, on_page=None):
 
 
 async def _do_sync_one(*, respect_grace: bool = False, merge_only: bool = False):
-    """Inner sync logic, called with _sync_executing lock held.
+    """Inner sync logic, called with the shared sync lock held.
 
     ``respect_grace`` is True for Vercel cron (wait for watch data) and False
     for manual Sync Now.

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -8,7 +8,6 @@ import hmac
 import logging
 import os
 import re
-import time
 from contextlib import asynccontextmanager
 from datetime import date, datetime, timezone
 from html import escape
@@ -188,8 +187,7 @@ def _render(template_name: str, **ctx) -> HTMLResponse:
 async def lifespan(app: FastAPI):
     """Start the auto-sync timer if configured, and cancel it on shutdown.
 
-    The helpers below are defined later in this module; the body only runs at
-    startup, so the names resolve by then.
+    Scheduling and cancelling both live in :mod:`hevy2garmin.autosync`.
     """
     config = load_config()
     auto_cfg = config.get("auto_sync", {})

--- a/src/hevy2garmin/syncstate.py
+++ b/src/hevy2garmin/syncstate.py
@@ -1,0 +1,89 @@
+"""Sync session state shared by the manual, cron and auto-sync paths.
+
+The lock and the last-sync timestamp are process-wide on purpose: every sync
+entry point — the Sync Now button, the Vercel cron endpoint, the routine routes
+and the auto-sync loop — has to see the same lock, or two syncs run at once.
+
+The mutable state is reached through the accessors below rather than imported
+directly. ``from hevy2garmin.syncstate import _last_sync_time`` would copy the
+*value* at import time, leaving the importer holding a snapshot that never
+updates; the accessors keep a single canonical copy.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from datetime import datetime, timezone
+
+from hevy2garmin import db
+
+logger = logging.getLogger("hevy2garmin")
+
+# Still a threading.Lock, not an asyncio one: it is shared with the manual and
+# cron sync routes, and every acquire is non-blocking, so it never stalls the
+# event loop. It also has to be released from the worker thread that runs the
+# blocking sync.
+_sync_executing = threading.Lock()  # Prevents concurrent sync execution
+_sync_lock_acquired_at: float = 0  # time.time() when lock was acquired
+_SYNC_LOCK_TIMEOUT = 300  # 5 minutes — force-release if exceeded
+_last_sync_time: datetime | None = None
+
+
+def acquire_sync_lock() -> bool:
+    """Try to acquire the sync lock. Force-release if held too long (hung sync)."""
+    global _sync_lock_acquired_at
+    if _sync_executing.acquire(blocking=False):
+        _sync_lock_acquired_at = time.time()
+        return True
+    # Check if the lock has been held too long (hung sync)
+    if _sync_lock_acquired_at and (time.time() - _sync_lock_acquired_at) > _SYNC_LOCK_TIMEOUT:
+        logger.warning("Sync lock held for >%ds — force-releasing (likely hung)", _SYNC_LOCK_TIMEOUT)
+        try:
+            _sync_executing.release()
+        except RuntimeError:
+            pass
+        if _sync_executing.acquire(blocking=False):
+            _sync_lock_acquired_at = time.time()
+            return True
+    return False
+
+
+def release_sync_lock() -> None:
+    """Release the sync lock.
+
+    Raises ``RuntimeError`` if the lock is not held, same as releasing the lock
+    directly — callers release from a ``finally`` that only runs after a
+    successful acquire.
+    """
+    _sync_executing.release()
+
+
+def mark_synced() -> None:
+    """Stamp the completion time of a sync, for the auto-sync status display."""
+    global _last_sync_time
+    _last_sync_time = datetime.now(timezone.utc)
+
+
+def get_last_sync_time() -> datetime | None:
+    """When the last sync finished, or ``None`` if none has run in this process."""
+    return _last_sync_time
+
+
+def record_sync_log(result: dict, trigger: str = "manual") -> None:
+    """Record a sync result to SQLite. Best-effort — never breaks a sync.
+
+    Now that failure paths record too, this runs from inside exception
+    handlers; a DB write raising there would replace a handled error with a
+    500. The log is diagnostic, so losing a row is always the lesser loss.
+    """
+    try:
+        db.record_sync_log(
+            synced=result.get("synced", 0),
+            skipped=result.get("skipped", 0),
+            failed=result.get("failed", 0),
+            trigger=trigger,
+        )
+    except Exception:
+        logger.debug("sync_log record failed (trigger=%s)", trigger, exc_info=True)

--- a/tests/test_autosync.py
+++ b/tests/test_autosync.py
@@ -367,11 +367,15 @@ class TestLastSyncTime:
     """mark_synced()/get_last_sync_time() replaced a bare module global."""
 
     def test_mark_synced_is_readable_back(self) -> None:
-        before = datetime.now(timezone.utc)
-        syncstate.mark_synced()
-        stamped = syncstate.get_last_sync_time()
-        assert stamped is not None
-        assert before <= stamped <= datetime.now(timezone.utc)
+        # Patched so the stamp is restored afterwards: _last_sync_time is
+        # process-wide, and leaking a value here makes every later dashboard
+        # render in the session report "just now".
+        with patch.object(syncstate, "_last_sync_time", None):
+            before = datetime.now(timezone.utc)
+            syncstate.mark_synced()
+            stamped = syncstate.get_last_sync_time()
+            assert stamped is not None
+            assert before <= stamped <= datetime.now(timezone.utc)
 
     def test_starts_empty(self) -> None:
         with patch.object(syncstate, "_last_sync_time", None):

--- a/tests/test_autosync.py
+++ b/tests/test_autosync.py
@@ -1,20 +1,26 @@
-"""Tests for auto-sync helpers in server.py."""
+"""Tests for the auto-sync loop and the shared sync lock.
+
+The loop lives in ``hevy2garmin.autosync`` and the lock in
+``hevy2garmin.syncstate``; the workflow-YAML helpers are still in
+``hevy2garmin.server``. State is always reached through the module
+(``syncstate.acquire_sync_lock()``, never a bare imported name) so patches in
+one place are visible everywhere.
+"""
 
 from __future__ import annotations
 
 import asyncio
 import json
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from hevy2garmin import server
+from hevy2garmin import autosync, server, syncstate
 from hevy2garmin.server import (
-    _acquire_sync_lock,
     _build_sync_workflow_yaml,
     _format_interval_label,
     _minutes_to_cron,
-    _sync_executing,
 )
 
 
@@ -71,14 +77,14 @@ class TestBuildSyncWorkflowYaml:
 class TestSyncLock:
     def test_acquire_and_release(self) -> None:
         """Lock can be acquired and released without crashing (verifies time module is imported)."""
-        assert _acquire_sync_lock() is True
-        _sync_executing.release()
+        assert syncstate.acquire_sync_lock() is True
+        syncstate.release_sync_lock()
 
     def test_acquire_blocks_second(self) -> None:
         """Second acquire returns False when lock is held."""
-        assert _acquire_sync_lock() is True
-        assert _acquire_sync_lock() is False  # Already held
-        _sync_executing.release()
+        assert syncstate.acquire_sync_lock() is True
+        assert syncstate.acquire_sync_lock() is False  # Already held
+        syncstate.release_sync_lock()
 
 
 class TestCronGraceDeferral:
@@ -150,8 +156,8 @@ class TestLifespanAutosync:
         scheduled: list[int] = []
         stopped: list[int] = []
         with patch.object(server, "load_config", lambda: config), \
-             patch.object(server, "_schedule_autosync", scheduled.append), \
-             patch.object(server, "_stop_autosync", lambda: stopped.append(1)):
+             patch.object(autosync, "schedule", scheduled.append), \
+             patch.object(autosync, "stop", lambda: stopped.append(1)):
             with TestClient(server.app):
                 pass
         return scheduled, stopped
@@ -188,7 +194,7 @@ class TestAutosyncLoop:
 
     @staticmethod
     def _run_loop(returns: list[int | None], sleeps: list[float]) -> None:
-        """Drive _autosync_loop with instant sleeps and canned sync results."""
+        """Drive autosync._loop with instant sleeps and canned sync results."""
         pending = list(returns)
 
         async def fake_sleep(seconds):
@@ -197,9 +203,9 @@ class TestAutosyncLoop:
         async def fake_threadpool(fn):
             return pending.pop(0)
 
-        with patch.object(server.asyncio, "sleep", fake_sleep), \
-             patch.object(server, "run_in_threadpool", fake_threadpool):
-            asyncio.run(server._autosync_loop(30))
+        with patch.object(autosync.asyncio, "sleep", fake_sleep), \
+             patch.object(autosync, "run_in_threadpool", fake_threadpool):
+            asyncio.run(autosync._loop(30))
 
     def test_sleeps_the_interval_before_first_sync(self) -> None:
         sleeps: list[float] = []
@@ -225,7 +231,7 @@ class TestAutosyncLoop:
 
     def test_cancellation_stops_the_loop(self) -> None:
         async def scenario():
-            task = asyncio.create_task(server._autosync_loop(60))
+            task = asyncio.create_task(autosync._loop(60))
             await asyncio.sleep(0)  # let it reach the first await
             task.cancel()
             with pytest.raises(asyncio.CancelledError):
@@ -235,43 +241,43 @@ class TestAutosyncLoop:
 
 
 def _really_acquire() -> bool:
-    """Stand in for _acquire_sync_lock but take the real lock, so the
+    """Stand in for syncstate.acquire_sync_lock but take the real lock, so the
     ``finally: release()`` under test has something to release."""
-    return server._sync_executing.acquire(blocking=False)
+    return syncstate._sync_executing.acquire(blocking=False)
 
 
 class TestRunAutosyncOnce:
-    """_run_autosync_once returns the next interval, or None to stop the loop."""
+    """autosync.run_once returns the next interval, or None to stop the loop."""
 
     def test_returns_none_when_disabled(self) -> None:
-        with patch.object(server, "load_config", lambda: {"auto_sync": {"enabled": False}}):
-            assert server._run_autosync_once() is None
+        with patch.object(autosync, "load_config", lambda: {"auto_sync": {"enabled": False}}):
+            assert autosync.run_once() is None
 
     def test_returns_none_when_config_missing(self) -> None:
-        with patch.object(server, "load_config", lambda: {}):
-            assert server._run_autosync_once() is None
+        with patch.object(autosync, "load_config", lambda: {}):
+            assert autosync.run_once() is None
 
     def test_returns_interval_without_syncing_when_lock_held(self) -> None:
         """A sync already in flight must not be joined, but the loop continues."""
         cfg = {"auto_sync": {"enabled": True, "interval_minutes": 45}}
         called = []
-        with patch.object(server, "load_config", lambda: cfg), \
-             patch.object(server, "_acquire_sync_lock", lambda: False), \
-             patch.object(server, "sync", lambda **kw: called.append(kw)):
-            assert server._run_autosync_once() == 45
+        with patch.object(autosync, "load_config", lambda: cfg), \
+             patch.object(syncstate, "acquire_sync_lock", lambda: False), \
+             patch.object(autosync, "sync", lambda **kw: called.append(kw)):
+            assert autosync.run_once() == 45
         assert called == []
 
     def test_returns_interval_after_a_successful_sync(self) -> None:
         cfg = {"auto_sync": {"enabled": True, "interval_minutes": 90}}
         result = {"synced": 2, "skipped": 0, "failed": 0}
-        with patch.object(server, "load_config", lambda: cfg), \
-             patch.object(server, "_acquire_sync_lock", _really_acquire), \
-             patch.object(server, "sync", lambda **kw: result), \
-             patch.object(server, "_record_sync_log", lambda *a, **k: None):
-            assert server._run_autosync_once() == 90
+        with patch.object(autosync, "load_config", lambda: cfg), \
+             patch.object(syncstate, "acquire_sync_lock", _really_acquire), \
+             patch.object(autosync, "sync", lambda **kw: result), \
+             patch.object(syncstate, "record_sync_log", lambda *a, **k: None):
+            assert autosync.run_once() == 90
         # the lock must be free again for the next run
-        assert server._sync_executing.acquire(blocking=False)
-        server._sync_executing.release()
+        assert syncstate._sync_executing.acquire(blocking=False)
+        syncstate.release_sync_lock()
 
     def test_releases_lock_when_sync_raises(self) -> None:
         cfg = {"auto_sync": {"enabled": True, "interval_minutes": 30}}
@@ -279,13 +285,13 @@ class TestRunAutosyncOnce:
         def boom(**kw):
             raise RuntimeError("hevy down")
 
-        with patch.object(server, "load_config", lambda: cfg), \
-             patch.object(server, "_acquire_sync_lock", _really_acquire), \
-             patch.object(server, "sync", boom), \
-             patch.object(server, "_record_sync_log", lambda *a, **k: None):
-            assert server._run_autosync_once() == 30
-        assert server._sync_executing.acquire(blocking=False)
-        server._sync_executing.release()
+        with patch.object(autosync, "load_config", lambda: cfg), \
+             patch.object(syncstate, "acquire_sync_lock", _really_acquire), \
+             patch.object(autosync, "sync", boom), \
+             patch.object(syncstate, "record_sync_log", lambda *a, **k: None):
+            assert autosync.run_once() == 30
+        assert syncstate._sync_executing.acquire(blocking=False)
+        syncstate.release_sync_lock()
 
     def test_stops_loop_when_hevy_key_is_invalid(self) -> None:
         """A bad key would fail every cycle, so the loop must stop, not spin."""
@@ -297,11 +303,118 @@ class TestRunAutosyncOnce:
         def boom(**kw):
             raise HevyAuthError("401")
 
-        with patch.object(server, "load_config", lambda: cfg), \
-             patch.object(server, "_acquire_sync_lock", _really_acquire), \
-             patch.object(server, "sync", boom), \
-             patch.object(server, "save_config", saved.append), \
-             patch.object(server.db, "get_database_url", lambda: None), \
-             patch.object(server, "_record_sync_log", lambda *a, **k: None):
-            assert server._run_autosync_once() is None
+        with patch.object(autosync, "load_config", lambda: cfg), \
+             patch.object(syncstate, "acquire_sync_lock", _really_acquire), \
+             patch.object(autosync, "sync", boom), \
+             patch.object(autosync, "save_config", saved.append), \
+             patch.object(autosync.db, "get_database_url", lambda: None), \
+             patch.object(syncstate, "record_sync_log", lambda *a, **k: None):
+            assert autosync.run_once() is None
         assert saved and saved[0]["auto_sync"]["enabled"] is False
+
+
+class TestScheduleAndStop:
+    """schedule()/stop() own the task handle.
+
+    Covered because the lifespan tests patch both out, and the loop test
+    cancels its own task — so nothing here exercised the real cancel path.
+    """
+
+    def test_stop_cancels_the_running_task(self) -> None:
+        async def scenario():
+            autosync.schedule(60)
+            task = autosync._autosync_task
+            assert task is not None
+            await asyncio.sleep(0)  # let it reach the first await
+
+            autosync.stop()
+            assert autosync._autosync_task is None
+            # Checked via task.cancelled() rather than `await task`: a stop()
+            # that fails to cancel would leave the await blocked on the loop's
+            # hour-long sleep, so the test would hang instead of failing.
+            await asyncio.sleep(0)
+            assert task.cancelled()
+
+        asyncio.run(scenario())
+
+    def test_stop_is_a_no_op_without_a_task(self) -> None:
+        autosync.stop()  # must not raise
+        autosync.stop()
+        assert autosync._autosync_task is None
+
+    def test_schedule_replaces_the_previous_task(self) -> None:
+        """A second schedule() must not leave two loops syncing in parallel."""
+
+        async def scenario():
+            autosync.schedule(60)
+            first = autosync._autosync_task
+            await asyncio.sleep(0)
+
+            autosync.schedule(30)
+            second = autosync._autosync_task
+            assert second is not first
+            await asyncio.sleep(0)
+            assert first.cancelled()
+
+            autosync.stop()
+            await asyncio.sleep(0)
+            assert second.cancelled()
+
+        asyncio.run(scenario())
+
+
+class TestLastSyncTime:
+    """mark_synced()/get_last_sync_time() replaced a bare module global."""
+
+    def test_mark_synced_is_readable_back(self) -> None:
+        before = datetime.now(timezone.utc)
+        syncstate.mark_synced()
+        stamped = syncstate.get_last_sync_time()
+        assert stamped is not None
+        assert before <= stamped <= datetime.now(timezone.utc)
+
+    def test_starts_empty(self) -> None:
+        with patch.object(syncstate, "_last_sync_time", None):
+            assert syncstate.get_last_sync_time() is None
+
+
+class TestAutosyncStatus:
+    """status() renders the last/next sync labels the dashboard shows."""
+
+    @staticmethod
+    def _status(last_sync, *, enabled=True, interval=30) -> dict:
+        cfg = {"auto_sync": {"enabled": enabled, "interval_minutes": interval}}
+        with patch.object(autosync, "load_config", lambda: cfg), \
+             patch.object(autosync.db, "get_database_url", lambda: None), \
+             patch.object(syncstate, "_last_sync_time", last_sync):
+            return autosync.status()
+
+    def test_no_sync_yet_reports_no_times(self) -> None:
+        st = self._status(None)
+        assert st["last_sync"] is None
+        assert st["next_sync"] is None
+        assert st["enabled"] is True
+        assert st["interval_minutes"] == 30
+
+    def test_a_sync_seconds_ago_reads_just_now(self) -> None:
+        st = self._status(datetime.now(timezone.utc))
+        assert st["last_sync"] == "just now"
+
+    def test_minutes_are_reported_in_minutes(self) -> None:
+        st = self._status(datetime.now(timezone.utc) - timedelta(minutes=5))
+        assert st["last_sync"] == "5 min ago"
+        assert st["next_sync"] == "in 25 min"
+
+    def test_over_an_hour_is_reported_in_hours_and_minutes(self) -> None:
+        st = self._status(datetime.now(timezone.utc) - timedelta(minutes=90), interval=240)
+        assert st["last_sync"] == "1h 30m ago"
+        assert st["next_sync"] == "in 2h 30m"
+
+    def test_an_overdue_sync_is_soon(self) -> None:
+        st = self._status(datetime.now(timezone.utc) - timedelta(minutes=90), interval=30)
+        assert st["next_sync"] == "soon"
+
+    def test_next_sync_is_blank_while_disabled(self) -> None:
+        st = self._status(datetime.now(timezone.utc) - timedelta(minutes=5), enabled=False)
+        assert st["last_sync"] == "5 min ago"
+        assert st["next_sync"] is None

--- a/tests/test_server_routes.py
+++ b/tests/test_server_routes.py
@@ -18,6 +18,7 @@ from unittest.mock import patch
 import pytest
 from fastapi.testclient import TestClient
 
+from hevy2garmin import autosync, syncstate
 from hevy2garmin import server as srv
 
 
@@ -180,8 +181,8 @@ class TestToggleAutosync:
         with patch.object(srv, "load_config", lambda: {}), \
              patch.object(srv, "save_config", saved.append), \
              patch.object(srv.db, "get_database_url", lambda: None), \
-             patch.object(srv, "_schedule_autosync", started.append), \
-             patch.object(srv, "_stop_autosync", lambda: stopped.append(1)):
+             patch.object(autosync, "schedule", started.append), \
+             patch.object(autosync, "stop", lambda: stopped.append(1)):
             r = client.post("/api/toggle-autosync", data=form)
         return r, started, stopped, saved
 
@@ -216,7 +217,7 @@ class TestToggleAutosync:
         started: list[int] = []
         saved: list[dict] = []
         with patch.object(srv, "save_config", saved.append), \
-             patch.object(srv, "_schedule_autosync", started.append):
+             patch.object(autosync, "schedule", started.append):
             r = demo_client.post("/api/toggle-autosync", data={"enabled": "true"})
         assert r.json()["status"] == "demo"
         assert started == [] and saved == []
@@ -470,7 +471,7 @@ class TestRoutinesSync:
     def test_refuses_while_another_sync_holds_the_lock(self, client) -> None:
         """Two concurrent routine syncs would race on the Garmin calendar."""
         called: list[int] = []
-        with patch.object(srv, "_acquire_sync_lock", lambda: False), \
+        with patch.object(syncstate, "acquire_sync_lock", lambda: False), \
              patch.object(srv, "sync_routines", lambda **k: called.append(1)):
             r = client.post("/api/routines/sync")
         assert "already running" in r.text.lower()

--- a/tests/test_server_routes.py
+++ b/tests/test_server_routes.py
@@ -178,7 +178,11 @@ class TestToggleAutosync:
         started: list[int] = []
         stopped: list[int] = []
         saved: list[dict] = []
+        # autosync.load_config as well as srv's: the route finishes by rendering
+        # autosync.status(), which reads the config through its own module. Left
+        # unpatched it would read the developer's real ~/.hevy2garmin/config.json.
         with patch.object(srv, "load_config", lambda: {}), \
+             patch.object(autosync, "load_config", lambda: {}), \
              patch.object(srv, "save_config", saved.append), \
              patch.object(srv.db, "get_database_url", lambda: None), \
              patch.object(autosync, "schedule", started.append), \

--- a/tests/test_sync_log_triggers.py
+++ b/tests/test_sync_log_triggers.py
@@ -33,6 +33,12 @@ def client(monkeypatch):
     os.environ.pop("HEVY2GARMIN_SECRET", None)
     os.environ.pop("DEMO_MODE", None)
     os.environ.pop("CRON_SECRET", None)
+    # /api/sync hands off to GitHub Actions when both of these are set, which
+    # would skip the sync under test *and* fire a real repository_dispatch at
+    # api.github.com from whatever machine runs the suite.
+    os.environ.pop("GITHUB_PAT", None)
+    os.environ.pop("GITHUB_REPO", None)
+    os.environ.pop("VERCEL", None)
     from hevy2garmin import server
 
     monkeypatch.setattr(server, "_is_configured_cache", True)

--- a/tests/test_sync_log_triggers.py
+++ b/tests/test_sync_log_triggers.py
@@ -18,12 +18,12 @@ from fastapi.testclient import TestClient
 
 @pytest.fixture
 def recorded(monkeypatch):
-    """Collect what _record_sync_log is asked to write."""
-    from hevy2garmin import server
+    """Collect what syncstate.record_sync_log is asked to write."""
+    from hevy2garmin import syncstate
 
     rows: list[tuple[dict, str]] = []
     monkeypatch.setattr(
-        server, "_record_sync_log", lambda result, trigger="manual": rows.append((result, trigger))
+        syncstate, "record_sync_log", lambda result, trigger="manual": rows.append((result, trigger))
     )
     return rows
 
@@ -157,15 +157,15 @@ class TestCronIsRecorded:
 
 class TestLockIsStillHeldAndReleased:
     def test_busy_response_records_nothing(self, client, recorded, monkeypatch):
-        from hevy2garmin import server
+        from hevy2garmin import syncstate
 
-        monkeypatch.setattr(server, "_acquire_sync_lock", lambda: False)
+        monkeypatch.setattr(syncstate, "acquire_sync_lock", lambda: False)
         resp = client.post("/api/sync-one")
         assert json.loads(resp.content)["busy"] is True
         assert recorded == []
 
     def test_lock_is_released_even_when_the_sync_raises(self, client, recorded, monkeypatch):
-        from hevy2garmin import server
+        from hevy2garmin import server, syncstate
 
         async def _boom(*, respect_grace=False, **kw):
             raise RuntimeError("boom")
@@ -174,22 +174,22 @@ class TestLockIsStillHeldAndReleased:
         with pytest.raises(RuntimeError):
             client.post("/api/sync-one")
         # A leaked semaphore would make the next sync permanently "busy".
-        assert server._acquire_sync_lock() is True
-        server._sync_executing.release()
+        assert syncstate.acquire_sync_lock() is True
+        syncstate.release_sync_lock()
         # Recording on the exception path must not swallow the exception either.
         assert recorded == [({"failed": 1}, "manual (one)")]
 
 
 class TestRecordingNeverBreaksASync:
     def test_a_failing_db_write_is_swallowed(self, monkeypatch):
-        """_record_sync_log now runs from inside except handlers."""
-        from hevy2garmin import db, server
+        """syncstate.record_sync_log now runs from inside except handlers."""
+        from hevy2garmin import db, syncstate
 
         def _boom(**kw):
             raise RuntimeError("database is locked")
 
         monkeypatch.setattr(db, "record_sync_log", _boom)
-        server._record_sync_log({"synced": 1}, trigger="manual (one)")  # must not raise
+        syncstate.record_sync_log({"synced": 1}, trigger="manual (one)")  # must not raise
 
 
 class TestPerRowSyncIsRecorded:
@@ -235,3 +235,47 @@ class TestPerRowSyncIsRecorded:
         assert resp.status_code == 200
         assert "Failed:" in resp.text
         assert recorded == [({"failed": 1}, "manual (single)")]
+
+
+class TestDashboardSyncIsRecorded:
+    """/api/sync records with the scope in its trigger label.
+
+    The label is the only thing on /history that distinguishes a 24h sync from
+    a full backfill, and nothing asserted it — replacing it with a constant
+    passed the whole suite.
+    """
+
+    def test_default_scope_is_labelled(self, client, recorded, monkeypatch):
+        from hevy2garmin import server
+
+        monkeypatch.setattr(server, "sync", lambda **kw: {"synced": 1, "skipped": 0, "failed": 0})
+        r = client.post("/api/sync", data={})
+        assert r.status_code == 200
+        assert recorded == [({"synced": 1, "skipped": 0, "failed": 0}, "manual (recent)")]
+
+    def test_scope_is_carried_into_the_label(self, client, recorded, monkeypatch):
+        from hevy2garmin import server
+
+        monkeypatch.setattr(server, "sync", lambda **kw: {"synced": 0, "skipped": 0, "failed": 0})
+        client.post("/api/sync", data={"scope": "1y"})
+        assert recorded and recorded[0][1] == "manual (1y)"
+
+    def test_a_failing_sync_still_records_under_its_scope(self, client, recorded, monkeypatch):
+        from hevy2garmin import server
+
+        def _boom(**kw):
+            raise RuntimeError("hevy down")
+
+        monkeypatch.setattr(server, "sync", _boom)
+        client.post("/api/sync", data={"scope": "7d"})
+        assert recorded and recorded[0][1] == "manual (7d)"
+        assert recorded[0][0]["failed"] == 1
+
+    def test_a_sync_stamps_the_last_sync_time(self, client, recorded, monkeypatch):
+        """The dashboard's "last sync" clock is driven from this call site."""
+        from hevy2garmin import server, syncstate
+
+        monkeypatch.setattr(server, "sync", lambda **kw: {"synced": 1, "skipped": 0, "failed": 0})
+        monkeypatch.setattr(syncstate, "_last_sync_time", None)
+        client.post("/api/sync", data={})
+        assert syncstate.get_last_sync_time() is not None


### PR DESCRIPTION
`server.py` is 2913 lines — 2.2× the next largest module. This lifts out the two clusters with the clearest seam, leaving it at 2724.

## What moves

**`hevy2garmin.syncstate`** (89 lines) — the sync lock, its hung-sync force-release, the last-sync timestamp and the sync-log writer. Shared by every sync entry point: Sync Now, the per-row sync, the cron endpoint, the routine routes and auto-sync.

**`hevy2garmin.autosync`** (164 lines) — the scheduled loop and its task handle, depending on `syncstate` for the lock.

Dependency direction is one-way: `server` → both, `autosync` → `syncstate`. No import cycle.

## Why accessors instead of shared globals

`from mod import _last_sync_time` copies the value at import time, which is how you end up with two divergent copies of one piece of state. Mutable state is reached through `mark_synced()` / `get_last_sync_time()` and the lock helpers instead. The lock and the failed-id set are safe to share only because they are mutated in place and never rebound — that distinction is the whole reason the split is not a cut-and-paste.

## What deliberately stays behind

`_unmapped_cache`, `_unmapped_cache_time` and `_failed_ids` sit in the same state block but auto-sync never reads any of them. The first is an exercise-mapping cache invalidated by three mapping routes; the second is skip state local to `_do_sync_one`. Moving them would have made those routes depend on the auto-sync module for state it does not touch.

## Verification

A green suite proves very little for a refactor like this, so every guard in the moved code was mutation-tested — nine deliberate breaks, all caught:

| Mutation | |
|---|---|
| `acquire_sync_lock` never reports contention | caught |
| `release_sync_lock` is a no-op | caught |
| `run_once` keeps looping on a disabled config | caught |
| `run_once` does not stop on a bad Hevy key | caught |
| `stop()` does not cancel the task | caught |
| the loop ignores the re-read interval | caught |
| `/api/sync` drops its trigger label | caught |
| `/api/sync` never stamps the last-sync time | caught |
| `lifespan` never schedules auto-sync | caught |

Three of those initially **survived**, exposing pre-existing gaps in code this PR moves: `stop()`'s cancel path (the lifespan tests patch `stop` out entirely), the `manual ({scope})` label on `/api/sync`, and the entire last-sync-time path — deleting `mark_synced()` passed all 772 tests. 15 tests were added to close them.

**787 passed, 7 skipped** (was 772 / 7).

The second commit is review follow-up: the new `/api/sync` tests needed `GITHUB_PAT`/`GITHUB_REPO` popped, since that route hands off to GitHub Actions when both are set and would otherwise fire a real `repository_dispatch`. Also a dead `import time`, a stale `lifespan` docstring, and two test-isolation leaks.
