### PR TITLE
feat: per-workout HR chart from cached Garmin heart-rate (#363)

### DIFF
--- a/web/app/api/workout/[hevyId]/hr/route.ts
+++ b/web/app/api/workout/[hevyId]/hr/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+
+// Reads the live hevy2garmin Postgres per request — never at build time.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * GET /api/workout/[hevyId]/hr
+ *
+ * Returns the cached heart-rate timeline for a workout's matched Garmin
+ * activity from the `hr_cache` table (data.samples) — mirroring
+ * db.get_cached_hr. Read-only: it never calls Garmin. The sync/cron job is what
+ * populates the cache, so this returns `{ samples: null }` for workouts that
+ * haven't been fetched yet.
+ */
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ hevyId: string }> },
+) {
+  const { hevyId } = await params;
+  if (!hevyId) {
+    return NextResponse.json({ error: "hevyId is required." }, { status: 400 });
+  }
+
+  let sql: ReturnType<typeof getDb>;
+  try {
+    sql = getDb();
+  } catch {
+    return NextResponse.json({ error: "DATABASE_URL not configured." }, { status: 503 });
+  }
+
+  try {
+    const rows = (await sql`
+      SELECT data, cached_at FROM hr_cache WHERE hevy_id = ${hevyId} LIMIT 1
+    `) as { data: unknown; cached_at: string | null }[];
+
+    if (rows.length === 0) {
+      return NextResponse.json({ samples: null, cached_at: null });
+    }
+
+    const data = rows[0].data;
+    const raw = data && typeof data === "object" ? (data as Record<string, unknown>).samples : null;
+    const samples = Array.isArray(raw)
+      ? raw.map((v) => Number(v)).filter((v) => Number.isFinite(v))
+      : null;
+
+    return NextResponse.json({
+      samples: samples && samples.length > 0 ? samples : null,
+      cached_at: rows[0].cached_at ?? null,
+    });
+  } catch (err) {
+    console.error("hr read failed:", err);
+    return NextResponse.json({ error: "Failed to read HR." }, { status: 500 });
+  }
+}

--- a/web/app/workouts/page.tsx
+++ b/web/app/workouts/page.tsx
@@ -1,4 +1,5 @@
 import { getDb } from "@/lib/db";
+import { WorkoutRow } from "@/components/workout-row";
 
 // Queries the live hevy2garmin Postgres per request — never at build time.
 export const dynamic = "force-dynamic";
@@ -97,47 +98,6 @@ async function loadWorkouts(): Promise<WorkoutsData> {
   return { dbConfigured: true, items: [...pendingItems, ...terminalItems] };
 }
 
