### PR TITLE
Emit FIT local_timestamp from a configurable timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,10 +576,13 @@ account; the watch brand you wear at the gym doesn't matter. It runs in the
 browser/cloud, not on the watch.
 
 **My activity shows the wrong time on Strava.**
-When Garmin pushes an API-uploaded activity to Strava, Strava sometimes uses the
-upload time instead of the workout time. The FIT file and Garmin Connect have the
-correct time — this is a Garmin→Strava quirk for non-watch uploads and isn't
-something hevy2garmin can control.
+The FIT file and Garmin Connect have the correct time. The problem is the handoff
+to Strava: for uploads that did not come from a real Garmin device, Strava can
+render the raw UTC time instead of your local time, so a 6am workout in a UTC+3
+zone shows up as 3am. Set your **Timezone** in Settings (Profile section, an IANA
+name like `Europe/Berlin`) and the tool stamps your local time into the uploaded
+file, so the correct offset travels with the activity. Leave it blank to keep the
+previous UTC behaviour.
 
 **Does 2FA / MFA work on Garmin?**
 Native 2FA support is in progress (tracked in

--- a/src/hevy2garmin/fit.py
+++ b/src/hevy2garmin/fit.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from hevy2garmin._isotime import parse_iso
 from pathlib import Path
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from fit_tool.fit_file_builder import FitFileBuilder
 from fit_tool.profile.messages.file_id_message import FileIdMessage
@@ -42,6 +43,11 @@ _MAX_SCALE = 2.0
 _DEFAULT_HR_BPM = 90  # fallback when no HR data at all
 DEFAULT_HR_BPM = _DEFAULT_HR_BPM  # public alias
 
+# FIT date_time epoch: 1989-12-31 00:00:00 UTC, in Unix seconds. The FIT
+# ``local_timestamp`` field is a plain uint32 of seconds-since-this-epoch in
+# local wall-clock time (unlike ``timestamp``, which fit_tool takes in ms).
+_FIT_EPOCH_S = 631065600
+
 
 def _get_profile(override: dict | None = None) -> dict:
     """Get user profile + timing from config, with optional overrides."""
@@ -51,6 +57,7 @@ def _get_profile(override: dict | None = None) -> dict:
         "weight_kg": cfg.get("user_profile", {}).get("weight_kg", 80.0),
         "birth_year": cfg.get("user_profile", {}).get("birth_year", 1990),
         "vo2max": cfg.get("user_profile", {}).get("vo2max", 45.0),
+        "timezone": cfg.get("user_profile", {}).get("timezone", ""),
         "working_set_s": cfg.get("timing", {}).get("working_set_seconds", 40),
         "warmup_set_s": cfg.get("timing", {}).get("warmup_set_seconds", 25),
         "rest_sets_s": cfg.get("timing", {}).get("rest_between_sets_seconds", 75),
@@ -64,6 +71,22 @@ def _get_profile(override: dict | None = None) -> dict:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+def _tz_offset_seconds(tz_name: str, at: datetime) -> int | None:
+    """UTC offset (seconds) for an IANA zone at a given instant, DST-correct.
+
+    Returns ``None`` for an empty or unrecognised zone — a bad timezone must
+    never crash a sync, it just means no local_timestamp is written.
+    """
+    if not tz_name:
+        return None
+    try:
+        tz = ZoneInfo(tz_name)
+    except (ZoneInfoNotFoundError, ValueError):
+        return None
+    off = at.astimezone(tz).utcoffset()
+    return int(off.total_seconds()) if off is not None else None
+
 
 def _ms(dt: datetime) -> int:
     """Convert a datetime to milliseconds since Unix epoch."""
@@ -431,6 +454,12 @@ def generate_fit(
     activity.type = Activity.MANUAL
     activity.event = Event.ACTIVITY
     activity.event_type = EventType.STOP
+    # Stamp local wall-clock time when a timezone is configured. Hevy gives us
+    # UTC only, so without this the activity carries no offset and Garmin can
+    # forward it to Strava as raw UTC (a 6am workout showing up as 3am).
+    tz_offset_s = _tz_offset_seconds(p.get("timezone", ""), start_dt)
+    if tz_offset_s is not None:
+        activity.local_timestamp = (end_ms // 1000 + tz_offset_s) - _FIT_EPOCH_S
     builder.add(activity)
 
     # -- Write file --

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -1219,6 +1219,7 @@ async def settings_page(request: Request):
 async def settings_save(
     hevy_api_key: str = Form(""), garmin_email: str = Form(""), garmin_password: str = Form(""),
     weight_kg: float = Form(80.0), birth_year: int = Form(1990), sex: str = Form("male"), vo2max: float = Form(45.0),
+    timezone: str = Form(""),
     working_set_seconds: int = Form(40), warmup_set_seconds: int = Form(25),
     rest_between_sets_seconds: int = Form(75), rest_between_exercises_seconds: int = Form(120),
     hr_fusion_enabled: str = Form("off"),
@@ -1239,7 +1240,10 @@ async def settings_save(
         config["garmin_email"] = garmin_email
     if garmin_password:
         config["garmin_password"] = garmin_password
-    config["user_profile"].update(weight_kg=weight_kg, birth_year=birth_year, sex=sex, vo2max=vo2max)
+    config["user_profile"].update(
+        weight_kg=weight_kg, birth_year=birth_year, sex=sex, vo2max=vo2max,
+        timezone=timezone.strip(),
+    )
     config["timing"].update(
         working_set_seconds=working_set_seconds, warmup_set_seconds=warmup_set_seconds,
         rest_between_sets_seconds=rest_between_sets_seconds,

--- a/src/hevy2garmin/templates/settings.html
+++ b/src/hevy2garmin/templates/settings.html
@@ -114,6 +114,17 @@
                 <input class="form-input" type="number" id="vo2max" name="vo2max" value="{{ config.get('user_profile', {}).get('vo2max', 45) }}" step="0.1">
                 <div class="form-hint">Used in calorie formula. Auto-filled by "Pull from Garmin".</div>
             </div>
+            <div class="form-group">
+                <label class="form-label" for="timezone">Timezone</label>
+                <input class="form-input" type="text" id="timezone" name="timezone" list="tz-list" placeholder="e.g. Europe/Berlin" value="{{ config.get('user_profile', {}).get('timezone', '') }}">
+                <datalist id="tz-list">
+                    <option value="Europe/London"><option value="Europe/Berlin"><option value="Europe/Madrid"><option value="Europe/Athens">
+                    <option value="America/New_York"><option value="America/Chicago"><option value="America/Denver"><option value="America/Los_Angeles"><option value="America/Sao_Paulo">
+                    <option value="Asia/Dubai"><option value="Asia/Kolkata"><option value="Asia/Singapore"><option value="Asia/Tokyo">
+                    <option value="Australia/Sydney"><option value="Pacific/Auckland">
+                </datalist>
+                <div class="form-hint">Optional IANA name. Stamps your local time into the uploaded file so Strava shows the right time. Leave blank to keep UTC.</div>
+            </div>
         </div>
 
         <!-- Calorie formula explanation -->

--- a/tests/test_server_routes.py
+++ b/tests/test_server_routes.py
@@ -682,3 +682,30 @@ class TestSetupActions:
             srv._is_configured_cache = True
         assert r.status_code == 200, "must not redirect to /setup"
         assert seen == [60]
+
+
+class TestTimezoneSetting:
+    """POST /settings persists the profile timezone used for FIT local_timestamp."""
+
+    _FORM = {
+        "weight_kg": "80", "birth_year": "1990", "sex": "male", "vo2max": "45",
+        "working_set_seconds": "40", "warmup_set_seconds": "25",
+        "rest_between_sets_seconds": "75", "rest_between_exercises_seconds": "120",
+    }
+
+    def _post(self, client, tz: str) -> dict:
+        store: dict = {"user_profile": {}, "timing": {}, "hr_fusion": {}}
+        with patch.object(srv, "load_config", lambda: store), \
+             patch.object(srv, "save_config", lambda c: store.update(c)), \
+             patch.object(srv.db, "get_database_url", lambda: None):
+            r = client.post("/settings", data={**self._FORM, "timezone": tz})
+        assert r.status_code == 200
+        return store
+
+    def test_timezone_is_saved_and_stripped(self, client) -> None:
+        store = self._post(client, "  Europe/Berlin  ")
+        assert store["user_profile"]["timezone"] == "Europe/Berlin"
+
+    def test_blank_timezone_persists_as_empty(self, client) -> None:
+        store = self._post(client, "")
+        assert store["user_profile"]["timezone"] == ""

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -1,0 +1,96 @@
+"""Timezone -> FIT ``local_timestamp``: keep the correct local time on Strava.
+
+Hevy hands us UTC-only timestamps, so with no configured zone we emit no
+``local_timestamp`` (unchanged behaviour). With one, we stamp the activity's
+local wall-clock time into the FIT so Garmin can forward the right offset to
+Strava, which otherwise renders the raw UTC instant.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from fit_tool.fit_file import FitFile
+from fit_tool.profile.messages.activity_message import ActivityMessage
+
+from hevy2garmin.fit import generate_fit, _tz_offset_seconds, _FIT_EPOCH_S
+
+
+def _workout(start_iso: str, end_iso: str) -> dict:
+    return {
+        "id": "tz-test",
+        "title": "Push",
+        "start_time": start_iso,
+        "end_time": end_iso,
+        "exercises": [
+            {
+                "index": 0,
+                "title": "Bench Press (Barbell)",
+                "exercise_template_id": "79D0BB3A",
+                "sets": [{"index": 0, "type": "normal", "weight_kg": 60, "reps": 5}],
+            }
+        ],
+    }
+
+
+def _activity_msg(fit_path: str) -> ActivityMessage | None:
+    for r in FitFile.from_file(fit_path).records:
+        if isinstance(r.message, ActivityMessage):
+            return r.message
+    return None
+
+
+def _embedded_offset_s(msg: ActivityMessage) -> int:
+    """UTC offset (seconds) implied by local_timestamp vs the UTC timestamp."""
+    return msg.local_timestamp - (msg.timestamp // 1000 - _FIT_EPOCH_S)
+
+
+class TestTzOffsetHelper:
+    def test_summer_offset(self) -> None:
+        # Europe/Berlin is CEST (UTC+2) on 1 July.
+        assert _tz_offset_seconds("Europe/Berlin", datetime(2026, 7, 1, tzinfo=timezone.utc)) == 7200
+
+    def test_winter_offset(self) -> None:
+        # Same zone is CET (UTC+1) on 1 January — the helper must be DST-aware.
+        assert _tz_offset_seconds("Europe/Berlin", datetime(2026, 1, 1, tzinfo=timezone.utc)) == 3600
+
+    def test_negative_offset(self) -> None:
+        # America/New_York is EDT (UTC-4) on 1 July.
+        assert _tz_offset_seconds("America/New_York", datetime(2026, 7, 1, tzinfo=timezone.utc)) == -4 * 3600
+
+    def test_empty_zone_is_none(self) -> None:
+        assert _tz_offset_seconds("", datetime(2026, 7, 1, tzinfo=timezone.utc)) is None
+
+    def test_invalid_zone_is_none(self) -> None:
+        assert _tz_offset_seconds("Not/AZone", datetime(2026, 7, 1, tzinfo=timezone.utc)) is None
+
+
+class TestFitLocalTimestamp:
+    def test_absent_without_timezone(self, sample_profile: dict, tmp_path) -> None:
+        prof = dict(sample_profile)
+        prof["timezone"] = ""  # explicit: no zone configured
+        out = str(tmp_path / "w.fit")
+        generate_fit(_workout("2026-07-01T12:00:00+00:00", "2026-07-01T12:45:00+00:00"), None, out, profile=prof)
+        assert _activity_msg(out).local_timestamp is None
+
+    def test_set_with_timezone_summer(self, sample_profile: dict, tmp_path) -> None:
+        prof = dict(sample_profile)
+        prof["timezone"] = "Europe/Berlin"
+        out = str(tmp_path / "w.fit")
+        generate_fit(_workout("2026-07-01T12:00:00+00:00", "2026-07-01T12:45:00+00:00"), None, out, profile=prof)
+        assert _embedded_offset_s(_activity_msg(out)) == 7200
+
+    def test_dst_winter_offset_differs(self, sample_profile: dict, tmp_path) -> None:
+        prof = dict(sample_profile)
+        prof["timezone"] = "Europe/Berlin"
+        out = str(tmp_path / "w.fit")
+        generate_fit(_workout("2026-01-01T12:00:00+00:00", "2026-01-01T12:45:00+00:00"), None, out, profile=prof)
+        assert _embedded_offset_s(_activity_msg(out)) == 3600
+
+    def test_invalid_timezone_does_not_crash_and_omits(self, sample_profile: dict, tmp_path) -> None:
+        prof = dict(sample_profile)
+        prof["timezone"] = "Not/AZone"
+        out = str(tmp_path / "w.fit")
+        generate_fit(_workout("2026-07-01T12:00:00+00:00", "2026-07-01T12:45:00+00:00"), None, out, profile=prof)
+        assert _activity_msg(out).local_timestamp is None


### PR DESCRIPTION
## What

Optional `user_profile.timezone` (IANA, e.g. `Europe/Berlin`). When set, the generated FIT carries `ActivityMessage.local_timestamp` (the workout's local wall-clock time), computed with a DST-correct offset from stdlib `zoneinfo` at the workout's own date.

## Why

Hevy only gives UTC timestamps and nothing stored a timezone, so uploads carried no local offset. Garmin Connect shows the right time (it applies the account zone), but when Garmin forwards an API/non-device upload to Strava, Strava renders the raw UTC instant — a 6am workout in a UTC+3 zone shows up as a 3am "Night" workout. Reported on Reddit (u/Icondacarver). Stamping `local_timestamp` gives Garmin an explicit offset in the activity to forward.

## Details

- `_tz_offset_seconds(tz, at)` returns the DST-correct UTC offset, or `None` for an empty/invalid zone (a bad zone never crashes a sync, it just skips the stamp).
- `local_timestamp` is a plain uint32 of seconds-since-the-FIT-epoch in local time (unlike `timestamp`, which fit_tool takes in ms). Verified the conversion by round-tripping a built FIT: 12:00Z + 2h decodes back to a 14:00 wall clock.
- Timezone field added to the Settings → Profile form (with a datalist of common zones); persists like the other profile fields.
- Corrects the "wrong time on Strava" FAQ — the real cause is the dropped offset, not the upload time.

## Tests

`tests/test_timezone.py` (9): offset helper for summer/winter/negative/empty/invalid zones; FIT `local_timestamp` present + correct (summer +2h, winter +1h to prove DST-awareness), absent without a zone, and an invalid zone omitting it without crashing. Plus 2 in `test_server_routes.py` for the settings-save wiring (saved + whitespace-stripped). Full suite green locally (774 passed).

## Honest scope

The FIT and Garmin Connect were always correct; this changes what Garmin forwards to Strava. The FIT now carries the right local offset, but whether Strava honours it on the forward is Garmin's behaviour and wants real-world confirmation.

Closes #344
Closes #345
Closes #346
Closes #347
