### PR TITLE
feat(web): unsynced candidates + per-workout sync

### DIFF
--- a/web/app/api/candidates/route.test.ts
+++ b/web/app/api/candidates/route.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/** GET /api/candidates — returns the unsynced list; degrades gracefully. */
+
+const listCandidates = vi.fn();
+vi.mock("@/lib/sync-one", () => ({ listCandidates: (...a: unknown[]) => listCandidates(...a) }));
+vi.mock("@/lib/db", () => ({ getDb: () => ({}) }));
+
+import { GET } from "./route";
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("GET /api/candidates", () => {
+  it("returns the candidate list", async () => {
+    listCandidates.mockResolvedValue([
+      { hevy_id: "a", title: "Push", start_time: "2026-08-01T10:00:00Z" },
+      { hevy_id: "b", title: "Pull", start_time: null },
+    ]);
+    const res = await GET();
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.candidates).toHaveLength(2);
+    expect(json.candidates[0].hevy_id).toBe("a");
+  });
+
+  it("a Hevy error degrades to an empty list + note (200, not 500)", async () => {
+    listCandidates.mockRejectedValue(new Error("No Hevy API key available"));
+    const res = await GET();
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.candidates).toEqual([]);
+    expect(json.error).toContain("Hevy");
+  });
+});

--- a/web/app/api/candidates/route.ts
+++ b/web/app/api/candidates/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { listCandidates } from "@/lib/sync-one";
+import { getDb } from "@/lib/db";
+
+// Reads live Hevy + the local ledger at request time — never at build.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * GET /api/candidates
+ *
+ * Returns the unsynced Hevy workouts — everything that would be a sync candidate
+ * (dedup layer 1). READ-ONLY: no Garmin call, no upload, no DB write. The
+ * workouts page uses it to show a "to sync" list with a per-workout Sync button.
+ */
+export async function GET() {
+  let sql: ReturnType<typeof getDb>;
+  try {
+    sql = getDb();
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `DB unavailable: ${error}`, candidates: [] }, { status: 503 });
+  }
+
+  try {
+    const candidates = await listCandidates(sql);
+    return NextResponse.json({ candidates });
+  } catch (err) {
+    // A missing Hevy key or a Hevy outage should degrade gracefully, not 500 the
+    // whole page — surface the message and an empty list.
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error, candidates: [] }, { status: 200 });
+  }
+}

--- a/web/app/api/connect-hevy/route.test.ts
+++ b/web/app/api/connect-hevy/route.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Tests for POST /api/connect-hevy — it must validate the key BEFORE writing,
+ * and never persist a rejected key.
+ */
+
+const fetchWorkoutCount = vi.fn();
+vi.mock("@/lib/hevy-sync", () => ({
+  fetchWorkoutCount: (...a: unknown[]) => fetchWorkoutCount(...a),
+}));
+
+// A tagged-template SQL spy with a .json() helper, matching lib/db's surface.
+const sqlTag = vi.fn((..._a: unknown[]) => Promise.resolve([] as unknown[]));
+const sqlObj = Object.assign(sqlTag, { json: (o: unknown) => o });
+vi.mock("@/lib/db", () => ({ getDb: () => sqlObj }));
+
+import { POST } from "./route";
+
+function req(body: unknown): Request {
+  return new Request("http://h/api/connect-hevy", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fetchWorkoutCount.mockResolvedValue(42);
+});
+
+describe("POST /api/connect-hevy", () => {
+  it("missing key → 400, no probe, no write", async () => {
+    const res = await POST(req({}));
+    expect(res.status).toBe(400);
+    expect(fetchWorkoutCount).not.toHaveBeenCalled();
+    expect(sqlTag).not.toHaveBeenCalled();
+  });
+
+  it("rejected key → valid:false and NOTHING is written", async () => {
+    fetchWorkoutCount.mockRejectedValue(new Error("401 Unauthorized"));
+    const res = await POST(req({ key: "bogus" }));
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(false);
+    expect(json.valid).toBe(false);
+    expect(sqlTag).not.toHaveBeenCalled(); // never persisted a bad key
+  });
+
+  it("valid key → persists + returns the workout count", async () => {
+    const res = await POST(req({ key: "good-key" }));
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.valid).toBe(true);
+    expect(json.workout_count).toBe(42);
+    expect(fetchWorkoutCount).toHaveBeenCalledWith("good-key");
+    expect(sqlTag).toHaveBeenCalledTimes(1); // the upsert ran
+  });
+
+  it("invalid JSON → 400", async () => {
+    const bad = new Request("http://h/api/connect-hevy", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{nope",
+    });
+    const res = await POST(bad);
+    expect(res.status).toBe(400);
+    expect(fetchWorkoutCount).not.toHaveBeenCalled();
+  });
+});

