### PR TITLE
feat(web): reconcile + retry for stuck pending workouts

### DIFF
--- a/web/app/api/pending/[hevyId]/reconcile/route.ts
+++ b/web/app/api/pending/[hevyId]/reconcile/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { reconcilePending } from "@/lib/pending-recovery";
+import { getDb } from "@/lib/db";
+
+// Reads Garmin + the local ledger at request time — never at build.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * POST /api/pending/[hevyId]/reconcile
+ *
+ * Checks whether Garmin already has an activity at the pending workout's start
+ * time. If so, the earlier attempt landed and the pending is completed as a
+ * matched success (no upload). Otherwise the pending is left in place. Mirrors
+ * the Python /api/pending/{id}/reconcile. It performs a Garmin READ but never
+ * uploads.
+ *
+ * NOTE: auth-gating is added in the login phase; intentionally open for now.
+ */
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ hevyId: string }> },
+) {
+  const { hevyId } = await params;
+  if (!hevyId) {
+    return NextResponse.json({ ok: false, error: "hevyId is required." }, { status: 400 });
+  }
+
+  let sql: ReturnType<typeof getDb>;
+  try {
+    sql = getDb();
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ ok: false, error: `DB unavailable: ${error}` }, { status: 503 });
+  }
+
+  try {
+    const result = await reconcilePending(hevyId, {}, sql);
+    if (result.status === "not_found") {
+      return NextResponse.json({ ok: false, error: "No pending operation." }, { status: 404 });
+    }
+    return NextResponse.json({ ok: true, ...result });
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ ok: false, error }, { status: 502 });
+  }
+}

--- a/web/app/api/pending/[hevyId]/retry/route.test.ts
+++ b/web/app/api/pending/[hevyId]/retry/route.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Gating tests for POST /api/pending/[hevyId]/retry — it WRITES to Garmin, so it
+ * must require BOTH an explicit confirm token (== hevyId) AND authorization.
+ */
+
+const retryPending = vi.fn();
+vi.mock("@/lib/pending-recovery", () => ({
+  retryPending: (...a: unknown[]) => retryPending(...a),
+}));
+vi.mock("@/lib/db", () => ({ getDb: () => ({}) }));
+
+const authEnabled = vi.fn();
+const verifySession = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  authEnabled: (...a: unknown[]) => authEnabled(...a),
+  verifySession: (...a: unknown[]) => verifySession(...a),
+  SESSION_COOKIE: "h2g_session",
+}));
+const cookieGet = vi.fn();
+vi.mock("next/headers", () => ({
+  cookies: async () => ({ get: (...a: unknown[]) => cookieGet(...a) }),
+}));
+
+import { POST } from "./route";
+
+const params = (id: string) => ({ params: Promise.resolve({ hevyId: id }) });
+function req(body: unknown, headers: Record<string, string> = {}): Request {
+  return new Request("http://h/api/pending/w1/retry", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.CRON_SECRET;
+  authEnabled.mockReturnValue(true);
+  verifySession.mockReturnValue(false);
+  cookieGet.mockReturnValue(undefined);
+  retryPending.mockResolvedValue({ status: "synced", garminActivityId: 555, error: null });
+});
+
+describe("POST /api/pending/[id]/retry — gating", () => {
+  it("missing/wrong confirm → 400, engine not called", async () => {
+    const res = await POST(req({ confirm: "not-w1" }), params("w1"));
+    expect(res.status).toBe(400);
+    expect(retryPending).not.toHaveBeenCalled();
+  });
+
+  it("correct confirm but unauthorized → 401", async () => {
+    const res = await POST(req({ confirm: "w1" }), params("w1"));
+    expect(res.status).toBe(401);
+    expect(retryPending).not.toHaveBeenCalled();
+  });
+
+  it("confirm + session → runs retry", async () => {
+    cookieGet.mockReturnValue({ value: "c" });
+    verifySession.mockReturnValue(true);
+    const res = await POST(req({ confirm: "w1" }), params("w1"));
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.status).toBe("synced");
+    expect(retryPending).toHaveBeenCalledTimes(1);
+  });
+
+  it("confirm + auth disabled → runs retry", async () => {
+    authEnabled.mockReturnValue(false);
+    const res = await POST(req({ confirm: "w1" }), params("w1"));
+    expect(res.status).toBe(200);
+    expect(retryPending).toHaveBeenCalledTimes(1);
+  });
+
+  it("no_payload result → 409", async () => {
+    authEnabled.mockReturnValue(false);
+    retryPending.mockResolvedValue({ status: "no_payload", garminActivityId: null, error: null });
+    const res = await POST(req({ confirm: "w1" }), params("w1"));
+    expect(res.status).toBe(409);
+  });
+});

