### PR TITLE
feat(web): scan for duplicate Garmin activities

### DIFF
--- a/web/app/api/scan-duplicates/route.test.ts
+++ b/web/app/api/scan-duplicates/route.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const getAllWorkouts = vi.fn();
+vi.mock("@/lib/hevy-sync", () => ({
+  getHevyClient: async () => ({ getAllWorkouts: (...a: unknown[]) => getAllWorkouts(...a) }),
+}));
+
+const detectDuplicates = vi.fn();
+vi.mock("@/lib/garmin-activities", () => ({
+  detectDuplicates: (...a: unknown[]) => detectDuplicates(...a),
+  garminClient: async () => ({}),
+}));
+
+import { POST } from "./route";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getAllWorkouts.mockResolvedValue([
+    { id: "w1", title: "Push", start_time: "2026-08-01T10:00:00Z", end_time: "2026-08-01T11:00:00Z" },
+  ]);
+});
+
+describe("POST /api/scan-duplicates", () => {
+  it("returns the duplicate count", async () => {
+    detectDuplicates.mockResolvedValue([
+      { workout_id: "w1", workout_title: "Push", tool_activity_id: 1, watch_activity_id: 2 },
+    ]);
+    const res = await POST();
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.count).toBe(1);
+    expect(detectDuplicates).toHaveBeenCalledTimes(1);
+  });
+
+  it("no duplicates → count 0", async () => {
+    detectDuplicates.mockResolvedValue([]);
+    const res = await POST();
+    const json = await res.json();
+    expect(json.count).toBe(0);
+  });
+
+  it("a failure → 502", async () => {
+    detectDuplicates.mockRejectedValue(new Error("Garmin unreachable"));
+    const res = await POST();
+    expect(res.status).toBe(502);
+  });
+});

--- a/web/app/api/scan-duplicates/route.ts
+++ b/web/app/api/scan-duplicates/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { getHevyClient } from "@/lib/hevy-sync";
+import { detectDuplicates, garminClient, type WorkoutWindow } from "@/lib/garmin-activities";
+
+// Reads live Hevy + Garmin at request time — never at build. Read-only: it
+// reports duplicate activity pairs, it never deletes anything.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * POST /api/scan-duplicates
+ *
+ * Scans the most recent Hevy workouts for windows where Garmin holds BOTH a
+ * tool-uploaded activity and the watch's own — the tell of a past sync race.
+ * Returns the count (and the descriptors). Log/report only — no deletion.
+ * Mirrors the Python /api/scan-duplicates.
+ */
+export async function POST() {
+  try {
+    const hevy = await getHevyClient();
+    const raw = (await hevy.getAllWorkouts()) as Array<Record<string, unknown>>;
+    const workouts: WorkoutWindow[] = raw.slice(0, 50).map((w) => ({
+      id: String(w.id),
+      title: (w.title as string | null) ?? null,
+      start_time: (w.start_time as string | null) ?? null,
+      end_time: (w.end_time as string | null) ?? null,
+    }));
+    const client = await garminClient();
+    const duplicates = await detectDuplicates(client, workouts);
+    return NextResponse.json({ ok: true, count: duplicates.length, duplicates });
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ ok: false, error }, { status: 502 });
+  }
+}

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -1,6 +1,7 @@
 import { getDb } from "@/lib/db";
 import { SettingsForm } from "@/components/settings-form";
 import { DangerZone } from "@/components/danger-zone";
+import { ScanDuplicates } from "@/components/scan-duplicates";
 
 // Queries the live hevy2garmin Postgres per request — never at build time.
 export const dynamic = "force-dynamic";
@@ -245,6 +246,12 @@ export default async function SettingsPage() {
             ))}
           </div>
         )}
+      </section>
+
+      {/* Maintenance */}
+      <section className="mt-8">
+        <h2 className="mb-3 text-lg font-semibold text-text">Maintenance</h2>
+        <ScanDuplicates />
       </section>
 
       {/* Danger zone */}