--- a/web/app/api/sync/[hevyId]/route.test.ts
+++ b/web/app/api/sync/[hevyId]/route.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/** Gating + targetHevyId passthrough for POST /api/sync/[hevyId]. */
+
+const syncOneWorkout = vi.fn();
+vi.mock("@/lib/sync-one", () => ({ syncOneWorkout: (...a: unknown[]) => syncOneWorkout(...a) }));
+vi.mock("@/lib/db", () => ({ getDb: () => ({}) }));
+
+const authEnabled = vi.fn();
+const verifySession = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  authEnabled: (...a: unknown[]) => authEnabled(...a),
+  verifySession: (...a: unknown[]) => verifySession(...a),
+  SESSION_COOKIE: "h2g_session",
+}));
+const cookieGet = vi.fn();
+vi.mock("next/headers", () => ({ cookies: async () => ({ get: (...a: unknown[]) => cookieGet(...a) }) }));
+
+import { POST } from "./route";
+
+const params = (id: string) => ({ params: Promise.resolve({ hevyId: id }) });
+function req(url: string, body: unknown = {}): Request {
+  return new Request(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.CRON_SECRET;
+  authEnabled.mockReturnValue(true);
+  verifySession.mockReturnValue(false);
+  cookieGet.mockReturnValue(undefined);
+  syncOneWorkout.mockResolvedValue({ status: "dry_run", dryRun: true, dedupDecision: "would_upload" });
+});
+
+describe("POST /api/sync/[hevyId]", () => {
+  it("no live → dry-run for the TARGET workout", async () => {
+    const res = await POST(req("http://h/api/sync/w9", {}), params("w9"));
+    expect(res.status).toBe(200);
+    expect(syncOneWorkout).toHaveBeenCalledWith(expect.anything(), {
+      dryRun: true,
+      targetHevyId: "w9",
+    });
+  });
+
+  it("live but unauthorized → 401, engine not called", async () => {
+    const res = await POST(req("http://h/api/sync/w9", { live: 1 }), params("w9"));
+    expect(res.status).toBe(401);
+    expect(syncOneWorkout).not.toHaveBeenCalled();
+  });
+
+  it("live + session → live sync of the target", async () => {
+    cookieGet.mockReturnValue({ value: "c" });
+    verifySession.mockReturnValue(true);
+    syncOneWorkout.mockResolvedValue({ status: "synced", dryRun: false, garminActivityId: 5 });
+    const res = await POST(req("http://h/api/sync/w9?live=1", {}), params("w9"));
+    expect(res.status).toBe(200);
+    expect(syncOneWorkout).toHaveBeenCalledWith(expect.anything(), {
+      dryRun: false,
+      targetHevyId: "w9",
+    });
+  });
+
+  it("invalid JSON → 400", async () => {
+    const bad = new Request("http://h/api/sync/w9", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{no",
+    });
+    const res = await POST(bad, params("w9"));
+    expect(res.status).toBe(400);
+  });
+});

