### PR TITLE
feat(web): setup page + connect Hevy

### DIFF
--- a/web/app/api/connect-hevy/route.ts
+++ b/web/app/api/connect-hevy/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { fetchWorkoutCount } from "@/lib/hevy-sync";
+import { getDb } from "@/lib/db";
+
+// Probes the live Hevy API and writes platform_credentials at request time.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * POST /api/connect-hevy
+ * Body: { key: "<hevy-api-key>" }
+ *
+ * Validates a Hevy API key with a read-only workout-count probe and, ONLY when
+ * it is valid, upserts it into platform_credentials (platform 'hevy',
+ * credentials { api_key }) so the sync engine can use it. An invalid key is
+ * rejected and nothing is written. Mirrors the Python setup's Hevy step.
+ */
+export async function POST(request: Request) {
+  let body: { key?: unknown } = {};
+  try {
+    const text = await request.text();
+    if (text) body = JSON.parse(text);
+  } catch {
+    return NextResponse.json({ ok: false, error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const key = typeof body.key === "string" ? body.key.trim() : "";
+  if (!key) {
+    return NextResponse.json({ ok: false, error: "A Hevy API key is required." }, { status: 400 });
+  }
+
+  // 1) Validate — a read-only probe. A bad key throws; nothing is written.
+  let workoutCount: number;
+  try {
+    workoutCount = await fetchWorkoutCount(key);
+  } catch {
+    return NextResponse.json(
+      { ok: false, valid: false, error: "That Hevy API key was rejected by Hevy." },
+      { status: 200 },
+    );
+  }
+
+  // 2) Valid → persist into platform_credentials.
+  let sql: ReturnType<typeof getDb>;
+  try {
+    sql = getDb();
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ ok: false, error: `DB unavailable: ${error}` }, { status: 503 });
+  }
+
+  try {
+    await sql`
+      INSERT INTO platform_credentials (platform, auth_type, credentials, status, connected_at)
+      VALUES ('hevy', 'api_key', ${sql.json({ api_key: key })}, 'active', NOW())
+      ON CONFLICT (platform) DO UPDATE SET
+        auth_type = 'api_key',
+        credentials = EXCLUDED.credentials,
+        status = 'active',
+        connected_at = NOW()
+    `;
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ ok: false, valid: true, error: `Could not save the key: ${error}` }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true, valid: true, workout_count: workoutCount });
+}

