### PR TITLE
feat(web): unsync-all danger action in settings

### DIFF
--- a/web/app/api/unsync-all/route.ts
+++ b/web/app/api/unsync-all/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+import { unsyncAll } from "@/lib/pending-store";
+
+// Deletes from the app's own synced_workouts table at request time — never at build.
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/unsync-all
+ *
+ * Clears every terminal synced_workouts row so all workouts become sync
+ * candidates again. DB-ONLY: it does NOT delete any Garmin activity (same
+ * boundary as single /api/unsync). Mirrors the Python /api/unsync-all.
+ *
+ * NOTE: auth-gating (session cookie / middleware) is added in the login phase;
+ * this route is intentionally unauthenticated for now.
+ */
+export async function POST() {
+  let count: number;
+  try {
+    count = await unsyncAll();
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error }, { status: 500 });
+  }
+  return NextResponse.json({ ok: true, count });
+}

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -1,5 +1,6 @@
 import { getDb } from "@/lib/db";
 import { SettingsForm } from "@/components/settings-form";
+import { DangerZone } from "@/components/danger-zone";
 
 // Queries the live hevy2garmin Postgres per request — never at build time.
 export const dynamic = "force-dynamic";
@@ -22,9 +23,10 @@ interface SettingsData {
   dbConfigured: boolean;
   platforms: PlatformRow[];
   config: ConfigEntry[];
+  syncedCount: number;
 }
 
-const EMPTY: SettingsData = { dbConfigured: false, platforms: [], config: [] };
+const EMPTY: SettingsData = { dbConfigured: false, platforms: [], config: [], syncedCount: 0 };
 
 // The user-editable config the Python app persists to app_cache (config.py).
 const CONFIG_KEYS = ["user_profile", "timing", "hr_fusion", "merge_settings", "auto_sync"];
@@ -37,7 +39,7 @@ async function loadSettings(): Promise<SettingsData> {
     return EMPTY;
   }
 
