### PR TITLE
feat(web): batch Sync all on the dashboard

### DIFF
--- a/web/app/api/sync/route.test.ts
+++ b/web/app/api/sync/route.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * Safety + behaviour tests for POST /api/sync (batch).
+ *
+ * The engine, auth, cookies and (for the dispatch path) global fetch are all
+ * mocked, so no network/DB/Garmin is touched. We assert the dry-run/auth gate,
+ * the GitHub-Actions dispatch path, and the inline loop's aggregation + cap.
+ */
+
+const syncOneWorkout = vi.fn();
+vi.mock("@/lib/sync-one", () => ({
+  syncOneWorkout: (...a: unknown[]) => syncOneWorkout(...a),
+}));
+vi.mock("@/lib/db", () => ({ getDb: () => ({}) }));
+
+const authEnabled = vi.fn();
+const verifySession = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  authEnabled: (...a: unknown[]) => authEnabled(...a),
+  verifySession: (...a: unknown[]) => verifySession(...a),
+  SESSION_COOKIE: "h2g_session",
+}));
+
+const cookieGet = vi.fn();
+vi.mock("next/headers", () => ({
+  cookies: async () => ({ get: (...a: unknown[]) => cookieGet(...a) }),
+}));
+
+import { POST } from "./route";
+
+function req(url: string, body: unknown = {}, headers: Record<string, string> = {}): Request {
+  return new Request(url, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+const DRY = { status: "dry_run", dryRun: true, remaining: 4, wouldUpload: true, dedupDecision: "would_upload" };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.CRON_SECRET;
+  delete process.env.GITHUB_PAT;
+  delete process.env.GITHUB_REPO;
+  authEnabled.mockReturnValue(true);
+  verifySession.mockReturnValue(false);
+  cookieGet.mockReturnValue(undefined);
+  syncOneWorkout.mockResolvedValue(DRY);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("POST /api/sync — batch", () => {
+  it("no live → dry-run preview with the candidate count", async () => {
+    const res = await POST(req("http://h/api/sync", {}));
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.dryRun).toBe(true);
+    expect(json.mode).toBe("preview");
+    expect(json.candidates).toBe(4);
+    expect(syncOneWorkout).toHaveBeenCalledWith(expect.anything(), { dryRun: true });
+  });
+
+  it("live but unauthorized → 401, engine never called", async () => {
+    const res = await POST(req("http://h/api/sync", { live: 1 }));
+    expect(res.status).toBe(401);
+    expect(syncOneWorkout).not.toHaveBeenCalled();
+  });
+
+  it("live + authorized + GITHUB_PAT/REPO → dispatches to Actions, no engine loop", async () => {
+    authEnabled.mockReturnValue(false); // authorized
+    process.env.GITHUB_PAT = "pat";
+    process.env.GITHUB_REPO = "drkostas/hevy2garmin";
+    const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const res = await POST(req("http://h/api/sync?live=1", {}));
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.mode).toBe("dispatch");
+    expect(json.triggered).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toContain("/repos/drkostas/hevy2garmin/dispatches");
+    expect(syncOneWorkout).not.toHaveBeenCalled();
+  });
+
+  it("live + authorized + no PAT → inline loop until 'none', aggregates", async () => {
+    authEnabled.mockReturnValue(false); // authorized
+    syncOneWorkout
+      .mockResolvedValueOnce({ status: "synced", remaining: 1 })
+      .mockResolvedValueOnce({ status: "synced", remaining: 0 })
+      .mockResolvedValueOnce({ status: "none", remaining: 0 });
+    const res = await POST(req("http://h/api/sync?live=1", {}));
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.mode).toBe("inline");
+    expect(json.ran).toBe(2);
+    expect(json.totalSynced).toBe(2);
+    expect(syncOneWorkout).toHaveBeenCalledTimes(3); // 2 synced + the terminating 'none'
+    expect(syncOneWorkout).toHaveBeenCalledWith(expect.anything(), { dryRun: false });
+  });
+
+  it("inline loop stops on a hard error", async () => {
+    authEnabled.mockReturnValue(false);
+    syncOneWorkout
+      .mockResolvedValueOnce({ status: "synced", remaining: 2 })
+      .mockResolvedValueOnce({ status: "error", remaining: 1, error: "boom" });
+    const res = await POST(req("http://h/api/sync?live=1", {}));
+    const json = await res.json();
+    expect(json.mode).toBe("inline");
+    expect(json.totalSynced).toBe(1);
+    expect(json.totalError).toBe(1);
+    expect(syncOneWorkout).toHaveBeenCalledTimes(2); // stopped after the error
+  });
+
+  it("invalid JSON → 400", async () => {
+    const bad = new Request("http://h/api/sync", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{nope",
+    });
+    const res = await POST(bad);
+    expect(res.status).toBe(400);
+    expect(syncOneWorkout).not.toHaveBeenCalled();
+  });
+});