--- a/web/app/api/sync/[hevyId]/route.ts
+++ b/web/app/api/sync/[hevyId]/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { syncOneWorkout } from "@/lib/sync-one";
+import { getDb } from "@/lib/db";
+import { verifySession, SESSION_COOKIE, authEnabled } from "@/lib/auth";
+
+// Reads live Hevy + Postgres (and, on the live path, Garmin) at request time.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * POST /api/sync/[hevyId]  —  sync ONE specific workout. DRY-RUN BY DEFAULT.
+ *
+ * Same engine and the same three-layer never-duplicate contract as
+ * /api/sync-one, but targets the given Hevy workout instead of the next
+ * candidate. A live upload fires only when the request both asks for it
+ * (?live=1 / body {live}) AND is authorized (h2g session cookie OR Bearer
+ * CRON_SECRET). Anything short of both runs a dry-run.
+ */
+
+async function isAuthorized(request: Request): Promise<boolean> {
+  const cronSecret = process.env.CRON_SECRET;
+  if (cronSecret) {
+    const auth = request.headers.get("authorization") ?? "";
+    const m = auth.match(/^Bearer\s+(.+)$/i);
+    if (m && m[1] === cronSecret) return true;
+  }
+  if (!authEnabled()) return true;
+  const store = await cookies();
+  const cookie = store.get(SESSION_COOKIE)?.value ?? null;
+  return verifySession(cookie);
+}
+
+function wantsLive(request: Request, body: Record<string, unknown>): boolean {
+  const q = new URL(request.url).searchParams.get("live");
+  if (q === "1" || q === "true") return true;
+  const b = body.live;
+  return b === 1 || b === true || b === "1" || b === "true";
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ hevyId: string }> },
+) {
+  const { hevyId } = await params;
+  if (!hevyId) {
+    return NextResponse.json({ error: "hevyId is required." }, { status: 400 });
+  }
+
+  let body: Record<string, unknown> = {};
+  try {
+    const text = await request.text();
+    if (text) body = JSON.parse(text);
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const requestedLive = wantsLive(request, body);
+  const authorized = requestedLive ? await isAuthorized(request) : false;
+  const dryRun = !(requestedLive && authorized);
+
+  if (requestedLive && !authorized) {
+    return NextResponse.json(
+      { error: "Unauthorized: a live upload requires a session or CRON_SECRET." },
+      { status: 401 },
+    );
+  }
+
+  let sql: ReturnType<typeof getDb>;
+  try {
+    sql = getDb();
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `DB unavailable: ${error}` }, { status: 503 });
+  }
+
+  try {
+    const result = await syncOneWorkout(sql, { dryRun, targetHevyId: hevyId });
+    return NextResponse.json(result);
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error }, { status: 500 });
+  }
+}

--- a/web/app/workouts/page.tsx
+++ b/web/app/workouts/page.tsx
@@ -1,5 +1,6 @@
 import { getDb } from "@/lib/db";
 import { WorkoutRow } from "@/components/workout-row";
+import { CandidatesList } from "@/components/candidates-list";
 
 // Queries the live hevy2garmin Postgres per request — never at build time.
 export const dynamic = "force-dynamic";