-  const [platforms, config] = await Promise.all([
+  const [platforms, config, counts] = await Promise.all([
     sql`
       SELECT platform, auth_type, status, connected_at, expires_at
       FROM platform_credentials
@@ -49,10 +51,14 @@ async function loadSettings(): Promise<SettingsData> {
       WHERE key = ANY(${CONFIG_KEYS})
       ORDER BY key ASC
     `.catch(() => [] as ConfigEntry[]),
+    sql`SELECT count(*)::int AS n FROM synced_workouts`.catch(
+      () => [] as Array<{ n: number }>,
+    ),
   ]);
 
   return {
     dbConfigured: true,
+    syncedCount: Number(counts[0]?.n ?? 0),
     platforms: platforms.map((p) => ({
       platform: p.platform,
       auth_type: p.auth_type ?? "",
@@ -239,6 +245,12 @@ export default async function SettingsPage() {
             ))}
           </div>
         )}
+      </section>
+
+      {/* Danger zone */}
+      <section className="mt-8">
+        <h2 className="mb-3 text-lg font-semibold text-danger">Danger zone</h2>
+        <DangerZone syncedCount={data.syncedCount} />
       </section>
     </main>
   );

--- a/web/components/danger-zone.tsx
+++ b/web/components/danger-zone.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+/**
+ * Destructive maintenance actions for the settings page.
+ *
+ * "Unsync all" clears every terminal synced_workouts row (DB-only — it does NOT
+ * delete Garmin activities) so every workout becomes a sync candidate again. It
+ * is guarded behind an inline confirmation because it affects all records.
+ */
+export function DangerZone({ syncedCount }: { syncedCount: number }) {
+  const router = useRouter();
+  const [confirming, setConfirming] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState<number | null>(null);
+
+  async function unsyncAll() {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/unsync-all", { method: "POST" });
+      const d = (await res.json().catch(() => ({}))) as { ok?: boolean; count?: number; error?: string };
+      if (!res.ok || !d.ok) {
+        setError(d.error ?? `Request failed (${res.status}).`);
+        return;
+      }
+      setDone(d.count ?? 0);
+      setConfirming(false);
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="rounded-xl border border-danger/40 bg-danger/5 p-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold text-danger">Unsync all workouts</h3>
+          <p className="mt-0.5 text-xs text-text-muted">
+            Clears the synced ledger ({syncedCount} record{syncedCount === 1 ? "" : "s"}) so
+            every workout can be synced again. Garmin activities are not deleted.
+          </p>
+        </div>
+        {!confirming ? (
+          <button
+            type="button"
+            onClick={() => setConfirming(true)}
+            disabled={busy || syncedCount === 0}
+            title={syncedCount === 0 ? "Nothing is synced yet" : undefined}
+            className="rounded-lg border border-danger/50 px-3 py-1.5 text-xs font-medium text-danger transition-colors hover:bg-danger/15 disabled:opacity-50"
+          >
+            Unsync all
+          </button>
+        ) : (
+          <span className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={unsyncAll}
+              disabled={busy}
+              className="rounded-lg bg-danger/20 px-3 py-1.5 text-xs font-medium text-danger transition-colors hover:bg-danger/30 disabled:opacity-50"
+            >
+              {busy ? "Clearing…" : `Yes, unsync all ${syncedCount}`}
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirming(false)}
+              disabled={busy}
+              className="rounded-lg border border-border px-3 py-1.5 text-xs font-medium text-text-secondary transition-colors hover:bg-surface-active disabled:opacity-50"
+            >
+              Cancel
+            </button>
+          </span>
+        )}
+      </div>
+      {done != null && (
+        <p className="mt-2 text-xs text-success">Unsynced {done} workout{done === 1 ? "" : "s"}.</p>
+      )}
+      {error && (
+        <p className="mt-2 text-xs text-danger" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web/lib/pending-store.ts
+++ b/web/lib/pending-store.ts
@@ -351,6 +351,17 @@ export async function unsync(hevyId: string, sql: Sql = getDb()): Promise<boolea
   return rows.length > 0;
 }
 
+/**
+ * Delete EVERY terminal row so all workouts become sync candidates again.
+ * Mirrors the Python /api/unsync-all. DB-ONLY: like unsync(), it does NOT delete
+ * any Garmin activity — only the local ledger is cleared. Returns how many rows
+ * were removed.
+ */
+export async function unsyncAll(sql: Sql = getDb()): Promise<number> {
+  const rows = await sql`DELETE FROM synced_workouts RETURNING hevy_id`;
+  return rows.length;
+}
+
 /** Set of hevy_ids with a terminal (synced_workouts) row. Batch read for dedup. */
 export async function loadSyncedIds(sql: Sql = getDb()): Promise<Set<string>> {
   const rows = await sql`SELECT hevy_id FROM synced_workouts`;


### PR DESCRIPTION
Closes #379. Part of the modern Next.js web rebuild (soma#385).

Mirrors the Python dashboard's POST /api/unsync-all, which the modern web lacked.

**Adds a Danger zone to settings** with an "Unsync all workouts" action behind an inline confirm (the confirm button shows the exact count, e.g. "Yes, unsync all 3"). Backed by a new **DB-only** `/api/unsync-all` route + an `unsyncAll()` pending-store helper: it clears every terminal `synced_workouts` row so all workouts become sync candidates again, and — like single unsync — does NOT delete any Garmin activity. The button is disabled when nothing is synced.

### Verified (Playwright + DB, against staging)
- Seeded 3 `synced_workouts` rows → settings Danger zone shows "Clears the synced ledger (3 records)…" and the "Unsync all" button.
- Confirm shows "Yes, unsync all 3" → real `POST /api/unsync-all` → DB verified: all 3 rows deleted (`synced_workouts` = 0). Garmin untouched.
- tsc green.
