### PR TITLE
feat: editable settings form on the web app (#361)

### DIFF
--- a/web/app/api/settings/route.ts
+++ b/web/app/api/settings/route.ts
@@ -1,0 +1,119 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { getDb } from "@/lib/db";
+import { verifySession, SESSION_COOKIE, authEnabled } from "@/lib/auth";
+
+// Writes config to the live hevy2garmin Postgres (app_cache) at request time.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * POST /api/settings
+ * Body: a partial map of editable config keys, e.g.
+ *   { auto_sync: { enabled, interval_minutes },
+ *     hr_fusion: { enabled },
+ *     merge_settings: { merge_watch_strategy, merge_activity_types },
+ *     user_profile: { weight_kg } }
+ *
+ * Session-gated. For each provided key it sanitises the payload, deep-merges it
+ * onto the stored value (preserving sub-fields the form doesn't manage), and
+ * upserts into app_cache — matching PostgresDatabase.set_cache (db_postgres.py:499).
+ * Config only; no sync/upload side effects.
+ */
+
+const INTERVALS = [30, 60, 120, 240, 360, 720, 1440];
+const WATCH_STRATEGIES = ["replace", "merge", "describe"];
+
+type Obj = Record<string, unknown>;
+
+function isObj(v: unknown): v is Obj {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** Keep only the recognised, validated sub-fields for a given config key. */
+function sanitise(key: string, raw: Obj): Obj {
+  const out: Obj = {};
+  if (key === "auto_sync") {
+    if ("enabled" in raw) out.enabled = Boolean(raw.enabled);
+    if ("interval_minutes" in raw) {
+      const n = Number(raw.interval_minutes);
+      out.interval_minutes = INTERVALS.includes(n) ? n : 120;
+    }
+  } else if (key === "hr_fusion") {
+    if ("enabled" in raw) out.enabled = Boolean(raw.enabled);
+  } else if (key === "merge_settings") {
+    if ("merge_watch_strategy" in raw) {
+      const s = String(raw.merge_watch_strategy);
+      out.merge_watch_strategy = WATCH_STRATEGIES.includes(s) ? s : "merge";
+    }
+    if (Array.isArray(raw.merge_activity_types)) {
+      out.merge_activity_types = (raw.merge_activity_types as unknown[]).map(String).filter(Boolean);
+    }
+  } else if (key === "user_profile") {
+    if ("weight_kg" in raw) {
+      const w = Number(raw.weight_kg);
+      if (Number.isFinite(w) && w > 0 && w < 500) out.weight_kg = Math.round(w * 10) / 10;
+    }
+  }
+  return out;
+}
+
+const EDITABLE = ["auto_sync", "hr_fusion", "merge_settings", "user_profile"];
+
+export async function POST(request: Request) {
+  // Gate only when a password is configured (prod). With no password set the app
+  // is open, matching the login model and the other benign DB-write routes.
+  if (authEnabled()) {
+    const store = await cookies();
+    if (!(await verifySession(store.get(SESSION_COOKIE)?.value ?? null))) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+  }
+
+  let body: Obj;
+  try {
+    body = (await request.json()) as Obj;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const changes: Record<string, Obj> = {};
+  for (const key of EDITABLE) {
+    if (isObj(body[key])) {
+      const s = sanitise(key, body[key] as Obj);
+      if (Object.keys(s).length > 0) changes[key] = s;
+    }
+  }
+  const keys = Object.keys(changes);
+  if (keys.length === 0) {
+    return NextResponse.json({ error: "No editable config provided." }, { status: 400 });
+  }
+
+  let sql: ReturnType<typeof getDb>;
+  try {
+    sql = getDb();
+  } catch {
+    return NextResponse.json({ error: "DATABASE_URL not configured." }, { status: 503 });
+  }
+
+  try {
+    const existing = (await sql`SELECT key, value FROM app_cache WHERE key = ANY(${keys})`) as {
+      key: string;
+      value: unknown;
+    }[];
+    const existingMap = new Map(existing.map((r) => [r.key, isObj(r.value) ? r.value : {}]));
+
+    for (const key of keys) {
+      const merged = { ...(existingMap.get(key) ?? {}), ...changes[key] };
+      await sql`
+        INSERT INTO app_cache (key, value)
+        VALUES (${key}, ${sql.json(merged)})
+        ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()
+      `;
+    }
+    return NextResponse.json({ ok: true, saved: keys });
+  } catch (err) {
+    console.error("settings write failed:", err);
+    return NextResponse.json({ error: "Failed to save settings." }, { status: 500 });
+  }
+}

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -1,4 +1,5 @@
 import { getDb } from "@/lib/db";
+import { SettingsForm } from "@/components/settings-form";
 
 // Queries the live hevy2garmin Postgres per request — never at build time.
 export const dynamic = "force-dynamic";
@@ -114,19 +115,25 @@ function StatusPill({ status }: { status: string }) {
 
 export default async function SettingsPage() {
   const data = await loadSettings();
+  const cfg = (key: string): Record<string, unknown> =>
+    data.config.find((c) => c.key === key)?.value ?? {};
+  const autoSync = cfg("auto_sync");
+  const hrFusion = cfg("hr_fusion");
+  const merge = cfg("merge_settings");
+  const profile = cfg("user_profile");
 
   return (
     <main className="mx-auto max-w-5xl px-4 py-8 md:px-6">
       <header className="mb-4">
         <h1 className="text-2xl font-bold text-text">Settings</h1>
         <p className="mt-1 text-sm text-text-secondary">
-          Current configuration and connection status.
+          Configuration and connection status.
         </p>
       </header>
 
       <div className="mb-6 rounded-lg border border-border bg-surface p-4 text-sm text-text-muted">
-        Read-only for now. Editing credentials and config from the web app comes
-        in a later phase.
+        Editing platform credentials from the web comes in a later phase; the
+        config below is editable now.
       </div>
 
       {!data.dbConfigured && (
@@ -178,9 +185,21 @@ export default async function SettingsPage() {
         )}
       </section>
 
-      {/* Config */}
-      <section>
+      {/* Editable config */}
+      <section className="mb-8">
         <h2 className="mb-3 text-lg font-semibold text-text">Configuration</h2>
+        <SettingsForm
+          autoSyncEnabled={Boolean(autoSync.enabled)}
+          autoSyncInterval={Number(autoSync.interval_minutes) || 120}
+          hrFusionEnabled={hrFusion.enabled == null ? true : Boolean(hrFusion.enabled)}
+          mergeWatchStrategy={String(merge.merge_watch_strategy ?? "merge")}
+          weightKg={profile.weight_kg != null ? Number(profile.weight_kg) : null}
+        />
+      </section>
+
+      {/* All stored config (read-only reference) */}
+      <section>
+        <h2 className="mb-3 text-lg font-semibold text-text">Stored config</h2>
         {data.config.length === 0 ? (
           <div className="rounded-lg border border-border bg-surface p-6 text-center text-sm text-text-muted">
             No configuration stored yet (defaults are in use).

--- a/web/components/settings-form.tsx
+++ b/web/components/settings-form.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+interface Props {
+  autoSyncEnabled: boolean;
+  autoSyncInterval: number;
+  hrFusionEnabled: boolean;
+  mergeWatchStrategy: string;
+  weightKg: number | null;
+}
+
+const INTERVALS = [30, 60, 120, 240, 360, 720, 1440];
+const STRATEGIES: { value: string; label: string }[] = [
+  { value: "replace", label: "Replace — upload a fresh strength activity" },
+  { value: "merge", label: "Merge — fold sets/reps into the watch activity" },
+  { value: "describe", label: "Describe — only set the watch activity's notes" },
+];
+
+function fmtInterval(m: number): string {
+  if (m < 60) return `${m} min`;
+  const h = m / 60;
+  return h === 1 ? "1 hour" : h < 24 ? `${h} hours` : "1 day";
+}
+
+const cardCls = "rounded-xl border border-border bg-surface-elevated p-4";
+const labelCls = "mb-1 block text-xs text-text-muted";
+const controlCls =
+  "w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text focus:border-teal focus:outline-none";
+
+/**
+ * Editable configuration form for the settings page. Posts the changed config
+ * keys to /api/settings (which upserts them into app_cache, matching the Python
+ * config schema) and refreshes the server-rendered view on success.
+ */
+export function SettingsForm(p: Props) {
+  const router = useRouter();
+  const [autoSync, setAutoSync] = useState(p.autoSyncEnabled);
+  const [interval, setIntervalMin] = useState(p.autoSyncInterval);
+  const [hrFusion, setHrFusion] = useState(p.hrFusionEnabled);
+  const [strategy, setStrategy] = useState(p.mergeWatchStrategy);
+  const [weight, setWeight] = useState(p.weightKg != null ? String(p.weightKg) : "");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [saved, setSaved] = useState(false);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setSaved(false);
+    setBusy(true);
+    try {
+      const w = weight.trim();
+      const body = {
+        auto_sync: { enabled: autoSync, interval_minutes: interval },
+        hr_fusion: { enabled: hrFusion },
+        merge_settings: { merge_watch_strategy: strategy },
+        ...(w ? { user_profile: { weight_kg: Number(w) } } : {}),
+      };
+      const res = await fetch("/api/settings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const data = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      if (!res.ok || !data.ok) {
+        setError(data.error ?? `Request failed (${res.status}).`);
+        return;
+      }
+      setSaved(true);
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form onSubmit={submit} className="grid grid-cols-1 gap-4 md:grid-cols-2">
+      <div className={cardCls}>
+        <label className="flex items-center justify-between gap-2">
+          <span className="text-sm font-semibold text-text">Auto-sync</span>
+          <input type="checkbox" checked={autoSync} onChange={(e) => setAutoSync(e.target.checked)} className="h-4 w-4 accent-teal" />
+        </label>
+        <p className="mb-2 mt-0.5 text-xs text-text-muted">Poll Hevy and push new workouts on a schedule.</p>
+        <label className={labelCls} htmlFor="sf-interval">Interval</label>
+        <select id="sf-interval" value={interval} onChange={(e) => setIntervalMin(Number.parseInt(e.target.value, 10))} disabled={!autoSync} className={`${controlCls} disabled:opacity-50`}>
+          {INTERVALS.map((m) => (
+            <option key={m} value={m}>{fmtInterval(m)}</option>
+          ))}
+        </select>
+      </div>
+
+      <div className={cardCls}>
+        <label className="flex items-center justify-between gap-2">
+          <span className="text-sm font-semibold text-text">HR fusion</span>
+          <input type="checkbox" checked={hrFusion} onChange={(e) => setHrFusion(e.target.checked)} className="h-4 w-4 accent-teal" />
+        </label>
+        <p className="mt-0.5 text-xs text-text-muted">Pull heart-rate from a matched Garmin activity into the synced workout.</p>
+      </div>
+
+      <div className={cardCls}>
+        <label className={labelCls} htmlFor="sf-strategy">Merge watch strategy</label>
+        <select id="sf-strategy" value={strategy} onChange={(e) => setStrategy(e.target.value)} className={controlCls}>
+          {STRATEGIES.map((s) => (
+            <option key={s.value} value={s.value}>{s.label}</option>
+          ))}
+        </select>
+        <p className="mt-1.5 text-xs text-text-muted">How a Hevy workout is combined with a same-time watch activity.</p>
+      </div>
+
+      <div className={cardCls}>
+        <label className={labelCls} htmlFor="sf-weight">Body weight (kg)</label>
+        <input id="sf-weight" type="number" min={1} max={499} step={0.1} value={weight} onChange={(e) => setWeight(e.target.value)} placeholder="e.g. 80" className={controlCls} />
+        <p className="mt-1.5 text-xs text-text-muted">Used for calorie estimation on synced workouts.</p>
+      </div>
+
+      <div className="flex items-center gap-3 md:col-span-2">
+        <button type="submit" disabled={busy} className="rounded-lg bg-teal/20 px-4 py-2 text-sm font-medium text-teal transition-colors hover:bg-teal/30 disabled:opacity-50">
+          {busy ? "Saving…" : "Save settings"}
+        </button>
+        {saved && <span className="text-xs text-success">Saved.</span>}
+        {error && <span className="text-xs text-danger" role="alert">{error}</span>}
+      </div>
+    </form>
+  );
+}


### PR DESCRIPTION
Closes #361. Part of the modern Next.js web rebuild (soma#385).

The web `/settings` page was read-only ("later phase"). This makes the configuration editable from the web.

## What changed
- **`web/app/api/settings/route.ts`** (new) — POST that sanitises the editable keys (`auto_sync`, `hr_fusion`, `merge_settings`, `user_profile`), deep-merges each onto the stored value (preserving sub-fields the form doesn't manage), and upserts into `app_cache` with `ON CONFLICT (key)` — matching `PostgresDatabase.set_cache` (db_postgres.py). Session-gated only when a password is configured (`authEnabled()`), matching the login model and the existing benign write routes (mapping is open).
- **`web/components/settings-form.tsx`** (new) — client form: auto-sync enabled + interval, HR fusion, merge watch strategy (replace/merge/describe), body weight; pre-filled from the live config.
- **`web/app/settings/page.tsx`** — renders the form; the read-only grid stays below as a "Stored config" reference.

## Verified (local dev server against the live DB)
- `tsc --noEmit` clean.
- The form renders pre-filled with the real config (auto-sync off / 2h, HR fusion on, Describe, weight 64.5).
- POST returns `200 {ok:true, saved:[...]}`; a weight change persisted on reload, and I restored the original value. The deep-merge preserved every unmanaged sub-field (merge_mode/overlap/drift/activity-types, user sex/vo2max/birth-year).

Note: CI (`ci.yml`) tests Python + the `typescript/` package, not `web/`, so this diff isn't exercised in CI — validated locally instead. Adding a `web/` typecheck+build CI job is a good follow-up.
