### PR TITLE
feat(web): routines list page

### DIFF
--- a/web/app/routines/page.tsx
+++ b/web/app/routines/page.tsx
@@ -1,24 +1,203 @@
-// Static placeholder — routine sync is a later phase.
-export const dynamic = "force-static";
+import { getDb } from "@/lib/db";
 
-export default function RoutinesPage() {
+// Queries the live hevy2garmin Postgres per request — never at build time.
+export const dynamic = "force-dynamic";
+
+interface RoutineRow {
+  hevy_routine_id: string;
+  title: string;
+  status: string;
+  garmin_workout_id: string | null;
+  scheduled_date: string | null;
+  synced_at: string | null;
+  schedule_count: number;
+}
+
+interface RoutinesData {
+  dbConfigured: boolean;
+  total: number;
+  scheduled: number;
+  rows: RoutineRow[];
+}
+
+const EMPTY: RoutinesData = { dbConfigured: false, total: 0, scheduled: 0, rows: [] };
+const LIMIT = 100;
+
+async function loadRoutines(): Promise<RoutinesData> {
+  let sql: ReturnType<typeof getDb>;
+  try {
+    sql = getDb();
+  } catch {
+    return EMPTY;
+  }
+
+  const [rows, scheduleCounts] = await Promise.all([
+    sql`
+      SELECT hevy_routine_id, title, COALESCE(status, 'success') AS status,
+             garmin_workout_id, scheduled_date, synced_at
+      FROM synced_routines
+      ORDER BY synced_at DESC NULLS LAST
+      LIMIT ${LIMIT}
+    `.catch(
+      () =>
+        [] as Array<{
+          hevy_routine_id: string;
+          title: string | null;
+          status: string;
+          garmin_workout_id: string | null;
+          scheduled_date: string | null;
+          synced_at: string | null;
+        }>,
+    ),
+    sql`
+      SELECT hevy_routine_id, COUNT(*)::int AS n
+      FROM routine_schedules
+      GROUP BY hevy_routine_id
+    `.catch(() => [] as Array<{ hevy_routine_id: string; n: number }>),
+  ]);
+
+  const counts = new Map(scheduleCounts.map((c) => [c.hevy_routine_id, Number(c.n)]));
+
+  const mapped: RoutineRow[] = rows.map((r) => ({
+    hevy_routine_id: r.hevy_routine_id,
+    title: r.title ?? "",
+    status: r.status,
+    garmin_workout_id: r.garmin_workout_id ?? null,
+    scheduled_date: r.scheduled_date ?? null,
+    synced_at: r.synced_at ?? null,
+    schedule_count: counts.get(r.hevy_routine_id) ?? 0,
+  }));
+
+  return {
+    dbConfigured: true,
+    total: mapped.length,
+    scheduled: mapped.filter((r) => r.schedule_count > 0).length,
+    rows: mapped,
+  };
+}
+
+function fmtDate(value: string | null): string {
+  if (!value) return "—";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function fmtDay(value: string | null): string {
+  if (!value) return "—";
+  // scheduled_date is a plain YYYY-MM-DD string from Hevy; show it verbatim
+  // rather than risk a timezone shift by parsing it as a Date.
+  return value;
+}
+
+function StatusPill({ status }: { status: string }) {
+  const map: Record<string, { cls: string; label: string }> = {
+    success: { cls: "bg-success/15 text-success", label: "Synced" },
+    failed: { cls: "bg-danger/15 text-danger", label: "Failed" },
+    skipped: { cls: "bg-surface-active text-text-muted", label: "Skipped" },
+  };
+  const s = map[status] ?? { cls: "bg-surface-active text-text-secondary", label: status };
+  return (
+    <span className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${s.cls}`}>
+      {s.label}
+    </span>
+  );
+}
+
+function StatCard({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-xl border border-border bg-surface-elevated p-4">
+      <div className="text-2xl font-bold tabular-nums text-text">{value}</div>
+      <div className="mt-0.5 text-xs text-text-muted">{label}</div>
+    </div>
+  );
+}
+
+export default async function RoutinesPage() {
+  const data = await loadRoutines();
+
   return (
     <main className="mx-auto max-w-5xl px-4 py-8 md:px-6">
-      <header className="mb-6">
+      <header className="mb-4">
         <h1 className="text-2xl font-bold text-text">Routines</h1>
         <p className="mt-1 text-sm text-text-secondary">
-          Hevy routine → Garmin planned-workout sync.
+          Hevy routines synced to Garmin as planned workouts.
         </p>
       </header>
 
-      <div className="rounded-lg border border-border bg-surface p-8 text-center">
-        <p className="text-sm font-medium text-text-secondary">
-          Coming in a later phase.
-        </p>
-        <p className="mt-1 text-xs text-text-muted">
-          Routine syncing isn&apos;t part of the read-only web app yet.
-        </p>
+      <div className="mb-6 rounded-lg border border-border bg-surface p-4 text-sm text-text-muted">
+        Routines are synced by the pipeline. Scheduling and one-click routine
+        sync from the web come in a later phase.
       </div>
+
+      {!data.dbConfigured && (
+        <div className="mb-6 rounded-lg border border-warm/40 bg-warm/10 p-4 text-sm text-warm">
+          No database is configured (DATABASE_URL is unset). Showing empty state.
+        </div>
+      )}
+
+      <div className="mb-6 grid grid-cols-2 gap-4">
+        <StatCard label="Synced routines" value={data.total} />
+        <StatCard label="With a schedule" value={data.scheduled} />
+      </div>
+
+      {data.rows.length === 0 ? (
+        <div className="rounded-lg border border-border bg-surface p-8 text-center">
+          <p className="text-sm font-medium text-text-secondary">
+            No routines synced yet.
+          </p>
+          <p className="mt-1 text-xs text-text-muted">
+            Routine → Garmin planned-workout sync runs from the pipeline; synced
+            routines will appear here.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-border bg-surface-elevated">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-text-muted">
+                <th className="px-4 py-2 font-medium">Routine</th>
+                <th className="px-4 py-2 font-medium">Status</th>
+                <th className="px-4 py-2 font-medium">Garmin workout</th>
+                <th className="px-4 py-2 font-medium">Scheduled</th>
+                <th className="px-4 py-2 font-medium">Synced</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {data.rows.map((r) => (
+                <tr key={r.hevy_routine_id}>
+                  <td className="px-4 py-2 font-medium text-text">
+                    {r.title || "Untitled routine"}
+                    {r.schedule_count > 0 && (
+                      <span className="ml-2 rounded-full bg-teal/15 px-2 py-0.5 text-xs font-medium text-teal">
+                        {r.schedule_count} scheduled
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-2">
+                    <StatusPill status={r.status} />
+                  </td>
+                  <td className="px-4 py-2 tabular-nums text-text-secondary">
+                    {r.garmin_workout_id || "—"}
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-2 tabular-nums text-text-muted">
+                    {fmtDay(r.scheduled_date)}
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-2 tabular-nums text-text-muted">
+                    {fmtDate(r.synced_at)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
Closes #369. Part of the modern Next.js web rebuild (soma#385).

The `/routines` page was a static "Coming in a later phase" placeholder. The `synced_routines` + `routine_schedules` tables already hold the pipeline's routine → Garmin planned-workout state, but the web app didn't surface it.

**Adds the read-only routines list:** two stat cards (synced routines, with-a-schedule) and a table — title, status pill, Garmin workout id, scheduled date, synced-at — plus a per-routine "N scheduled" badge from a `routine_schedules` group-count join. Mirrors the History page (`getDb` + `.catch` guards + graceful empty state). `scheduled_date` is shown verbatim (a plain `YYYY-MM-DD` from Hevy) to avoid a timezone shift. Read-only — scheduling / one-click routine sync stay a later phase.

### Verified (Playwright + DB, against staging)
- **Empty state** (0 routines): header, banner, `0 / 0` stat cards, "No routines synced yet." — no longer the stub.
- **Populated** (seeded 2 routines, 1 with a schedule): stat cards `2 Synced routines / 1 With a schedule`; table rows with Synced pills, Garmin ids `990011`/`990022`, `2026-09-02` shown verbatim / `—` for the null date; the **1 scheduled** badge appears only on the scheduled routine (join correct).
- Cleaned up the seeded rows (both tables back to 0). tsc green.
