### PR TITLE
feat(web): dashboard sync controls (dry-run preview + gated live upload)

### DIFF
--- a/web/app/api/sync-one/route.test.ts
+++ b/web/app/api/sync-one/route.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Safety-gating tests for POST /api/sync-one.
+ *
+ * The route's whole reason to exist is that a live Garmin upload must fire ONLY
+ * when the caller both (a) explicitly asks for it and (b) is authorized —
+ * otherwise it runs the engine in dry-run. We mock the engine + auth + cookies
+ * so no network or DB is touched, and assert exactly which (dryRun) the engine
+ * is invoked with (or that it is never invoked).
+ */
+
+const syncOneWorkout = vi.fn();
+vi.mock("@/lib/sync-one", () => ({
+  syncOneWorkout: (...a: unknown[]) => syncOneWorkout(...a),
+}));
+
+vi.mock("@/lib/db", () => ({ getDb: () => ({}) }));
+
+const authEnabled = vi.fn();
+const verifySession = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  authEnabled: (...a: unknown[]) => authEnabled(...a),
+  verifySession: (...a: unknown[]) => verifySession(...a),
+  SESSION_COOKIE: "h2g_session",
+}));
+
+const cookieGet = vi.fn();
+vi.mock("next/headers", () => ({
+  cookies: async () => ({ get: (...a: unknown[]) => cookieGet(...a) }),
+}));
+
+import { POST } from "./route";
+
+const DRY = {
+  status: "dry_run",
+  dryRun: true,
+  wouldUpload: true,
+  dedupDecision: "would_upload",
+  remaining: 3,
+};
+const LIVE = {
+  status: "synced",
+  dryRun: false,
+  garminActivityId: 555,
+  dedupDecision: "would_upload",
+  remaining: 2,
+};
+
+function req(
+  url: string,
+  body: unknown = {},
+  headers: Record<string, string> = {},
+): Request {
+  return new Request(url, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.CRON_SECRET;
+  syncOneWorkout.mockResolvedValue(DRY);
+  authEnabled.mockReturnValue(true);
+  verifySession.mockReturnValue(false);
+  cookieGet.mockReturnValue(undefined);
+});
+
+describe("POST /api/sync-one — dry-run / auth gating", () => {
+  it("no live requested → dry-run (engine called with dryRun:true)", async () => {
+    const res = await POST(req("http://h/api/sync-one", {}));
+    expect(res.status).toBe(200);
+    expect(syncOneWorkout).toHaveBeenCalledWith(expect.anything(), { dryRun: true });
+  });
+
+  it("live requested but NOT authorized → 401, engine never called", async () => {
+    const res = await POST(req("http://h/api/sync-one", { live: 1 }));
+    expect(res.status).toBe(401);
+    expect(syncOneWorkout).not.toHaveBeenCalled();
+  });
+
+  it("live + valid session → live run (engine called with dryRun:false)", async () => {
+    cookieGet.mockReturnValue({ value: "cookie" });
+    verifySession.mockReturnValue(true);
+    syncOneWorkout.mockResolvedValue(LIVE);
+    const res = await POST(req("http://h/api/sync-one", { live: true }));
+    expect(res.status).toBe(200);
+    expect(syncOneWorkout).toHaveBeenCalledWith(expect.anything(), { dryRun: false });
+  });
+
+  it("live + auth DISABLED (no password configured) → authorized → live run", async () => {
+    authEnabled.mockReturnValue(false);
+    syncOneWorkout.mockResolvedValue(LIVE);
+    const res = await POST(req("http://h/api/sync-one?live=1", {}));
+    expect(res.status).toBe(200);
+    expect(syncOneWorkout).toHaveBeenCalledWith(expect.anything(), { dryRun: false });
+  });
+
+  it("live via CRON_SECRET bearer token → live run", async () => {
+    process.env.CRON_SECRET = "s3cret";
+    const res = await POST(
+      req("http://h/api/sync-one", { live: 1 }, { authorization: "Bearer s3cret" }),
+    );
+    expect(res.status).toBe(200);
+    expect(syncOneWorkout).toHaveBeenCalledWith(expect.anything(), { dryRun: false });
+  });
+
+  it("live with a WRONG CRON_SECRET and no session → 401, engine never called", async () => {
+    process.env.CRON_SECRET = "s3cret";
+    const res = await POST(
+      req("http://h/api/sync-one", { live: 1 }, { authorization: "Bearer nope" }),
+    );
+    expect(res.status).toBe(401);
+    expect(syncOneWorkout).not.toHaveBeenCalled();
+  });
+
+  it("invalid JSON body → 400, engine never called", async () => {
+    const bad = new Request("http://h/api/sync-one", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{not json",
+    });
+    const res = await POST(bad);
+    expect(res.status).toBe(400);
+    expect(syncOneWorkout).not.toHaveBeenCalled();
+  });
+});

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -1,4 +1,5 @@
 import { getDb } from "@/lib/db";