--- a/web/app/api/pending/[hevyId]/retry/route.ts
+++ b/web/app/api/pending/[hevyId]/retry/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { retryPending } from "@/lib/pending-recovery";
+import { getDb } from "@/lib/db";
+import { verifySession, SESSION_COOKIE, authEnabled } from "@/lib/auth";
+
+// Reads/writes Garmin + the local ledger at request time — never at build.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * POST /api/pending/[hevyId]/retry
+ * Body: { confirm: "<hevyId>" }
+ *
+ * Re-attempts a stuck upload: reconciles first (so it never double-uploads),
+ * then re-generates the FIT from the stored payload and re-uploads. Mirrors the
+ * Python /api/pending/{id}/retry. Because it WRITES to Garmin it requires BOTH:
+ *   1. an explicit confirmation: body { confirm } equal to the hevyId; AND
+ *   2. authorization: a valid h2g session cookie OR Bearer CRON_SECRET (or auth
+ *      being disabled entirely on a local/self-hosted deploy).
+ */
+
+async function isAuthorized(request: Request): Promise<boolean> {
+  const cronSecret = process.env.CRON_SECRET;
+  if (cronSecret) {
+    const auth = request.headers.get("authorization") ?? "";
+    const m = auth.match(/^Bearer\s+(.+)$/i);
+    if (m && m[1] === cronSecret) return true;
+  }
+  if (!authEnabled()) return true;
+  const store = await cookies();
+  const cookie = store.get(SESSION_COOKIE)?.value ?? null;
+  return verifySession(cookie);
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ hevyId: string }> },
+) {
+  const { hevyId } = await params;
+  if (!hevyId) {
+    return NextResponse.json({ ok: false, error: "hevyId is required." }, { status: 400 });
+  }
+
+  let body: { confirm?: unknown } = {};
+  try {
+    const text = await request.text();
+    if (text) body = JSON.parse(text);
+  } catch {
+    return NextResponse.json({ ok: false, error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  if (body.confirm !== hevyId) {
+    return NextResponse.json(
+      { ok: false, error: "Explicit confirmation required." },
+      { status: 400 },
+    );
+  }
+
+  if (!(await isAuthorized(request))) {
+    return NextResponse.json(
+      { ok: false, error: "Unauthorized: a retry upload requires a session or CRON_SECRET." },
+      { status: 401 },
+    );
+  }
+
+  let sql: ReturnType<typeof getDb>;
+  try {
+    sql = getDb();
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ ok: false, error: `DB unavailable: ${error}` }, { status: 503 });
+  }
+
+  try {
+    const result = await retryPending(hevyId, {}, sql);
+    if (result.status === "not_found") {
+      return NextResponse.json({ ok: false, error: "No pending operation." }, { status: 404 });
+    }
+    if (result.status === "no_payload") {
+      return NextResponse.json(
+        { ok: false, error: "Stored workout payload is unavailable." },
+        { status: 409 },
+      );
+    }
+    return NextResponse.json({ ok: true, ...result });
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ ok: false, error }, { status: 502 });
+  }
+}

