### PR TITLE
fix(deps): restore psycopg2-binary to base deps so Vercel/Neon deploys work

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,11 @@ dependencies = [
     "jinja2>=3.1",
     "python-multipart>=0.0.9",
     "pynacl>=1.5",
+    # Postgres/Neon driver. Kept in base (not just the [cloud] extra) because the
+    # Vercel one-click deploy — the primary hosted path — installs the pyproject
+    # base dependencies, not the [cloud] extra, so a cloud deploy needs it here or
+    # it fails at runtime with "No module named 'psycopg2'" (#357).
+    "psycopg2-binary>=2.9",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Problem

A new user reported (#357) that a fresh Vercel + Neon deploy crashes on the dashboard with `ModuleNotFoundError: No module named 'psycopg2'`, even though Neon is connected.

## Root cause

#335 moved `psycopg2-binary` from the base `[project.dependencies]` into the `[cloud]` optional extra, to spare self-hosted SQLite installs a database driver they don't use. But the Vercel one-click deploy (the primary hosted path, and what the no-code guide walks users through) installs the **pyproject base dependencies**, not the `[cloud]` extra. So since #335, every fresh cloud deploy has shipped without psycopg2 and fails the moment the dashboard queries Neon. The traceback confirms it: the app boots (fastapi/starlette load) and only dies when a DB call hits the missing driver.

## Fix

Restore `psycopg2-binary>=2.9` to base `[project.dependencies]`. Verified a base `pip install .` (no extras) now imports psycopg2 2.9.x. psycopg2-binary ships manylinux/macos/win wheels, so self-hosters take a small wheel with no compilation — the cost #335 was avoiding is minimal, and correctness for the primary deploy path wins.

Closes #357