@@ -111,10 +112,12 @@ export default async function WorkoutsPage() {
       </header>
 
       <div className="mb-6 rounded-lg border border-border bg-surface p-4 text-sm text-text-muted">
-        Resolve an in-flight workout with Mark as synced or Skip, and expand a
-        Garmin-matched workout to see its cached heart-rate. Live Hevy fetch and
-        one-click Garmin upload come in a later phase.
+        Sync an unsynced workout from the To sync list, resolve an in-flight one
+        with Mark as synced / Skip / Abandon, and expand a Garmin-matched workout
+        to see its cached heart-rate.
       </div>
+
+      {data.dbConfigured && <CandidatesList />}
 
       {!data.dbConfigured && (
         <div className="mb-6 rounded-lg border border-warm/40 bg-warm/10 p-4 text-sm text-warm">

--- a/web/components/candidates-list.tsx
+++ b/web/components/candidates-list.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+interface Candidate {
+  hevy_id: string;
+  title: string | null;
+  start_time: string | null;
+}
+
+interface SyncResult {
+  status: string;
+  dryRun: boolean;
+  wouldUpload: boolean;
+  dedupDecision: string;
+  garminActivityId: number | null;
+  error: string | null;
+}
+
+const DECISION_LABEL: Record<string, string> = {
+  would_upload: "Would upload a new Garmin activity",
+  existing_garmin_activity: "Garmin already has this — would match, not upload",
+  already_synced: "Already synced",
+  no_start_time: "No start time — can't sync safely",
+  no_candidates: "No longer a candidate",
+};
+
+function fmtDate(value: string | null): string {
+  if (!value) return "—";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+}
+
+const btn =
+  "rounded-lg border border-border px-2.5 py-1 text-xs font-medium text-text-secondary transition-colors hover:bg-surface-active disabled:opacity-50";
+
+function CandidateRow({ c, onSynced }: { c: Candidate; onSynced: (id: string) => void }) {
+  const router = useRouter();
+  const [busy, setBusy] = useState<null | "preview" | "live">(null);
+  const [result, setResult] = useState<SyncResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [confirm, setConfirm] = useState(false);
+
+  async function run(live: boolean) {
+    setBusy(live ? "live" : "preview");
+    setError(null);
+    try {
+      const res = await fetch(`/api/sync/${encodeURIComponent(c.hevy_id)}${live ? "?live=1" : ""}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(live ? { live: 1 } : {}),
+      });
+      const d = (await res.json().catch(() => ({}))) as SyncResult & { error?: string };
+      if (!res.ok) {
+        setError(d.error ?? `Request failed (${res.status}).`);
+        return;
+      }
+      setResult(d);
+      setConfirm(false);
+      if (live && d.status === "synced") {
+        onSynced(c.hevy_id);
+        router.refresh();
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <li className="px-4 py-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="truncate text-sm font-medium text-text">{c.title || "Untitled workout"}</div>
+          <div className="mt-0.5 text-xs text-text-muted">{fmtDate(c.start_time)}</div>
+        </div>
+        <div className="flex items-center gap-2">
+          <button type="button" onClick={() => run(false)} disabled={busy !== null} className={btn}>
+            {busy === "preview" ? "Previewing…" : "Preview"}
+          </button>
+          {!confirm ? (
+            <button
+              type="button"
+              onClick={() => setConfirm(true)}
+              disabled={busy !== null}
+              className="rounded-lg bg-teal/20 px-2.5 py-1 text-xs font-medium text-teal transition-colors hover:bg-teal/30 disabled:opacity-50"
+            >
+              Sync
+            </button>
+          ) : (
+            <span className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => run(true)}
+                disabled={busy !== null}
+                className="rounded-lg bg-teal/30 px-2.5 py-1 text-xs font-medium text-teal transition-colors hover:bg-teal/40 disabled:opacity-50"
+              >
+                {busy === "live" ? "Syncing…" : "Confirm"}
+              </button>
+              <button type="button" onClick={() => setConfirm(false)} disabled={busy !== null} className={btn}>
+                Cancel
+              </button>
+            </span>
+          )}
+        </div>
+      </div>
+      {result && !error && (
+        <div className="mt-1.5 text-xs text-text-secondary">
+          {result.dryRun ? "Preview: " : ""}
+          {DECISION_LABEL[result.dedupDecision] ?? result.dedupDecision}
+          {result.status === "synced" && result.garminActivityId
+            ? ` · Garmin ${result.garminActivityId}`
+            : ""}
+        </div>
+      )}
+      {error && (
+        <div className="mt-1.5 text-xs text-danger" role="alert">
+          {error}
+        </div>
+      )}
+    </li>
+  );
+}
+
+/**
+ * The unsynced-workouts ("to sync") list on the workouts page. Fetches
+ * /api/candidates (a read-only Hevy probe) on mount and offers a per-workout
+ * Preview (dry-run) and gated Sync (live). Degrades quietly when Hevy is
+ * unreachable or nothing is pending.
+ */
+export function CandidatesList() {
+  const [phase, setPhase] = useState<"loading" | "ready" | "error">("loading");
+  const [candidates, setCandidates] = useState<Candidate[]>([]);
+  const [note, setNote] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    fetch("/api/candidates")
+      .then((r) => r.json())
+      .then((d: { candidates?: Candidate[]; error?: string }) => {
+        if (!alive) return;
+        setCandidates(Array.isArray(d.candidates) ? d.candidates : []);
+        if (d.error) setNote(d.error);
+        setPhase("ready");
+      })
+      .catch((err) => {
+        if (!alive) return;
+        setNote(err instanceof Error ? err.message : String(err));
+        setPhase("error");
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const onSynced = (id: string) => setCandidates((cs) => cs.filter((c) => c.hevy_id !== id));
+
+  return (
+    <section className="mb-8">
+      <h2 className="mb-3 text-lg font-semibold text-text">To sync</h2>
+      {phase === "loading" ? (
+        <div className="rounded-lg border border-border bg-surface p-6 text-center text-sm text-text-muted">
+          Checking Hevy for unsynced workouts…
+        </div>
+      ) : candidates.length === 0 ? (
+        <div className="rounded-lg border border-border bg-surface p-6 text-center text-sm text-text-muted">
+          {note ? `Couldn't load candidates: ${note}` : "Everything from Hevy is already synced."}
+        </div>
+      ) : (
+        <ul className="divide-y divide-border overflow-hidden rounded-xl border border-border bg-surface-elevated">
+          {candidates.map((c) => (
+            <CandidateRow key={c.hevy_id} c={c} onSynced={onSynced} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/web/lib/sync-one.test.ts
+++ b/web/lib/sync-one.test.ts
@@ -67,7 +67,7 @@ vi.mock("./pending-store", () => ({
 // getDb is imported for the Sql type; give it a harmless stub.
 vi.mock("./db", () => ({ getDb: () => ({}) }));
 
-import { syncOneWorkout } from "./sync-one";
+import { syncOneWorkout, listCandidates } from "./sync-one";
 import type { GarminClient } from "garmin-auth";
 
 const sql = {} as ReturnType<typeof import("./db").getDb>;
@@ -287,5 +287,46 @@ describe("empty + edge inputs", () => {
     // Never consulted Garmin (no start time to look up).
     expect(garminClientFactory).not.toHaveBeenCalled();
     expectNoWrites();
+  });
+});
+
+describe("targetHevyId — sync a specific workout", () => {
+  it("targets the matching candidate (dry-run), not the first", async () => {
+    const res = await syncOneWorkout(sql, {
+      targetHevyId: "hevy-1",
+      fetchWorkouts: fetchOne(),
+      garminClientFactory,
+    });
+    expect(res.dryRun).toBe(true);
+    expect(res.workout?.hevy_id).toBe("hevy-1");
+    expect(res.dedupDecision).toBe("would_upload");
+    expectNoWrites();
+  });
+
+  it("a target that is not a candidate → no_candidates", async () => {
+    const res = await syncOneWorkout(sql, {
+      targetHevyId: "does-not-exist",
+      fetchWorkouts: fetchOne(),
+      garminClientFactory,
+    });
+    expect(res.status).toBe("none");
+    expect(res.dedupDecision).toBe("no_candidates");
+    expectNoWrites();
+  });
+});
+
+describe("listCandidates — the unsynced list", () => {
+  it("returns the unsynced workouts (dedup layer 1)", async () => {
+    const cands = await listCandidates(sql, { fetchWorkouts: fetchOne() });
+    expect(cands).toHaveLength(1);
+    expect(cands[0].hevy_id).toBe("hevy-1");
+    expect(cands[0].title).toBe("Push Day");
+    expectNoWrites();
+  });
+
+  it("excludes already-synced ids", async () => {
+    loadSyncedIds.mockResolvedValue(new Set(["hevy-1"]));
+    const cands = await listCandidates(sql, { fetchWorkouts: fetchOne() });
+    expect(cands).toHaveLength(0);
   });
 });

--- a/web/lib/sync-one.ts
+++ b/web/lib/sync-one.ts
@@ -100,6 +100,13 @@ export interface SyncOneOptions {
   garminClientFactory?: () => Promise<GarminClient>;
   /** Whether to attach a text description on the activity. Default true. */
   descriptionEnabled?: boolean;
+  /**
+   * Sync a SPECIFIC workout by its Hevy id instead of the next candidate. When
+   * set, the workout must still be an unsynced candidate (all three dedup layers
+   * still gate the upload); if it is not among the candidates the result is
+   * `no_candidates`.
+   */
+  targetHevyId?: string;
 }
 
 function fitStatsOf(r: FitResult): FitStats {
@@ -118,6 +125,39 @@ function workoutView(w: DedupWorkout): SyncOneResult["workout"] {
     title: (w.title as string | null) ?? null,
     start_time: (w.start_time as string | null) ?? null,
   };
+}
+
+/** The live Hevy workout fetch used by default (all workouts). */
+async function defaultFetchWorkouts(): Promise<HevyWorkout[]> {
+  const client = await getHevyClient();
+  return (await client.getAllWorkouts()) as HevyWorkout[];
+}
+
+/** A candidate workout surfaced to the /api/candidates route. */
+export interface CandidateWorkout {
+  hevy_id: string;
+  title: string | null;
+  start_time: string | null;
+}
+
+/**
+ * The unsynced Hevy workouts (dedup layer 1) — everything that would be a sync
+ * candidate. READ-ONLY: no Garmin call, no DB write. Injectable Hevy fetch for
+ * tests.
+ */
+export async function listCandidates(
+  sql: Sql,
+  opts: { fetchWorkouts?: () => Promise<HevyWorkout[]> } = {},
+): Promise<CandidateWorkout[]> {
+  const fetchWorkouts = opts.fetchWorkouts ?? defaultFetchWorkouts;
+  const workouts = (await fetchWorkouts()) as DedupWorkout[];
+  const [syncedIds, pendingIds] = await Promise.all([loadSyncedIds(sql), loadPendingIds(sql)]);
+  const candidates = filterUnsynced(workouts, syncedIds, pendingIds);
+  return candidates.map((c) => ({
+    hevy_id: String(c.id),
+    title: (c.title as string | null) ?? null,
+    start_time: (c.start_time as string | null) ?? null,
+  }));
 }
 
 /**
@@ -220,14 +260,11 @@ export async function syncOneWorkout(
 ): Promise<SyncOneResult> {
   const dryRun = options.dryRun ?? true; // SAFE DEFAULT
   const descriptionEnabled = options.descriptionEnabled ?? true;
+  const targetHevyId = options.targetHevyId;
 
   // 1) Fetch the Hevy workout list + the dedup id-sets, then pick the next
   //    unsynced candidate (dedup layer 1, pure). Reads only.
-  const fetchWorkouts =
-    options.fetchWorkouts ?? (async () => {
-      const client = await getHevyClient();
-      return (await client.getAllWorkouts()) as HevyWorkout[];
-    });
+  const fetchWorkouts = options.fetchWorkouts ?? defaultFetchWorkouts;
 
   const workouts = (await fetchWorkouts()) as DedupWorkout[];
   const [syncedIds, pendingIds] = await Promise.all([
@@ -236,7 +273,10 @@ export async function syncOneWorkout(
   ]);
   const candidates = filterUnsynced(workouts, syncedIds, pendingIds);
   const remaining = candidates.length;
-  const workout = candidates[0] ?? null;
+  // Target a specific workout when asked; otherwise take the next candidate.
+  const workout = targetHevyId
+    ? candidates.find((c) => String(c.id) === targetHevyId) ?? null
+    : candidates[0] ?? null;
 
   if (!workout) {
     return emptyResult(dryRun, "no_candidates", 0);


### PR DESCRIPTION
Closes #387. Part of the modern Next.js web rebuild (soma#385).

The Python workouts page lists live Hevy workouts that aren't synced yet and lets you sync each; the modern web page only showed already-synced + pending rows. This adds the unsynced-candidates view.

**Engine**: `syncOneWorkout` gains a `targetHevyId` option (sync a specific workout, still gated by all three dedup layers) and a `listCandidates()` helper (live Hevy → dedup → the unsynced list). **Routes**: `GET /api/candidates` (read-only list) and `POST /api/sync/[hevyId]` (targeted, dry-run default, same auth gate as sync-one). **UI**: a "To sync" section on the workouts page with per-workout Preview (dry-run) and gated Sync (live, confirm); synced rows drop from the list, and it degrades quietly when Hevy is unreachable.

### Verified — never runs live vs staging
- **10 new tests** (73 web tests total, green): engine `targetHevyId` targets the right candidate / `no_candidates` when absent; `listCandidates` returns the unsynced list + excludes synced ids; targeted-sync route gating + `targetHevyId` passthrough; candidates route list + graceful Hevy-error degradation (200, empty).
- **Playwright** (`/api/candidates` + `/api/sync/[id]` mocked via a `fetch` patch across a client nav — real Hevy/Garmin never hit): the To-sync list renders both candidates; Preview → "Would upload a new Garmin activity"; Sync → Confirm → the row drops from the list. DB counts unchanged (0).
- tsc + `next build` green.