--- a/web/components/workout-row.tsx
+++ b/web/components/workout-row.tsx
@@ -89,6 +89,8 @@ export function WorkoutRow({ item }: { item: WorkoutItem }) {
   const [unsyncing, setUnsyncing] = useState(false);
   const [acting, setActing] = useState(false);
   const [actionErr, setActionErr] = useState<string | null>(null);
+  const [recoveryMsg, setRecoveryMsg] = useState<string | null>(null);
+  const [retryConfirm, setRetryConfirm] = useState(false);
   const canHr = Boolean(item.garmin_activity_id);
   const canResolve = item.kind === "pending";
   const canUnsync = item.kind === "terminal";
@@ -149,6 +151,57 @@ export function WorkoutRow({ item }: { item: WorkoutItem }) {
       }
       // The pending row is dropped; the workout becomes a candidate again and
       // this row leaves the list on refresh.
+      setResolving(false);
+      router.refresh();
+    } catch (err) {
+      setActionErr(err instanceof Error ? err.message : String(err));
+    } finally {
+      setActing(false);
+    }
+  }
+
+  async function reconcile() {
+    setActing(true);
+    setActionErr(null);
+    setRecoveryMsg(null);
+    try {
+      const res = await fetch(`/api/pending/${encodeURIComponent(item.hevy_id)}/reconcile`, {
+        method: "POST",
+      });
+      const d = (await res.json().catch(() => ({}))) as { ok?: boolean; status?: string; error?: string };
+      if (!res.ok || !d.ok) {
+        setActionErr(d.error ?? `Request failed (${res.status}).`);
+        return;
+      }
+      if (d.status === "reconciled_synced") {
+        setResolving(false);
+        router.refresh(); // Garmin already had it — this row is now terminal.
+      } else {
+        setRecoveryMsg("Not on Garmin yet — still pending.");
+      }
+    } catch (err) {
+      setActionErr(err instanceof Error ? err.message : String(err));
+    } finally {
+      setActing(false);
+    }
+  }
+
+  async function retry() {
+    setActing(true);
+    setActionErr(null);
+    setRecoveryMsg(null);
+    try {
+      const res = await fetch(`/api/pending/${encodeURIComponent(item.hevy_id)}/retry`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ confirm: item.hevy_id }),
+      });
+      const d = (await res.json().catch(() => ({}))) as { ok?: boolean; status?: string; error?: string };
+      if (!res.ok || !d.ok) {
+        setActionErr(d.error ?? `Request failed (${res.status}).`);
+        return;
+      }
+      setRetryConfirm(false);
       setResolving(false);
       router.refresh();
     } catch (err) {
@@ -272,6 +325,52 @@ export function WorkoutRow({ item }: { item: WorkoutItem }) {
               <span className="text-xs text-danger" role="alert">
                 {actionErr}
               </span>
+            )}
+          </div>
+
+          <div className="mt-2 flex flex-wrap items-center gap-2 border-t border-border pt-2">
+            <span className="text-xs text-text-muted">Recovery:</span>
+            <button
+              type="button"
+              onClick={reconcile}
+              disabled={acting}
+              title="Check whether Garmin already has this activity"
+              className={actionBtn}
+            >
+              {acting ? "Working…" : "Check Garmin"}
+            </button>
+            {!retryConfirm ? (
+              <button
+                type="button"
+                onClick={() => setRetryConfirm(true)}
+                disabled={acting}
+                title="Re-upload this workout to Garmin"
+                className={actionBtn}
+              >
+                Retry upload
+              </button>
+            ) : (
+              <span className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={retry}
+                  disabled={acting}
+                  className="rounded-lg bg-teal/20 px-3 py-1.5 text-xs font-medium text-teal transition-colors hover:bg-teal/30 disabled:opacity-50"
+                >
+                  {acting ? "Retrying…" : "Confirm re-upload"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setRetryConfirm(false)}
+                  disabled={acting}
+                  className={actionBtn}
+                >
+                  Cancel
+                </button>
+              </span>
+            )}
+            {recoveryMsg && (
+              <span className="text-xs text-text-secondary">{recoveryMsg}</span>
             )}
           </div>
         </div>