+import { SyncPanel } from "@/components/sync-panel";
 
 // Queries the live hevy2garmin Postgres per request — never at build time.
 export const dynamic = "force-dynamic";
@@ -206,6 +207,9 @@ export default async function DashboardPage() {
         <StatCard label="Total synced" value={data.totalSynced} accent="text-teal" />
         <StatCard label="Synced this week" value={data.syncedThisWeek} accent="text-warm" />
       </section>
+
+      {/* Sync controls (preview is dry-run; live upload is gated) */}
+      <SyncPanel ready={data.hevyConnected && data.garminConnected} />
 
       {/* Recent synced workouts */}
       <section className="mb-8">

--- a/web/components/sync-panel.tsx
+++ b/web/components/sync-panel.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+/** Mirrors the SyncOneResult shape returned by /api/sync-one. */
+interface SyncResult {
+  status: "synced" | "skipped" | "deferred" | "dry_run" | "none" | "error";
+  dryRun: boolean;
+  wouldUpload: boolean;
+  dedupDecision: string;
+  workout: { hevy_id: string; title: string | null; start_time: string | null } | null;
+  fitStats: {
+    exercises: number;
+    totalSets: number;
+    calories: number;
+    avgHr: number | null;
+    durationS: number;
+  } | null;
+  existingGarminActivityId: number | null;
+  garminActivityId: number | null;
+  remaining: number;
+  syncMethod: "upload" | "match" | null;
+  error: string | null;
+}
+
+const DECISION_LABEL: Record<string, string> = {
+  would_upload: "A new Garmin activity would be uploaded",
+  already_synced: "Already synced — skipped",
+  existing_garmin_activity: "Garmin already has this — it will be matched, not re-uploaded",
+  claim_lost: "Another sync is already handling this workout",
+  no_candidates: "Nothing to sync — every workout is already handled",
+  no_start_time: "The next workout has no start time, so it can't be matched safely",
+};
+
+const STATUS_STYLE: Record<string, string> = {
+  synced: "bg-success/15 text-success",
+  dry_run: "bg-teal/15 text-teal",
+  skipped: "bg-surface-active text-text-muted",
+  deferred: "bg-warm/15 text-warm",
+  none: "bg-surface-active text-text-muted",
+  error: "bg-danger/15 text-danger",
+};
+
+function fmtDuration(s: number): string {
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m} min`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m`;
+}
+
+/**
+ * Sync controls for the dashboard.
+ *
+ * "Preview" runs /api/sync-one in its default DRY-RUN mode: it computes what the
+ * next sync WOULD do (which workout, whether it would upload or match an
+ * existing Garmin activity) without writing anything to Garmin or the DB.
+ *
+ * "Sync now" opts into a real upload (?live=1). Because a bad upload creates a
+ * duplicate Garmin/Strava activity, it is guarded behind an explicit inline
+ * confirmation, and the server independently requires authorization before it
+ * will run live.
+ */
+export function SyncPanel({ ready }: { ready: boolean }) {
+  const router = useRouter();
+  const [result, setResult] = useState<SyncResult | null>(null);
+  const [busy, setBusy] = useState<null | "preview" | "live">(null);
+  const [error, setError] = useState<string | null>(null);
+  const [confirmLive, setConfirmLive] = useState(false);
+
+  async function run(live: boolean) {
+    setBusy(live ? "live" : "preview");
+    setError(null);
+    try {
+      const res = await fetch(`/api/sync-one${live ? "?live=1" : ""}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(live ? { live: 1 } : {}),
+      });
+      const d = (await res.json().catch(() => ({}))) as SyncResult & { error?: string };
+      if (!res.ok) {
+        setError(d.error ?? `Request failed (${res.status}).`);
+        return;
+      }
+      setResult(d);
+      setConfirmLive(false);
+      if (live && d.status === "synced") router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <section className="mb-8 rounded-xl border border-border bg-surface-elevated p-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-text">Run a sync</h2>
+          <p className="mt-0.5 text-sm text-text-secondary">
+            Preview shows what the next sync would do. Nothing is uploaded until
+            you choose Sync now.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => run(false)}
+            disabled={busy !== null}
+            className="rounded-lg border border-border px-3 py-1.5 text-sm font-medium text-text-secondary transition-colors hover:bg-surface-active disabled:opacity-50"
+          >
+            {busy === "preview" ? "Previewing…" : "Preview"}
+          </button>
+          {!confirmLive ? (
+            <button
+              type="button"
+              onClick={() => setConfirmLive(true)}
+              disabled={busy !== null || !ready}
+              title={ready ? undefined : "Connect Hevy and Garmin first"}
+              className="rounded-lg bg-teal/20 px-3 py-1.5 text-sm font-medium text-teal transition-colors hover:bg-teal/30 disabled:opacity-50"
+            >
+              Sync now
+            </button>
+          ) : (
+            <span className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => run(true)}
+                disabled={busy !== null}
+                className="rounded-lg bg-teal/30 px-3 py-1.5 text-sm font-medium text-teal transition-colors hover:bg-teal/40 disabled:opacity-50"
+              >
+                {busy === "live" ? "Syncing…" : "Confirm upload"}
+              </button>
+              <button
+                type="button"
+                onClick={() => setConfirmLive(false)}
+                disabled={busy !== null}
+                className="rounded-lg border border-border px-3 py-1.5 text-sm font-medium text-text-secondary transition-colors hover:bg-surface-active disabled:opacity-50"
+              >
+                Cancel
+              </button>
+            </span>
+          )}
+        </div>
+      </div>
+
+      {confirmLive && (
+        <p className="mt-3 rounded-lg border border-warm/40 bg-warm/10 p-3 text-xs text-warm">
+          This uploads the next workout to Garmin Connect. It runs the same
+          duplicate-safety checks as the automatic sync, but it is a real upload.
+        </p>
+      )}
+
+      {error && (
+        <p className="mt-3 rounded-lg border border-danger/40 bg-danger/10 p-3 text-sm text-danger" role="alert">
+          {error}
+        </p>
+      )}
+
+      {result && (
+        <div className="mt-4 rounded-lg border border-border bg-surface p-4">
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                STATUS_STYLE[result.status] ?? "bg-surface-active text-text-secondary"
+              }`}
+            >
+              {result.dryRun ? "Preview" : result.status}
+            </span>
+            <span className="text-sm text-text">
+              {DECISION_LABEL[result.dedupDecision] ?? result.dedupDecision}
+            </span>
+          </div>
+
+          {result.workout && (
+            <div className="mt-3 text-sm">
+              <div className="font-medium text-text">
+                {result.workout.title || "Untitled workout"}
+              </div>
+              {result.fitStats && (
+                <div className="mt-1 text-xs text-text-muted tabular-nums">
+                  {result.fitStats.exercises} exercises · {result.fitStats.totalSets} sets ·{" "}
+                  {result.fitStats.calories} kcal
+                  {result.fitStats.avgHr != null && <> · {result.fitStats.avgHr} bpm avg</>} ·{" "}
+                  {fmtDuration(result.fitStats.durationS)}
+                </div>
+              )}
+            </div>
+          )}
+
+          {(result.garminActivityId || result.existingGarminActivityId) && (
+            <div className="mt-2 text-xs text-text-muted">
+              Garmin activity {result.garminActivityId ?? result.existingGarminActivityId}
+              {result.syncMethod === "match" && " (matched existing)"}
+            </div>
+          )}
+
+          <div className="mt-2 text-xs text-text-muted">
+            {result.remaining} workout{result.remaining === 1 ? "" : "s"} left to consider
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
Closes #371. Part of the modern Next.js web rebuild (soma#385). First Garmin-touching UI slice — mock-verified.

The `syncOneWorkout` engine (`lib/sync-one`) + `/api/sync-one` route already existed (route is **dry-run by default**; a live Garmin upload fires only when the request asks for it *and* is authorized). This wires them to a UI.

**Adds `SyncPanel` to the dashboard:**
- **Preview** → `POST /api/sync-one` (dry-run): shows the next sync's decision, candidate workout, FIT stats, and remaining count — no upload, no DB write.
- **Sync now** → an inline confirm with a real-upload warning → `POST /api/sync-one?live=1`. The server independently re-checks authorization before running live.

**Adds `route.test.ts`** mock-verifying the safety gating.

### Verified (mock-only — no real Garmin/Hevy touched)
- **7 new route tests** (40 web tests total, all green): no-live → dry-run; live+unauthorized → 401 (engine never called); live+session → dryRun:false; live+auth-disabled → live; live via correct `CRON_SECRET` bearer → live; wrong secret → 401; bad JSON → 400.
- **Playwright** (with `/api/sync-one` mocked via a `fetch` patch, so the real engine/tokens were never hit): Preview renders the decision + `Push Day` + `5 exercises · 18 sets · 421 kcal · 118 bpm avg · 1h 5m` + remaining; Sync now reveals the confirm + warning banner; Confirm shows the `synced` pill + `Garmin activity 778899` + decremented remaining. DB counts unchanged (both 0) afterward.
- tsc + `next build` green.