--- a/web/app/api/sync/route.test.ts
+++ b/web/app/api/sync/route.test.ts
@@ -75,7 +75,7 @@ describe("POST /api/sync — batch", () => {
     authEnabled.mockReturnValue(false); // authorized
     process.env.GITHUB_PAT = "pat";
     process.env.GITHUB_REPO = "drkostas/hevy2garmin";
-    const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
+    const fetchMock = vi.fn(async (..._a: unknown[]) => new Response(null, { status: 204 }));
     vi.stubGlobal("fetch", fetchMock);
     const res = await POST(req("http://h/api/sync?live=1", {}));
     const json = await res.json();
@@ -83,7 +83,7 @@ describe("POST /api/sync — batch", () => {
     expect(json.mode).toBe("dispatch");
     expect(json.triggered).toBe(true);
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock.mock.calls[0][0]).toContain("/repos/drkostas/hevy2garmin/dispatches");
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("/repos/drkostas/hevy2garmin/dispatches");
     expect(syncOneWorkout).not.toHaveBeenCalled();
   });
 

--- a/web/app/api/sync/route.ts
+++ b/web/app/api/sync/route.ts
@@ -1,0 +1,156 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { syncOneWorkout, type SyncOneResult } from "@/lib/sync-one";
+import { getDb } from "@/lib/db";
+import { verifySession, SESSION_COOKIE, authEnabled } from "@/lib/auth";
+
+// Reads live Hevy + Postgres (and, on the live path, Garmin) at request time.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * POST /api/sync  —  batch sync of ALL candidates. DRY-RUN BY DEFAULT.
+ *
+ * Mirrors the Python dashboard's /api/sync:
+ *   - dry-run (default): reports how many workouts WOULD sync, plus a preview of
+ *     the next one — no upload, no DB write.
+ *   - live (requires ?live=1 AND authorization): if GITHUB_PAT + GITHUB_REPO are
+ *     set, triggers the sync GitHub Action via repository_dispatch (the deployed
+ *     path — avoids the Vercel function timeout + browser-auth constraints);
+ *     otherwise loops the tested single-workout engine (syncOneWorkout) up to a
+ *     safety cap, aggregating the per-workout results.
+ *
+ * A live upload fires only when BOTH the request asks for it (?live=1 / body
+ * {live}) AND is authorized (h2g session cookie OR Bearer CRON_SECRET) — the
+ * same gate as /api/sync-one.
+ */
+
+const CAP = 50; // never loop the inline engine more than this many times
+
+async function isAuthorized(request: Request): Promise<boolean> {
+  const cronSecret = process.env.CRON_SECRET;
+  if (cronSecret) {
+    const auth = request.headers.get("authorization") ?? "";
+    const m = auth.match(/^Bearer\s+(.+)$/i);
+    if (m && m[1] === cronSecret) return true;
+  }
+  if (!authEnabled()) return true;
+  const store = await cookies();
+  const cookie = store.get(SESSION_COOKIE)?.value ?? null;
+  return verifySession(cookie);
+}
+
+function wantsLive(request: Request, body: Record<string, unknown>): boolean {
+  const q = new URL(request.url).searchParams.get("live");
+  if (q === "1" || q === "true") return true;
+  const b = body.live;
+  return b === 1 || b === true || b === "1" || b === "true";
+}
+
+async function triggerViaActions(pat: string, repo: string): Promise<boolean> {
+  const res = await fetch(`https://api.github.com/repos/${repo}/dispatches`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${pat}`,
+      Accept: "application/vnd.github+json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ event_type: "sync-trigger" }),
+  });
+  return res.ok;
+}
+
+export async function POST(request: Request) {
+  let body: Record<string, unknown> = {};
+  try {
+    const text = await request.text();
+    if (text) body = JSON.parse(text);
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const requestedLive = wantsLive(request, body);
+  const authorized = requestedLive ? await isAuthorized(request) : false;
+  const dryRun = !(requestedLive && authorized);
+
+  if (requestedLive && !authorized) {
+    return NextResponse.json(
+      { error: "Unauthorized: a live batch sync requires a session or CRON_SECRET." },
+      { status: 401 },
+    );
+  }
+
+  let sql: ReturnType<typeof getDb>;
+  try {
+    sql = getDb();
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `DB unavailable: ${error}` }, { status: 503 });
+  }
+
+  // Dry-run: a single read pass tells us how many candidates would sync.
+  if (dryRun) {
+    try {
+      const preview = await syncOneWorkout(sql, { dryRun: true });
+      return NextResponse.json({
+        dryRun: true,
+        mode: "preview",
+        candidates: preview.status === "none" ? 0 : preview.remaining,
+        preview,
+      });
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return NextResponse.json({ error }, { status: 500 });
+    }
+  }
+
+  // Live, deployed: hand off to the GitHub Action so the long browser-auth sync
+  // runs off the request path.
+  const pat = process.env.GITHUB_PAT;
+  const repo = process.env.GITHUB_REPO;
+  if (pat && repo) {
+    try {
+      const ok = await triggerViaActions(pat, repo);
+      if (!ok) {
+        return NextResponse.json(
+          { error: "Failed to trigger the sync workflow." },
+          { status: 502 },
+        );
+      }
+      return NextResponse.json({ dryRun: false, mode: "dispatch", triggered: true });
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return NextResponse.json({ error }, { status: 502 });
+    }
+  }
+
+  // Live, local/self-hosted: loop the tested single-workout engine.
+  const runs: SyncOneResult[] = [];
+  try {
+    for (let i = 0; i < CAP; i++) {
+      const r = await syncOneWorkout(sql, { dryRun: false });
+      if (r.status === "none") break; // no candidates left
+      runs.push(r);
+      if (r.status === "error") break; // stop the batch on a hard error
+    }
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error, runs }, { status: 500 });
+  }
+
+  const totalSynced = runs.filter((r) => r.status === "synced").length;
+  const totalSkipped = runs.filter((r) => r.status === "skipped").length;
+  const totalDeferred = runs.filter((r) => r.status === "deferred").length;
+  const totalError = runs.filter((r) => r.status === "error").length;
+
+  return NextResponse.json({
+    dryRun: false,
+    mode: "inline",
+    ran: runs.length,
+    totalSynced,
+    totalSkipped,
+    totalDeferred,
+    totalError,
+    runs,
+  });
+}

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -1,5 +1,6 @@
 import { getDb } from "@/lib/db";
 import { SyncPanel } from "@/components/sync-panel";
+import { BatchSync } from "@/components/batch-sync";
 
 // Queries the live hevy2garmin Postgres per request — never at build time.
 export const dynamic = "force-dynamic";
@@ -210,6 +211,7 @@ export default async function DashboardPage() {
 
       {/* Sync controls (preview is dry-run; live upload is gated) */}
       <SyncPanel ready={data.hevyConnected && data.garminConnected} />
+      <BatchSync ready={data.hevyConnected && data.garminConnected} />
 
       {/* Recent synced workouts */}
       <section className="mb-8">

--- a/web/components/batch-sync.tsx
+++ b/web/components/batch-sync.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+interface BatchResult {
+  dryRun: boolean;
+  mode: "preview" | "dispatch" | "inline";
+  candidates?: number;
+  triggered?: boolean;
+  ran?: number;
+  totalSynced?: number;
+  totalSkipped?: number;
+  totalDeferred?: number;
+  totalError?: number;
+  error?: string;
+}
+
+/**
+ * Batch "Sync all" for the dashboard.
+ *
+ * "Preview all" runs /api/sync in dry-run and reports how many workouts would
+ * sync. "Sync all" opts into a real batch (?live=1): on a deployed instance it
+ * triggers the sync GitHub Action (repository_dispatch); locally it loops the
+ * sync engine. Because a batch uploads many activities, it is guarded behind an
+ * inline confirmation, and the server independently requires authorization.
+ */
+export function BatchSync({ ready }: { ready: boolean }) {
+  const router = useRouter();
+  const [result, setResult] = useState<BatchResult | null>(null);
+  const [busy, setBusy] = useState<null | "preview" | "live">(null);
+  const [error, setError] = useState<string | null>(null);
+  const [confirm, setConfirm] = useState(false);
+
+  async function run(live: boolean) {
+    setBusy(live ? "live" : "preview");
+    setError(null);
+    try {
+      const res = await fetch(`/api/sync${live ? "?live=1" : ""}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(live ? { live: 1 } : {}),
+      });
+      const d = (await res.json().catch(() => ({}))) as BatchResult;
+      if (!res.ok) {
+        setError(d.error ?? `Request failed (${res.status}).`);
+        return;
+      }
+      setResult(d);
+      setConfirm(false);
+      if (live) router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <section className="mb-8 rounded-xl border border-border bg-surface-elevated p-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-text">Sync everything</h2>
+          <p className="mt-0.5 text-sm text-text-secondary">
+            Preview all counts what would sync. Sync all uploads every pending
+            workout (via the scheduled job when deployed).
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => run(false)}
+            disabled={busy !== null}
+            className="rounded-lg border border-border px-3 py-1.5 text-sm font-medium text-text-secondary transition-colors hover:bg-surface-active disabled:opacity-50"
+          >
+            {busy === "preview" ? "Checking…" : "Preview all"}
+          </button>
+          {!confirm ? (
+            <button
+              type="button"
+              onClick={() => setConfirm(true)}
+              disabled={busy !== null || !ready}
+              title={ready ? undefined : "Connect Hevy and Garmin first"}
+              className="rounded-lg bg-teal/20 px-3 py-1.5 text-sm font-medium text-teal transition-colors hover:bg-teal/30 disabled:opacity-50"
+            >
+              Sync all
+            </button>
+          ) : (
+            <span className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => run(true)}
+                disabled={busy !== null}
+                className="rounded-lg bg-teal/30 px-3 py-1.5 text-sm font-medium text-teal transition-colors hover:bg-teal/40 disabled:opacity-50"
+              >
+                {busy === "live" ? "Starting…" : "Confirm sync all"}
+              </button>
+              <button
+                type="button"
+                onClick={() => setConfirm(false)}
+                disabled={busy !== null}
+                className="rounded-lg border border-border px-3 py-1.5 text-sm font-medium text-text-secondary transition-colors hover:bg-surface-active disabled:opacity-50"
+              >
+                Cancel
+              </button>
+            </span>
+          )}
+        </div>
+      </div>
+
+      {confirm && (
+        <p className="mt-3 rounded-lg border border-warm/40 bg-warm/10 p-3 text-xs text-warm">
+          This syncs every pending workout to Garmin Connect. Each upload runs the
+          same duplicate-safety checks as the automatic sync.
+        </p>
+      )}
+
+      {error && (
+        <p className="mt-3 rounded-lg border border-danger/40 bg-danger/10 p-3 text-sm text-danger" role="alert">
+          {error}
+        </p>
+      )}
+
+      {result && (
+        <div className="mt-4 rounded-lg border border-border bg-surface p-4 text-sm">
+          {result.mode === "preview" && (
+            <span className="text-text">
+              {result.candidates === 0
+                ? "Nothing to sync — every workout is already handled."
+                : `${result.candidates} workout${result.candidates === 1 ? "" : "s"} would sync.`}
+            </span>
+          )}
+          {result.mode === "dispatch" && (
+            <span className="text-success">
+              Sync triggered. Workouts will appear in a few minutes.
+            </span>
+          )}
+          {result.mode === "inline" && (
+            <span className="text-text tabular-nums">
+              Synced {result.totalSynced ?? 0}, skipped {result.totalSkipped ?? 0}
+              {result.totalDeferred ? `, deferred ${result.totalDeferred}` : ""}
+              {result.totalError ? `, ${result.totalError} error(s)` : ""}.
+            </span>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
Closes #381. Part of the modern Next.js web rebuild (soma#385).

The Python dashboard has a batch `/api/sync`; the modern web only had single-workout sync. This adds the batch.

**`/api/sync` route** — dry-run by default (reports how many candidates would sync + a preview). A live batch requires authorization (session or `CRON_SECRET`), like `/api/sync-one`. When `GITHUB_PAT` + `GITHUB_REPO` are set it triggers the sync GitHub Action via `repository_dispatch` (the deployed path, off the request); otherwise it loops the tested `syncOneWorkout` engine up to a cap and aggregates.

**`BatchSync` dashboard panel** — "Preview all" (dry-run count) and "Sync all" (gated, inline confirm + warning). Renders the result per mode: preview count, Actions "triggered", or inline synced/skipped totals.

### Verified
- **6 new route tests** (46 web tests total, all green): no-live → dry-run preview count; live+unauthorized → 401; live + `GITHUB_PAT/REPO` → dispatch (fetch to `/repos/.../dispatches`, engine not looped); live + no PAT → inline loop until `none` with aggregation; loop stops on a hard error; bad JSON → 400.
- **Playwright** (with `/api/sync` mocked via a `fetch` patch — real engine/tokens never hit): "Preview all" → "3 workouts would sync"; "Sync all" shows the warning; "Confirm sync all" → "Synced 3, skipped 1." DB untouched.
- tsc + `next build` green.