--- a/web/lib/pending-recovery.test.ts
+++ b/web/lib/pending-recovery.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Unit tests for reconcile/retry (lib/pending-recovery). Every Garmin op, the
+ * FIT generator, and the DB helpers are mocked, so no network/DB is touched. We
+ * assert the "never double-upload" property (reconcile completes as matched; a
+ * retry that finds an existing activity does NOT upload) and the happy retry
+ * path.
+ */
+
+const generateFit = vi.fn(() => ({
+  fit: new Uint8Array([1, 2, 3]),
+  exercises: 2,
+  total_sets: 6,
+  calories: 321,
+  avg_hr: 110,
+  duration_s: 3600,
+}));
+vi.mock("hevy2garmin", () => ({ generateFit: (...a: unknown[]) => generateFit(...a) }));
+
+const getGarminClient = vi.fn(async () => ({ domain: "garmin.com" }));
+const findExistingActivity = vi.fn();
+const upload = vi.fn();
+const rename = vi.fn();
+const describe_ = vi.fn();
+vi.mock("./garmin-upload", () => ({
+  getGarminClient: (...a: unknown[]) => getGarminClient(...a),
+  findExistingActivity: (...a: unknown[]) => findExistingActivity(...a),
+  upload: (...a: unknown[]) => upload(...a),
+  rename: (...a: unknown[]) => rename(...a),
+  describe: (...a: unknown[]) => describe_(...a),
+}));
+
+const getPending = vi.fn();
+const completePending = vi.fn();
+const updatePending = vi.fn();
+vi.mock("./pending-store", () => ({
+  getPending: (...a: unknown[]) => getPending(...a),
+  completePending: (...a: unknown[]) => completePending(...a),
+  updatePending: (...a: unknown[]) => updatePending(...a),
+}));
+
+vi.mock("./sync-one", () => ({ generateDescription: () => "desc" }));
+vi.mock("./db", () => ({ getDb: () => ({}) }));
+
+import { reconcilePending, retryPending } from "./pending-recovery";
+
+const sql = {} as ReturnType<typeof import("./db").getDb>;
+const client = { domain: "garmin.com" };
+const garminClientFactory = vi.fn(async () => client as never);
+
+const PENDING = {
+  hevy_id: "w1",
+  phase: "processing",
+  attempt_count: 1,
+  payload: {
+    workout: { id: "w1", title: "Push Day", start_time: "2026-08-01T10:00:00Z" },
+    title: "Push Day",
+    calories: 321,
+    avg_hr: 110,
+  },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getPending.mockResolvedValue(PENDING);
+  findExistingActivity.mockResolvedValue(null);
+  upload.mockResolvedValue({ uploadId: 9, activityId: 555 });
+});
+
+describe("reconcilePending", () => {
+  it("no pending row → not_found", async () => {
+    getPending.mockResolvedValue(null);
+    const r = await reconcilePending("w1", { garminClientFactory }, sql);
+    expect(r.status).toBe("not_found");
+    expect(findExistingActivity).not.toHaveBeenCalled();
+  });
+
+  it("no usable payload → no_payload, no Garmin call", async () => {
+    getPending.mockResolvedValue({ ...PENDING, payload: {} });
+    const r = await reconcilePending("w1", { garminClientFactory }, sql);
+    expect(r.status).toBe("no_payload");
+    expect(garminClientFactory).not.toHaveBeenCalled();
+  });
+
+  it("Garmin already has it → completes as matched, no upload", async () => {
+    findExistingActivity.mockResolvedValue(4242);
+    const r = await reconcilePending("w1", { garminClientFactory }, sql);
+    expect(r.status).toBe("reconciled_synced");
+    expect(r.garminActivityId).toBe(4242);
+    expect(completePending).toHaveBeenCalledWith(
+      "w1",
+      expect.objectContaining({ garminActivityId: "4242", syncMethod: "match" }),
+      sql,
+    );
+    expect(upload).not.toHaveBeenCalled();
+  });
+
+  it("Garmin has nothing → no_activity, pending left in place", async () => {
+    const r = await reconcilePending("w1", { garminClientFactory }, sql);
+    expect(r.status).toBe("no_activity");
+    expect(completePending).not.toHaveBeenCalled();
+    expect(updatePending).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("retryPending", () => {
+  it("Garmin already has it → matched, NEVER uploads", async () => {
+    findExistingActivity.mockResolvedValue(4242);
+    const r = await retryPending("w1", { garminClientFactory }, sql);
+    expect(r.status).toBe("reconciled_synced");
+    expect(upload).not.toHaveBeenCalled();
+    expect(generateFit).not.toHaveBeenCalled();
+  });
+
+  it("fresh → regenerates FIT, uploads, finalizes, completes", async () => {
+    const r = await retryPending("w1", { garminClientFactory }, sql);
+    expect(r.status).toBe("synced");
+    expect(r.garminActivityId).toBe(555);
+    expect(generateFit).toHaveBeenCalledTimes(1);
+    expect(upload).toHaveBeenCalledTimes(1);
+    expect(rename).toHaveBeenCalledWith(client, 555, "Push Day");
+    expect(describe_).toHaveBeenCalledTimes(1);
+    expect(completePending).toHaveBeenCalledWith(
+      "w1",
+      expect.objectContaining({ garminActivityId: "555", syncMethod: "upload" }),
+      sql,
+    );
+  });
+
+  it("upload throws → parks pending with the error, no completion", async () => {
+    upload.mockRejectedValue(new Error("Garmin upload failed (500)"));
+    const r = await retryPending("w1", { garminClientFactory }, sql);
+    expect(r.status).toBe("error");
+    expect(r.error).toContain("Garmin upload failed");
+    expect(completePending).not.toHaveBeenCalled();
+    expect(updatePending).toHaveBeenCalledWith(
+      "w1",
+      expect.objectContaining({ phase: "processing", last_error: expect.stringContaining("failed") }),
+      sql,
+    );
+  });
+
+  it("no usable payload → no_payload", async () => {
+    getPending.mockResolvedValue({ ...PENDING, payload: { title: "x" } });
+    const r = await retryPending("w1", { garminClientFactory }, sql);
+    expect(r.status).toBe("no_payload");
+    expect(upload).not.toHaveBeenCalled();
+  });
+});

--- a/web/lib/pending-recovery.test.ts
+++ b/web/lib/pending-recovery.test.ts
@@ -8,7 +8,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
  * path.
  */
 
-const generateFit = vi.fn(() => ({
+const generateFit = vi.fn((..._a: unknown[]) => ({
   fit: new Uint8Array([1, 2, 3]),
   exercises: 2,
   total_sets: 6,
@@ -18,7 +18,7 @@ const generateFit = vi.fn(() => ({
 }));
 vi.mock("hevy2garmin", () => ({ generateFit: (...a: unknown[]) => generateFit(...a) }));
 
-const getGarminClient = vi.fn(async () => ({ domain: "garmin.com" }));
+const getGarminClient = vi.fn(async (..._a: unknown[]) => ({ domain: "garmin.com" }));
 const findExistingActivity = vi.fn();
 const upload = vi.fn();
 const rename = vi.fn();

--- a/web/lib/pending-recovery.ts
+++ b/web/lib/pending-recovery.ts
@@ -1,0 +1,170 @@
+/**
+ * Recovery for stuck in-flight uploads — the counterpart to lib/sync-one for a
+ * SPECIFIC pending workout rather than the next candidate.
+ *
+ *   reconcile — a Garmin READ: check whether Garmin already has an activity at
+ *     the workout's start time. If it does, the earlier attempt actually landed,
+ *     so complete the pending as a matched success (no re-upload). Otherwise
+ *     leave the pending in place and record that nothing was found.
+ *
+ *   retry — reconcile first (never double-upload), and only if Garmin still has
+ *     nothing, regenerate the FIT from the stored payload and re-upload, then
+ *     finalize. A Garmin WRITE — the route gates it behind auth + confirmation.
+ *
+ * Both reuse the same helpers as sync-one and take an injectable Garmin client
+ * factory so they can be unit-tested with no network.
+ */
+import { generateFit, type HevyWorkout as FitWorkout } from "hevy2garmin";
+import {
+  getGarminClient,
+  findExistingActivity,
+  upload,
+  rename,
+  describe,
+} from "./garmin-upload";
+import { getPending, completePending, updatePending, type PendingRow } from "./pending-store";
+import { generateDescription } from "./sync-one";
+import type { GarminClient } from "garmin-auth";
+import { getDb } from "./db";
+
+type Sql = ReturnType<typeof getDb>;
+
+export interface RecoveryOptions {
+  /** Injectable Garmin client factory (tests). Defaults to the live client. */
+  garminClientFactory?: () => Promise<GarminClient>;
+  /** Attach a text description on a retried upload. Default true. */
+  descriptionEnabled?: boolean;
+}
+
+export interface RecoveryResult {
+  /**
+   * reconciled_synced — Garmin already had it, completed as matched.
+   * no_activity — reconcile found nothing on Garmin, pending left in place.
+   * synced — retry re-uploaded successfully.
+   * not_found — no pending row for this id.
+   * no_payload — the pending row has no usable stored workout.
+   * error — the retry upload failed (pending parked with the error).
+   */
+  status: "reconciled_synced" | "no_activity" | "synced" | "not_found" | "no_payload" | "error";
+  garminActivityId: number | null;
+  error: string | null;
+}
+
+interface StoredPayload {
+  workout?: Record<string, unknown>;
+  title?: string;
+  calories?: number;
+  avg_hr?: number | null;
+}
+
+function payloadOf(pending: PendingRow): StoredPayload {
+  const p = pending.payload;
+  return p && typeof p === "object" ? (p as StoredPayload) : {};
+}
+
+function startTimeOf(workout: Record<string, unknown> | undefined): string | null {
+  const s = workout?.start_time;
+  return typeof s === "string" && s ? s : null;
+}
+
+/** Complete a pending as a matched Garmin activity (no upload). */
+async function completeMatched(
+  hevyId: string,
+  pl: StoredPayload,
+  activityId: number,
+  sql: Sql,
+): Promise<void> {
+  await completePending(
+    hevyId,
+    {
+      garminActivityId: String(activityId),
+      title: pl.title ?? "",
+      calories: pl.calories ?? null,
+      avgHr: pl.avg_hr ?? null,
+      syncMethod: "match",
+    },
+    sql,
+  );
+}
+
+export async function reconcilePending(
+  hevyId: string,
+  opts: RecoveryOptions = {},
+  sql: Sql = getDb(),
+): Promise<RecoveryResult> {
+  const pending = await getPending(hevyId, sql);
+  if (!pending) return { status: "not_found", garminActivityId: null, error: null };
+  const pl = payloadOf(pending);
+  const startTime = startTimeOf(pl.workout);
+  if (!startTime) return { status: "no_payload", garminActivityId: null, error: null };
+
+  const factory = opts.garminClientFactory ?? (() => getGarminClient());
+  const client = await factory();
+  const existing = await findExistingActivity(client, startTime);
+  if (existing != null) {
+    await completeMatched(hevyId, pl, existing, sql);
+    return { status: "reconciled_synced", garminActivityId: existing, error: null };
+  }
+  await updatePending(hevyId, { last_error: "reconcile: no matching Garmin activity" }, sql);
+  return { status: "no_activity", garminActivityId: null, error: null };
+}
+
+export async function retryPending(
+  hevyId: string,
+  opts: RecoveryOptions = {},
+  sql: Sql = getDb(),
+): Promise<RecoveryResult> {
+  const pending = await getPending(hevyId, sql);
+  if (!pending) return { status: "not_found", garminActivityId: null, error: null };
+  const pl = payloadOf(pending);
+  const workout = pl.workout;
+  const startTime = startTimeOf(workout);
+  if (!workout || !startTime) return { status: "no_payload", garminActivityId: null, error: null };
+
+  const factory = opts.garminClientFactory ?? (() => getGarminClient());
+  const client = await factory();
+
+  // Never double-upload: if Garmin already has it, complete as matched.
+  const existing = await findExistingActivity(client, startTime);
+  if (existing != null) {
+    await completeMatched(hevyId, pl, existing, sql);
+    return { status: "reconciled_synced", garminActivityId: existing, error: null };
+  }
+
+  try {
+    const fit = generateFit(workout as unknown as FitWorkout, null);
+    await updatePending(
+      hevyId,
+      { phase: "processing", attempt_count: (pending.attempt_count ?? 0) + 1, last_error: null },
+      sql,
+    );
+    const up = await upload(client, fit.fit, startTime);
+    const activityId = up.activityId;
+    if (activityId != null) {
+      await rename(client, activityId, pl.title ?? "");
+      if (opts.descriptionEnabled !== false) {
+        await describe(
+          client,
+          activityId,
+          generateDescription(workout, fit.calories, fit.avg_hr),
+        );
+      }
+    }
+    await completePending(
+      hevyId,
+      {
+        garminActivityId: activityId != null ? String(activityId) : null,
+        title: pl.title ?? "",
+        calories: fit.calories,
+        avgHr: fit.avg_hr,
+        syncMethod: "upload",
+      },
+      sql,
+    );
+    return { status: "synced", garminActivityId: activityId ?? null, error: null };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await updatePending(hevyId, { phase: "processing", last_error: message }, sql);
+    return { status: "error", garminActivityId: null, error: message };
+  }
+}


### PR DESCRIPTION
Closes #383. Part of the modern Next.js web rebuild (soma#385).

Ports the Python dashboard's pending-recovery actions, which the modern web lacked (it only had Abandon).

**`lib/pending-recovery`** — the per-workout counterpart to `sync-one`:
- **reconcile** (Garmin READ): if Garmin already has an activity at the workout's start time, the earlier attempt landed, so complete the pending as matched (no upload); otherwise leave it.
- **retry** (Garmin WRITE): reconcile first (never double-upload), then regenerate the FIT from the stored payload and re-upload. Reuses the same garmin-upload + generateFit + pending-store helpers, with an injectable Garmin client for tests.

**Routes**: `/api/pending/[id]/reconcile` (open) and `/api/pending/[id]/retry` (gated behind auth + a `confirm` token == the hevyId, since it writes to Garmin).

**UI**: a Recovery row in the pending Resolve panel — "Check Garmin" and "Retry upload" (behind a confirm).

### Verified — never runs live vs staging
- **13 new tests** (59 web tests total, all green): engine — reconcile not_found/no_payload/matched/no_activity, retry never-double-uploads / happy upload+finalize / error-parks / no_payload; route — retry rejects a missing/wrong confirm (400), unauthorized (401), runs on session or auth-disabled, 409 on no_payload.
- **Playwright** (reconcile/retry mocked via `fetch` patch — real Garmin never hit): the Recovery row renders; "Check Garmin" → "Not on Garmin yet — still pending."; "Retry upload" → confirm → success collapses the panel with no error. Seeded pending row cleaned up (DB back to 0).
- tsc + `next build` green.