--- a/web/components/scan-duplicates.tsx
+++ b/web/components/scan-duplicates.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * "Scan for duplicates" maintenance action for the settings page. Posts to
+ * /api/scan-duplicates (read-only — it reports, never deletes) and shows the
+ * count of tool+watch duplicate Garmin activity pairs from a past sync race.
+ */
+export function ScanDuplicates() {
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function scan() {
+    setBusy(true);
+    setError(null);
+    setResult(null);
+    try {
+      const res = await fetch("/api/scan-duplicates", { method: "POST" });
+      const d = (await res.json().catch(() => ({}))) as { ok?: boolean; count?: number; error?: string };
+      if (!res.ok || !d.ok) {
+        setError(d.error ?? `Request failed (${res.status}).`);
+        return;
+      }
+      const n = d.count ?? 0;
+      setResult(n === 0 ? "No duplicate activities found." : `Found ${n} possible duplicate${n === 1 ? "" : "s"} — see the details in Garmin Connect.`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="rounded-xl border border-border bg-surface-elevated p-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold text-text">Scan for duplicates</h3>
+          <p className="mt-0.5 text-xs text-text-muted">
+            Checks recent workouts for a tool + watch activity pair on Garmin (a
+            past sync race). Report only — nothing is deleted.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={scan}
+          disabled={busy}
+          className="rounded-lg border border-border px-3 py-1.5 text-xs font-medium text-text-secondary transition-colors hover:bg-surface-active disabled:opacity-50"
+        >
+          {busy ? "Scanning…" : "Scan"}
+        </button>
+      </div>
+      {result && <p className="mt-2 text-xs text-text-secondary">{result}</p>}
+      {error && (
+        <p className="mt-2 text-xs text-danger" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web/lib/garmin-activities.test.ts
+++ b/web/lib/garmin-activities.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("./garmin-upload", () => ({ getGarminClient: async () => ({}) }));
+
+import { detectDuplicates, getActivitiesByDate, type GarminActivity } from "./garmin-activities";
+import type { GarminClient } from "garmin-auth";
+
+const client = {} as GarminClient;
+const window1 = {
+  id: "w1",
+  title: "Push",
+  start_time: "2026-08-01T10:00:00Z",
+  end_time: "2026-08-01T11:00:00Z",
+};
+const acts = (list: GarminActivity[]) => ({ getActivities: async () => list });
+
+describe("detectDuplicates", () => {
+  it("flags a tool (DEVELOPMENT) + watch pair overlapping the window", async () => {
+    const dups = await detectDuplicates(client, [window1], acts([
+      { activityId: 1, startTimeGMT: "2026-08-01 10:05:00", duration: 600, manufacturer: "DEVELOPMENT" },
+      { activityId: 2, startTimeGMT: "2026-08-01 10:00:00", duration: 3600, manufacturer: "GARMIN" },
+    ]));
+    expect(dups).toHaveLength(1);
+    expect(dups[0]).toMatchObject({ workout_id: "w1", tool_activity_id: 1, watch_activity_id: 2 });
+  });
+
+  it("a tool activity alone is not a duplicate", async () => {
+    const dups = await detectDuplicates(client, [window1], acts([
+      { activityId: 1, startTimeGMT: "2026-08-01 10:05:00", duration: 600, manufacturer: "DEVELOPMENT" },
+    ]));
+    expect(dups).toHaveLength(0);
+  });
+
+  it("non-overlapping activities are ignored", async () => {
+    const dups = await detectDuplicates(client, [window1], acts([
+      { activityId: 1, startTimeGMT: "2026-08-01 13:00:00", duration: 600, manufacturer: "DEVELOPMENT" },
+      { activityId: 2, startTimeGMT: "2026-08-01 13:00:00", duration: 600, manufacturer: "GARMIN" },
+    ]));
+    expect(dups).toHaveLength(0);
+  });
+
+  it("a workout without a start/end time is skipped", async () => {
+    const getActivities = vi.fn(async () => [] as GarminActivity[]);
+    const dups = await detectDuplicates(client, [{ id: "x", start_time: null, end_time: null }], { getActivities });
+    expect(dups).toHaveLength(0);
+    expect(getActivities).not.toHaveBeenCalled();
+  });
+});
+
+describe("getActivitiesByDate", () => {
+  it("calls the activitylist endpoint for the date and returns the array", async () => {
+    const connectapi = vi.fn(async (..._a: unknown[]) => [{ activityId: 9 }]);
+    const c = { connectapi } as unknown as GarminClient;
+    const res = await getActivitiesByDate(c, "2026-08-01");
+    expect(res).toEqual([{ activityId: 9 }]);
+    expect(connectapi).toHaveBeenCalledTimes(1);
+    expect(String(connectapi.mock.calls[0]?.[0])).toContain("/activitylist-service/activities/search/activities");
+    expect(String(connectapi.mock.calls[0]?.[0])).toContain("startDate=2026-08-01");
+  });
+
+  it("a non-array response degrades to []", async () => {
+    const c = { connectapi: async () => null } as unknown as GarminClient;
+    expect(await getActivitiesByDate(c, "2026-08-01")).toEqual([]);
+  });
+});

--- a/web/lib/garmin-activities.ts
+++ b/web/lib/garmin-activities.ts
@@ -1,0 +1,104 @@
+/**
+ * Read-only Garmin activity queries + duplicate detection. Ports
+ * reconcile.detect_duplicates from the Python: a past sync race can leave TWO
+ * Garmin activities for one workout (a tool-uploaded one + the watch's own), and
+ * this flags those pairs. Log/report only — nothing is deleted.
+ *
+ * The activity listing uses the GarminClient's generic `connectapi`, so it needs
+ * no new package surface. The exact activitylist endpoint + field names are the
+ * well-known garth ones; a live smoke-test confirms them.
+ */
+import type { GarminClient } from "garmin-auth";
+import { getGarminClient } from "./garmin-upload";
+
+export interface GarminActivity {
+  activityId?: number;
+  startTimeGMT?: string;
+  startTimeLocal?: string;
+  duration?: number;
+  manufacturer?: string;
+}
+
+/** Garmin activities on a given YYYY-MM-DD (activitylist-service search). */
+export async function getActivitiesByDate(
+  client: GarminClient,
+  date: string,
+): Promise<GarminActivity[]> {
+  const path = `/activitylist-service/activities/search/activities?startDate=${date}&endDate=${date}&start=0&limit=20`;
+  const res = await client.connectapi<GarminActivity[]>(path);
+  return Array.isArray(res) ? res : [];
+}
+
+export interface DuplicateDescriptor {
+  workout_id: string;
+  workout_title: string | null;
+  tool_activity_id: number;
+  watch_activity_id: number;
+}
+
+export interface WorkoutWindow {
+  id: string;
+  title?: string | null;
+  start_time?: string | null;
+  end_time?: string | null;
+}
+
+/** Parse an ISO/GMT timestamp to epoch ms, treating a bare (naive) string as UTC. */
+function parseMs(s?: string | null): number | null {
+  if (!s) return null;
+  const iso = /[TZ]|[+-]\d\d:?\d\d$/.test(s) ? s : `${s.replace(" ", "T")}Z`;
+  const t = Date.parse(iso);
+  return Number.isNaN(t) ? null : t;
+}
+
+/**
+ * Detect duplicate Garmin activities: for each workout window, a tool activity
+ * (manufacturer DEVELOPMENT) AND a watch activity (any other manufacturer) that
+ * both overlap the window. Best-effort — a per-workout failure is skipped, never
+ * thrown. `getActivities` is injectable for tests.
+ */
+export async function detectDuplicates(
+  client: GarminClient,
+  workouts: WorkoutWindow[],
+  opts: { getActivities?: (c: GarminClient, date: string) => Promise<GarminActivity[]> } = {},
+): Promise<DuplicateDescriptor[]> {
+  const getActs = opts.getActivities ?? getActivitiesByDate;
+  const dups: DuplicateDescriptor[] = [];
+  for (const w of workouts) {
+    try {
+      const start = parseMs(w.start_time);
+      const end = parseMs(w.end_time);
+      if (start == null || end == null) continue;
+      const date = String(w.start_time).slice(0, 10);
+      const acts = await getActs(client, date);
+      let toolId: number | null = null;
+      let watchId: number | null = null;
+      for (const a of acts) {
+        const aStart = parseMs(a.startTimeGMT || a.startTimeLocal);
+        const aDurMs = (a.duration ?? 0) * 1000;
+        if (aStart == null || aDurMs <= 0) continue;
+        const aEnd = aStart + aDurMs;
+        if (aStart > end || aEnd < start) continue; // no overlap
+        const manufacturer = String(a.manufacturer ?? "").toUpperCase();
+        if (manufacturer === "DEVELOPMENT") toolId = a.activityId ?? null;
+        else if (manufacturer) watchId = a.activityId ?? null;
+      }
+      if (toolId != null && watchId != null) {
+        dups.push({
+          workout_id: w.id,
+          workout_title: w.title ?? null,
+          tool_activity_id: toolId,
+          watch_activity_id: watchId,
+        });
+      }
+    } catch {
+      // best-effort: skip a workout whose scan fails
+    }
+  }
+  return dups;
+}
+
+/** Convenience: build a live Garmin client (used by the route). */
+export async function garminClient(): Promise<GarminClient> {
+  return getGarminClient();
+}


### PR DESCRIPTION
Closes #391. Part of the modern Next.js web rebuild (soma#385). Mock-verified Garmin feature.

Ports the Python `/api/scan-duplicates`. A past sync race can leave TWO Garmin activities for one workout (a tool upload + the watch's own); this scans recent Hevy workouts and reports how many such tool+watch pairs Garmin holds. **Report only — nothing is deleted.**

- **`lib/garmin-activities`**: `getActivitiesByDate` (via `GarminClient.connectapi`, the garth activitylist endpoint) + `detectDuplicates` (port of `reconcile.detect_duplicates` — DEVELOPMENT + watch manufacturer overlapping the window). Injectable `getActivities` for tests.
- **`POST /api/scan-duplicates`** scans the recent workouts and returns the count.
- **UI**: a "Scan for duplicates" action in a new Settings → Maintenance section.

### Verified (mock — no real Hevy/Garmin touched)
- **9 new tests** (82 web tests total, green): detectDuplicates flags a tool+watch pair, ignores a lone tool / non-overlapping activities / no-time workouts; getActivitiesByDate hits the activitylist endpoint + degrades a non-array to `[]`; route returns the count and 502s on failure.
- **Playwright** (`/api/scan-duplicates` mocked): the Maintenance section + Scan button render; Scan → "Found 2 possible duplicates".
- tsc + `next build` green.

The real Garmin activitylist call (endpoint + field names are the well-known garth ones) needs a live smoke-test to confirm.