--- a/web/app/setup/page.tsx
+++ b/web/app/setup/page.tsx
@@ -1,0 +1,119 @@
+import { getDb } from "@/lib/db";
+import { ConnectHevy } from "@/components/connect-hevy";
+
+// Queries the live hevy2garmin Postgres per request — never at build time.
+export const dynamic = "force-dynamic";
+
+interface Conn {
+  platform: string;
+  status: string;
+  connected_at: string | null;
+}
+
+interface SetupData {
+  dbConfigured: boolean;
+  hevy: Conn | null;
+  garmin: Conn | null;
+}
+
+const EMPTY: SetupData = { dbConfigured: false, hevy: null, garmin: null };
+
+async function loadSetup(): Promise<SetupData> {
+  let sql: ReturnType<typeof getDb>;
+  try {
+    sql = getDb();
+  } catch {
+    return EMPTY;
+  }
+  const rows = await sql`
+    SELECT platform, status, connected_at
+    FROM platform_credentials
+    WHERE platform IN ('hevy', 'garmin')
+  `.catch(() => [] as Conn[]);
+  const find = (p: string): Conn | null =>
+    rows.find((r) => r.platform === p) ?? null;
+  return { dbConfigured: true, hevy: find("hevy"), garmin: find("garmin") };
+}
+
+function isConnected(c: Conn | null): boolean {
+  return Boolean(c && c.status !== "disconnected");
+}
+
+function fmtDate(value: string | null): string {
+  if (!value) return "";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleString(undefined, { year: "numeric", month: "short", day: "numeric" });
+}
+
+function StatusDot({ connected }: { connected: boolean }) {
+  return (
+    <span className="inline-flex items-center gap-2">
+      <span
+        className={`inline-block h-2.5 w-2.5 rounded-full ${connected ? "bg-success" : "bg-danger"}`}
+        aria-hidden
+      />
+      <span className={`text-xs ${connected ? "text-success" : "text-text-muted"}`}>
+        {connected ? "Connected" : "Not connected"}
+      </span>
+    </span>
+  );
+}
+
+export default async function SetupPage() {
+  const data = await loadSetup();
+  const hevyConnected = isConnected(data.hevy);
+  const garminConnected = isConnected(data.garmin);
+
+  return (
+    <main className="mx-auto max-w-3xl px-4 py-8 md:px-6">
+      <header className="mb-6">
+        <h1 className="text-2xl font-bold text-text">Setup</h1>
+        <p className="mt-1 text-sm text-text-secondary">
+          Connect Hevy and Garmin so your workouts can sync.
+        </p>
+      </header>
+
+      {!data.dbConfigured && (
+        <div className="mb-6 rounded-lg border border-warm/40 bg-warm/10 p-4 text-sm text-warm">
+          No database is configured (DATABASE_URL is unset).
+        </div>
+      )}
+
+      {/* Hevy */}
+      <section className="mb-6 rounded-xl border border-border bg-surface-elevated p-5">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <h2 className="text-lg font-semibold text-text">Hevy</h2>
+          <StatusDot connected={hevyConnected} />
+        </div>
+        {hevyConnected && data.hevy?.connected_at && (
+          <p className="mb-3 text-xs text-text-muted">
+            Connected {fmtDate(data.hevy.connected_at)}.
+          </p>
+        )}
+        <ConnectHevy connected={hevyConnected} />
+      </section>
+
+      {/* Garmin */}
+      <section className="rounded-xl border border-border bg-surface-elevated p-5">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <h2 className="text-lg font-semibold text-text">Garmin Connect</h2>
+          <StatusDot connected={garminConnected} />
+        </div>
+        {garminConnected ? (
+          <p className="text-sm text-text-secondary">
+            Garmin is connected{data.garmin?.connected_at ? ` (${fmtDate(data.garmin.connected_at)})` : ""}.
+            Re-connecting from the web is coming next; for now the scheduled job
+            refreshes the Garmin session.
+          </p>
+        ) : (
+          <p className="text-sm text-text-secondary">
+            Garmin sign-in from the web (including the verification code step) is
+            coming next. Until then, the scheduled job establishes the Garmin
+            session.
+          </p>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/web/components/connect-hevy.tsx
+++ b/web/components/connect-hevy.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+/**
+ * Connect-Hevy form for the setup page. Sends the entered API key to
+ * /api/connect-hevy, which validates it against Hevy (read-only) and, only if
+ * valid, stores it. The key is never echoed back — on success the field clears.
+ */
+export function ConnectHevy({ connected }: { connected: boolean }) {
+  const router = useRouter();
+  const [key, setKey] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [okMsg, setOkMsg] = useState<string | null>(null);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setOkMsg(null);
+    const trimmed = key.trim();
+    if (!trimmed) {
+      setError("Enter your Hevy API key.");
+      return;
+    }
+    setBusy(true);
+    try {
+      const res = await fetch("/api/connect-hevy", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ key: trimmed }),
+      });
+      const d = (await res.json().catch(() => ({}))) as {
+        ok?: boolean;
+        valid?: boolean;
+        workout_count?: number;
+        error?: string;
+      };
+      if (!res.ok || !d.ok) {
+        setError(d.error ?? `Request failed (${res.status}).`);
+        return;
+      }
+      setKey("");
+      setOkMsg(
+        `Connected — Hevy reports ${d.workout_count ?? 0} workout${d.workout_count === 1 ? "" : "s"}.`,
+      );
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form onSubmit={submit} className="space-y-3">
+      <p className="text-xs text-text-muted">
+        {connected
+          ? "Hevy is connected. Enter a new key to replace it."
+          : "Paste your Hevy API key. Find it in the Hevy app under Settings → API."}
+      </p>
+      <input
+        type="password"
+        autoComplete="off"
+        value={key}
+        onChange={(e) => setKey(e.target.value)}
+        placeholder="Hevy API key"
+        className="w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text focus:border-teal focus:outline-none"
+      />
+      <div className="flex items-center gap-3">
+        <button
+          type="submit"
+          disabled={busy}
+          className="rounded-lg bg-teal/20 px-4 py-2 text-sm font-medium text-teal transition-colors hover:bg-teal/30 disabled:opacity-50"
+        >
+          {busy ? "Validating…" : "Validate & save"}
+        </button>
+        {okMsg && <span className="text-xs text-success">{okMsg}</span>}
+        {error && (
+          <span className="text-xs text-danger" role="alert">
+            {error}
+          </span>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/web/components/nav-bar.tsx
+++ b/web/components/nav-bar.tsx
@@ -11,6 +11,7 @@ const NAV_ITEMS = [
   { href: "/mappings", label: "Mappings", icon: "⇄" },
   { href: "/history", label: "History", icon: "◷" },
   { href: "/settings", label: "Settings", icon: "⚙" },
+  { href: "/setup", label: "Setup", icon: "⇆" },
 ];
 
 export function NavBar({ authEnabled = false }: { authEnabled?: boolean }) {


### PR DESCRIPTION
Part of the modern Next.js web rebuild (soma#385). Closes hevy2garmin#385.

The Python dashboard has a /setup page to connect Hevy + Garmin; the modern web had none (it assumed the accounts were already connected). This adds the setup page and the **Hevy** connection. Garmin browser sign-in is the follow-up.

**`/setup`** shows both connection statuses (from `platform_credentials`) and a **Connect Hevy** form: the entered key is validated with a read-only Hevy workout-count probe and, only if valid, upserted into `platform_credentials` (platform `hevy`, `{api_key}`). New **`POST /api/connect-hevy`** does validate-then-save. Adds a Setup nav link. The Garmin card shows status with a note that web sign-in is coming next.

### Verified — never overwrote the real stored key
- **4 route tests** (63 web tests total, green): missing key → 400 (no probe/write); a rejected key → `valid:false` and **nothing is written**; a valid key → persists + returns the count; bad JSON → 400.
- **Playwright** against staging: /setup renders both status cards + the form; submitting a **bogus** key hit the real Hevy probe → "rejected by Hevy" shown, field kept. The `platform_credentials` hevy row md5 was **identical before and after** — the real key was never touched.
- tsc + `next build` green.

The valid-key save path is unit-tested (I never entered a real key). A live smoke-test with your real key confirms the happy path.
