### PR TITLE
ci: add web/ job (typecheck + build + vitest) to PR gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,3 +88,31 @@ jobs:
 
       - name: Test
         run: npm test
+
+  check-web:
+    name: Tests (Web)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install
+        run: npm ci || npm install
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Build
+        # Routes are force-dynamic, so no real DB is touched at build time.
+        env:
+          DATABASE_URL: postgres://ci:ci@localhost:5432/ci
+        run: npm run build
+
+      - name: Test
+        run: npm test


### PR DESCRIPTION
Closes #365. Part of the modern Next.js web rebuild (soma#385).

`ci.yml` ran the Python suites + the `typescript/` package tests, but **nothing exercised the `web/` Next.js app** — web PRs passed CI with zero validation. As the rebuild grows, a type or build error could land unnoticed.

**Adds a `check-web` job** (`working-directory: web`, mirrors `check-typescript`):
- `npm ci`
- `tsc --noEmit` (typecheck)
- `next build` with a dummy `DATABASE_URL` (routes are `force-dynamic`, so no DB is touched at build)
- `vitest run` (33 web tests)

Verified locally: tsc exit 0, build compiles all routes, 33/33 tests pass.
