### PR TITLE
feat(web): auto-sync quick toggle on the dashboard

### DIFF
--- a/web/app/api/toggle-autosync/route.ts
+++ b/web/app/api/toggle-autosync/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+
+// Reads/writes the app_cache config at request time — never at build.
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/toggle-autosync
+ * Body: { enabled?: boolean }
+ *
+ * Flips (or sets, when `enabled` is given) the scheduled-sync switch, stored as
+ * app_cache 'auto_sync'.enabled — the same value the settings form edits. The
+ * interval and any other keys are preserved. DB-only; mirrors the Python
+ * /api/toggle-autosync.
+ */
+export async function POST(request: Request) {
+  let body: { enabled?: unknown } = {};
+  try {
+    const text = await request.text();
+    if (text) body = JSON.parse(text);
+  } catch {
+    return NextResponse.json({ ok: false, error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  let sql: ReturnType<typeof getDb>;
+  try {
+    sql = getDb();
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ ok: false, error: `DB unavailable: ${error}` }, { status: 503 });
+  }
+
+  try {
+    const rows = (await sql`
+      SELECT value FROM app_cache WHERE key = 'auto_sync' LIMIT 1
+    `) as Array<{ value: unknown }>;
+    const current =
+      rows[0]?.value && typeof rows[0].value === "object"
+        ? (rows[0].value as Record<string, unknown>)
+        : {};
+    const enabled =
+      typeof body.enabled === "boolean" ? body.enabled : !Boolean(current.enabled);
+    const next = { ...current, enabled };
+    await sql`
+      INSERT INTO app_cache (key, value, updated_at)
+      VALUES ('auto_sync', ${sql.json(next)}, NOW())
+      ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()
+    `;
+    return NextResponse.json({ ok: true, enabled });
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ ok: false, error }, { status: 500 });
+  }
+}

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -1,6 +1,7 @@
 import { getDb } from "@/lib/db";
 import { SyncPanel } from "@/components/sync-panel";
 import { BatchSync } from "@/components/batch-sync";
+import { AutoSyncToggle } from "@/components/autosync-toggle";
 
 // Queries the live hevy2garmin Postgres per request — never at build time.
 export const dynamic = "force-dynamic";
@@ -32,6 +33,7 @@ interface DashboardData {
   syncedThisWeek: number;
   recent: RecentWorkout[];
   syncLog: SyncLogEntry[];
+  autoSyncEnabled: boolean;
 }
 
 const EMPTY: DashboardData = {
@@ -42,6 +44,7 @@ const EMPTY: DashboardData = {
   syncedThisWeek: 0,
   recent: [],
   syncLog: [],
+  autoSyncEnabled: false,
 };
 
 async function loadDashboard(): Promise<DashboardData> {
@@ -54,7 +57,7 @@ async function loadDashboard(): Promise<DashboardData> {
 
   // Every query is guarded so a missing/empty table degrades to a sane default
   // rather than crashing the whole page render.
-  const [connected, counts, recent, syncLog] = await Promise.all([
+  const [connected, counts, recent, syncLog, autoSync] = await Promise.all([
     sql`
       SELECT platform, status
       FROM platform_credentials
@@ -82,7 +85,15 @@ async function loadDashboard(): Promise<DashboardData> {
       ORDER BY id DESC
       LIMIT 10
     `.catch(() => [] as SyncLogEntry[]),
+    sql`
+      SELECT value FROM app_cache WHERE key = 'auto_sync' LIMIT 1
+    `.catch(() => [] as Array<{ value: unknown }>),
   ]);
+
+  const autoSyncValue =
+    autoSync[0]?.value && typeof autoSync[0].value === "object"
+      ? (autoSync[0].value as Record<string, unknown>)
+      : {};
 
   return {
     dbConfigured: true,
@@ -113,6 +124,7 @@ async function loadDashboard(): Promise<DashboardData> {
       failed: Number(r.failed) || 0,
       trigger: r.trigger ?? "manual",
     })),
+    autoSyncEnabled: Boolean(autoSyncValue.enabled),
   };
 }
 
@@ -212,6 +224,10 @@ export default async function DashboardPage() {
       {/* Sync controls (preview is dry-run; live upload is gated) */}
       <SyncPanel ready={data.hevyConnected && data.garminConnected} />
       <BatchSync ready={data.hevyConnected && data.garminConnected} />
+
+      <div className="mb-8">
+        <AutoSyncToggle enabled={data.autoSyncEnabled} />
+      </div>
 
       {/* Recent synced workouts */}
       <section className="mb-8">

--- a/web/components/autosync-toggle.tsx
+++ b/web/components/autosync-toggle.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+/**
+ * A compact on/off switch for scheduled auto-sync, for the dashboard. Posts to
+ * /api/toggle-autosync (DB-only) and refreshes. The same value is editable in
+ * Settings; this is the quick toggle.
+ */
+export function AutoSyncToggle({ enabled }: { enabled: boolean }) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function toggle() {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/toggle-autosync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: !enabled }),
+      });
+      const d = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      if (!res.ok || !d.ok) {
+        setError(d.error ?? `Request failed (${res.status}).`);
+        return;
+      }
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-border bg-surface px-4 py-3">
+      <div className="flex-1">
+        <div className="text-sm font-medium text-text">Auto-sync</div>
+        <div className="text-xs text-text-muted">
+          {enabled ? "On — new workouts sync on a schedule." : "Off — sync only when you run it."}
+        </div>
+        {error && (
+          <div className="mt-1 text-xs text-danger" role="alert">
+            {error}
+          </div>
+        )}
+      </div>
+      <button
+        type="button"
+        onClick={toggle}
+        disabled={busy}
+        aria-pressed={enabled}
+        className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors disabled:opacity-50 ${
+          enabled ? "bg-teal/60" : "bg-surface-active"
+        }`}
+      >
+        <span
+          className={`inline-block h-4 w-4 transform rounded-full bg-text transition-transform ${
+            enabled ? "translate-x-6" : "translate-x-1"
+          }`}
+        />
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #389. Part of the modern Next.js web rebuild (soma#385).

The Python dashboard has a quick auto-sync on/off toggle; the modern web could only change it in Settings. Adds the dashboard quick-toggle for parity.

**`POST /api/toggle-autosync`** flips (or sets, given `enabled`) `app_cache.auto_sync.enabled` — the same value the settings form edits — preserving the interval. DB-only. **`AutoSyncToggle`** on the dashboard shows the current state and flips on click.

### Verified (Playwright + DB, real state restored)
- Dashboard renders the toggle in the real state (Off / `aria-pressed=false`).
- Click → `POST /api/toggle-autosync` → DB verified `enabled=true`, `interval_minutes` preserved (120); UI updates to "On".
- Clicked back → DB `enabled=false`; the real setting was restored to its original `false|120`.
- tsc + `next build` green.
