### PR TITLE
feat(web): log out affordance in the nav

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { NavBar } from "@/components/nav-bar";
+import { authEnabled } from "@/lib/auth";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -18,7 +19,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" className="dark">
       <body className="bg-base text-text min-h-screen antialiased">
-        <NavBar />
+        <NavBar authEnabled={authEnabled()} />
         <div className="pb-20 md:pb-0">{children}</div>
       </body>
     </html>

--- a/web/components/nav-bar.tsx
+++ b/web/components/nav-bar.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import Link from "next/link";
+import { useState } from "react";
 
 const NAV_ITEMS = [
   { href: "/dashboard", label: "Dashboard", icon: "◉" },
@@ -12,11 +13,27 @@ const NAV_ITEMS = [
   { href: "/settings", label: "Settings", icon: "⚙" },
 ];
 
-export function NavBar() {
+export function NavBar({ authEnabled = false }: { authEnabled?: boolean }) {
   const pathname = usePathname();
+  const router = useRouter();
+  const [loggingOut, setLoggingOut] = useState(false);
 
   const isActive = (href: string) =>
     pathname === href || pathname.startsWith(href + "/");
+
+  // Hide the whole bar on the login screen.
+  if (pathname === "/login") return null;
+
+  async function logout() {
+    setLoggingOut(true);
+    try {
+      await fetch("/api/logout", { method: "POST" });
+    } catch {
+      // ignore — navigate to login regardless
+    }
+    router.push("/login");
+    router.refresh();
+  }
 
   return (
     <>
@@ -39,6 +56,16 @@ export function NavBar() {
               {label}
             </Link>
           ))}
+          {authEnabled && (
+            <button
+              type="button"
+              onClick={logout}
+              disabled={loggingOut}
+              className="ml-2 rounded-lg border border-border px-3 py-1.5 text-sm font-medium text-text-secondary transition-colors hover:bg-surface-active disabled:opacity-50"
+            >
+              {loggingOut ? "Logging out…" : "Log out"}
+            </button>
+          )}
         </div>
       </nav>
 
@@ -56,6 +83,17 @@ export function NavBar() {
             <span className="text-[10px] font-medium">{label}</span>
           </Link>
         ))}
+        {authEnabled && (
+          <button
+            type="button"
+            onClick={logout}
+            disabled={loggingOut}
+            className="flex flex-col items-center gap-0.5 px-2 py-1 min-w-[52px] text-text-muted disabled:opacity-50"
+          >
+            <span className="text-lg">⏻</span>
+            <span className="text-[10px] font-medium">Log out</span>
+          </button>
+        )}
       </nav>
     </>
   );


### PR DESCRIPTION
Closes #377. Part of the modern Next.js web rebuild (soma#385).

The Python dashboard has logout but the modern web nav had no way to end a session (`/api/logout` already exists and clears the `h2g_session` cookie).

**Adds a Log out button** to the desktop top bar and mobile tab bar, shown only when auth is enabled (`authEnabled()` is computed in the server layout and passed to the client `NavBar`). It POSTs to `/api/logout` and routes to `/login`. The nav is also hidden entirely on the `/login` screen.

### Verified (Playwright, throwaway password via inline env — `.env.local` untouched)
- `authEnabled=false` (staging default): no Log out button (correct).
- With a password set: `/dashboard` server-redirects to `/login` (auth gate works); `/login` renders with the nav hidden; login API returns `{ok:true}` and sets the session.
- On the authed dashboard the **Log out** button renders (desktop + mobile); clicking it clears the session and routes back to `/login`, after which `/dashboard` re-redirects.
- Restored the no-auth dev server afterward. tsc green.