-function fmtDate(value: string | null): string {
-  if (!value) return "—";
-  const d = new Date(value);
-  if (Number.isNaN(d.getTime())) return "—";
-  return d.toLocaleString(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
-
-function StatusPill({ item }: { item: WorkoutItem }) {
-  // Terminal statuses map to fixed colours; any pending phase is "warm/in-flight".
-  const terminalStyles: Record<string, { cls: string; label: string }> = {
-    success: { cls: "bg-success/15 text-success", label: "Uploaded" },
-    manual: { cls: "bg-warm/15 text-warm", label: "Marked as synced" },
-    skipped: { cls: "bg-surface-active text-text-muted", label: "Skipped" },
-    failed: { cls: "bg-danger/15 text-danger", label: "Failed" },
-  };
-
-  if (item.kind === "terminal") {
-    const s = terminalStyles[item.state] ?? {
-      cls: "bg-surface-active text-text-secondary",
-      label: item.state,
-    };
-    return (
-      <span className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${s.cls}`}>
-        {s.label}
-      </span>
-    );
-  }
-
-  // Pending — teal to distinguish from terminal states.
-  return (
-    <span className="inline-block rounded-full bg-teal/15 px-2.5 py-0.5 text-xs font-medium text-teal">
-      {item.state}
-    </span>
-  );
-}
-
 export default async function WorkoutsPage() {
   const data = await loadWorkouts();
 
@@ -151,8 +111,8 @@ export default async function WorkoutsPage() {
       </header>
 
       <div className="mb-6 rounded-lg border border-border bg-surface p-4 text-sm text-text-muted">
-        Live Hevy fetch and per-workout sync actions come in a later phase. This
-        view is read-only and shows only what the database already knows.
+        Live Hevy fetch and per-workout sync actions come in a later phase.
+        Expand a Garmin-matched workout to see its cached heart-rate.
       </div>
 
       {!data.dbConfigured && (
@@ -173,26 +133,7 @@ export default async function WorkoutsPage() {
       ) : (
         <ul className="divide-y divide-border overflow-hidden rounded-xl border border-border bg-surface-elevated">
           {data.items.map((w) => (
-            <li
-              key={w.hevy_id}
-              className="flex items-center justify-between gap-3 px-4 py-3"
-            >
-              <div className="min-w-0">
-                <div className="truncate text-sm font-medium text-text">
-                  {w.title || "Untitled workout"}
-                </div>
-                <div className="mt-0.5 text-xs text-text-muted">
-                  {fmtDate(w.when)}
-                  {w.garmin_activity_id && (
-                    <span> · Garmin {w.garmin_activity_id}</span>
-                  )}
-                  {w.detail && (
-                    <span className="text-text-secondary"> · {w.detail}</span>
-                  )}
-                </div>
-              </div>
-              <StatusPill item={w} />
-            </li>
+            <WorkoutRow key={w.hevy_id} item={w} />
           ))}
         </ul>
       )}

--- a/web/components/workout-row.tsx
+++ b/web/components/workout-row.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useState } from "react";
+
+export interface WorkoutItem {
+  hevy_id: string;
+  title: string | null;
+  when: string | null;
+  garmin_activity_id: string | null;
+  detail?: string | null;
+  kind: "terminal" | "pending";
+  state: string;
+}
+
+function fmtDate(value: string | null): string {
+  if (!value) return "—";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+}
+
+function StatusPill({ item }: { item: WorkoutItem }) {
+  const terminal: Record<string, { cls: string; label: string }> = {
+    success: { cls: "bg-success/15 text-success", label: "Uploaded" },
+    manual: { cls: "bg-warm/15 text-warm", label: "Marked as synced" },
+    skipped: { cls: "bg-surface-active text-text-muted", label: "Skipped" },
+    failed: { cls: "bg-danger/15 text-danger", label: "Failed" },
+  };
+  if (item.kind === "terminal") {
+    const s = terminal[item.state] ?? { cls: "bg-surface-active text-text-secondary", label: item.state };
+    return <span className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${s.cls}`}>{s.label}</span>;
+  }
+  return <span className="inline-block rounded-full bg-teal/15 px-2.5 py-0.5 text-xs font-medium text-teal">{item.state}</span>;
+}
+
+function HrChart({ samples }: { samples: number[] }) {
+  const min = Math.min(...samples);
+  const max = Math.max(...samples);
+  const range = max - min || 1;
+  const avg = Math.round(samples.reduce((a, b) => a + b, 0) / samples.length);
+  const W = 600;
+  const H = 120;
+  const pad = 8;
+  const xy = (v: number, i: number) => {
+    const x = pad + (i / Math.max(1, samples.length - 1)) * (W - 2 * pad);
+    const y = pad + (1 - (v - min) / range) * (H - 2 * pad);
+    return `${x.toFixed(1)},${y.toFixed(1)}`;
+  };
+  const line = samples.map(xy).join(" ");
+  const area = `${pad},${H - pad} ${line} ${W - pad},${H - pad}`;
+  return (
+    <div className="mt-2">
+      <svg viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" className="w-full rounded-lg bg-surface" style={{ height: 110 }}>
+        <polygon points={area} fill="rgba(239, 68, 68, 0.12)" />
+        <polyline points={line} fill="none" stroke="#ef4444" strokeWidth={1.6} vectorEffect="non-scaling-stroke" />
+      </svg>
+      <div className="mt-1 flex justify-between text-xs text-text-muted tabular-nums">
+        <span>min {min} bpm</span>
+        <span>avg {avg} bpm</span>
+        <span>max {max} bpm</span>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * A workout row with an on-demand heart-rate chart. The HR toggle appears only
+ * when the workout is matched to a Garmin activity; expanding it fetches the
+ * cached HR from /api/workout/[id]/hr (read-only) and draws an inline SVG.
+ */
+export function WorkoutRow({ item }: { item: WorkoutItem }) {
+  const [open, setOpen] = useState(false);
+  const [samples, setSamples] = useState<number[] | null | undefined>(undefined); // undefined = not fetched
+  const [loading, setLoading] = useState(false);
+  const canHr = Boolean(item.garmin_activity_id);
+
+  async function toggle() {
+    const next = !open;
+    setOpen(next);
+    if (next && samples === undefined) {
+      setLoading(true);
+      try {
+        const res = await fetch(`/api/workout/${encodeURIComponent(item.hevy_id)}/hr`);
+        const d = (await res.json().catch(() => ({}))) as { samples?: unknown };
+        setSamples(Array.isArray(d.samples) ? (d.samples as number[]) : null);
+      } catch {
+        setSamples(null);
+      } finally {
+        setLoading(false);
+      }
+    }
+  }
+
+  return (
+    <li className="px-4 py-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="truncate text-sm font-medium text-text">{item.title || "Untitled workout"}</div>
+          <div className="mt-0.5 text-xs text-text-muted">
+            {fmtDate(item.when)}
+            {item.garmin_activity_id && <span> · Garmin {item.garmin_activity_id}</span>}
+            {item.detail && <span className="text-text-secondary"> · {item.detail}</span>}
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {canHr && (
+            <button
+              type="button"
+              onClick={toggle}
+              className="rounded-lg border border-border px-2.5 py-1 text-xs font-medium text-text-secondary transition-colors hover:bg-surface-active"
+            >
+              {open ? "Hide HR" : "HR"}
+            </button>
+          )}
+          <StatusPill item={item} />
+        </div>
+      </div>
+      {open && (
+        <div>
+          {loading ? (
+            <p className="mt-2 text-xs text-text-muted">Loading heart-rate…</p>
+          ) : samples ? (
+            <HrChart samples={samples} />
+          ) : (
+            <p className="mt-2 text-xs text-text-muted">No cached heart-rate for this workout yet.</p>
+          )}
+        </div>
+      )}
+    </li>
+  );
+}


### PR DESCRIPTION
Closes #363. Part of the modern Next.js web rebuild (soma#385).

The Python dashboard renders a per-workout HR chart from HR cached in the DB. The web workouts list had none.

## What changed
- **`web/app/api/workout/[hevyId]/hr/route.ts`** (new) — GET that reads `hr_cache` (`data.samples`), mirroring `db.get_cached_hr`. Read-only: it never calls Garmin (the sync/cron job populates the cache), returning `{ samples: null }` when a workout hasn't been fetched yet.
- **`web/components/workout-row.tsx`** (new) — a client `WorkoutRow` with an HR toggle (shown only when the workout is Garmin-matched); expanding it fetches the cached HR and draws an inline SVG line+area with min/avg/max bpm. No chart library.
- **`web/app/workouts/page.tsx`** — renders `WorkoutRow` (moving `StatusPill`/`fmtDate` into it); banner updated.

## Verified (local dev server against the staging DB)
- `tsc --noEmit` clean.
- The endpoint returns 75 cached HR samples for a demo id.
- Seeded one temp Garmin-matched workout row → the HR toggle appeared → expanding drew the chart (75-point polyline, min 60 / avg 99 / max 138 bpm), then removed the temp row. Uncached workouts show "No cached heart-rate yet".

Note: the staging DB has no real synced workouts and CI doesn't build `web/`, so this was validated locally with seeded demo data. The chart lights up for real workouts once the sync/cron job caches their HR.
