### PR TITLE
feat(web): cron sync entry (GET /api/cron/sync)

### DIFF
--- a/web/app/api/cron/sync/route.test.ts
+++ b/web/app/api/cron/sync/route.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const syncOneWorkout = vi.fn();
+vi.mock("@/lib/sync-one", () => ({ syncOneWorkout: (...a: unknown[]) => syncOneWorkout(...a) }));
+vi.mock("@/lib/db", () => ({ getDb: () => ({}) }));
+
+import { GET } from "./route";
+
+function req(headers: Record<string, string> = {}): Request {
+  return new Request("http://h/api/cron/sync", { method: "GET", headers });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.CRON_SECRET;
+  delete process.env.GITHUB_PAT;
+  delete process.env.GITHUB_REPO;
+});
+afterEach(() => vi.unstubAllGlobals());
+
+describe("GET /api/cron/sync", () => {
+  it("no CRON_SECRET configured → 401", async () => {
+    const res = await GET(req({ authorization: "Bearer whatever" }));
+    expect(res.status).toBe(401);
+    expect(syncOneWorkout).not.toHaveBeenCalled();
+  });
+
+  it("wrong Bearer → 401", async () => {
+    process.env.CRON_SECRET = "s3cret";
+    const res = await GET(req({ authorization: "Bearer nope" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("correct Bearer + GITHUB_PAT/REPO → dispatches, no engine loop", async () => {
+    process.env.CRON_SECRET = "s3cret";
+    process.env.GITHUB_PAT = "pat";
+    process.env.GITHUB_REPO = "drkostas/hevy2garmin";
+    const fetchMock = vi.fn(async (..._a: unknown[]) => new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const res = await GET(req({ authorization: "Bearer s3cret" }));
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.mode).toBe("dispatch");
+    expect(json.triggered).toBe(true);
+    expect(syncOneWorkout).not.toHaveBeenCalled();
+  });
+
+  it("correct Bearer + no PAT → inline loop until none, counts synced", async () => {
+    process.env.CRON_SECRET = "s3cret";
+    syncOneWorkout
+      .mockResolvedValueOnce({ status: "synced" })
+      .mockResolvedValueOnce({ status: "skipped" })
+      .mockResolvedValueOnce({ status: "none" });
+    const res = await GET(req({ authorization: "Bearer s3cret" }));
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.mode).toBe("inline");
+    expect(json.ran).toBe(2);
+    expect(json.synced).toBe(1);
+    expect(syncOneWorkout).toHaveBeenCalledWith(expect.anything(), { dryRun: false });
+  });
+});

--- a/web/app/api/cron/sync/route.ts
+++ b/web/app/api/cron/sync/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from "next/server";
+import { syncOneWorkout, type SyncOneResult } from "@/lib/sync-one";
+import { getDb } from "@/lib/db";
+
+// Runs the sync at request time — never at build.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * GET /api/cron/sync  —  the scheduled-trigger entry (Vercel cron / any
+ * scheduler). Requires `Authorization: Bearer <CRON_SECRET>`. Then, like the
+ * live path of POST /api/sync, it hands off to the GitHub Action when
+ * GITHUB_PAT + GITHUB_REPO are set (the deployed path, off the request), or
+ * loops the tested single-workout engine up to a cap. Mirrors the Python
+ * /api/cron/sync.
+ */
+
+const CAP = 50;
+
+async function triggerViaActions(pat: string, repo: string): Promise<boolean> {
+  const res = await fetch(`https://api.github.com/repos/${repo}/dispatches`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${pat}`,
+      Accept: "application/vnd.github+json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ event_type: "sync-trigger" }),
+  });
+  return res.ok;
+}
+
+export async function GET(request: Request) {
+  const secret = process.env.CRON_SECRET;
+  const auth = request.headers.get("authorization") ?? "";
+  const m = auth.match(/^Bearer\s+(.+)$/i);
+  if (!secret || !m || m[1] !== secret) {
+    return NextResponse.json({ ok: false, error: "Unauthorized." }, { status: 401 });
+  }
+
+  // Deployed path: hand off to the Action so the long browser-auth sync runs off
+  // the request.
+  const pat = process.env.GITHUB_PAT;
+  const repo = process.env.GITHUB_REPO;
+  if (pat && repo) {
+    try {
+      const ok = await triggerViaActions(pat, repo);
+      return NextResponse.json({ ok, mode: "dispatch", triggered: ok }, { status: ok ? 200 : 502 });
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return NextResponse.json({ ok: false, error }, { status: 502 });
+    }
+  }
+
+  // Local/self-hosted path: loop the tested engine.
+  let sql: ReturnType<typeof getDb>;
+  try {
+    sql = getDb();
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ ok: false, error: `DB unavailable: ${error}` }, { status: 503 });
+  }
+
+  const runs: SyncOneResult[] = [];
+  try {
+    for (let i = 0; i < CAP; i++) {
+      const r = await syncOneWorkout(sql, { dryRun: false });
+      if (r.status === "none") break;
+      runs.push(r);
+      if (r.status === "error") break;
+    }
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ ok: false, error, ran: runs.length }, { status: 500 });
+  }
+
+  const synced = runs.filter((r) => r.status === "synced").length;
+  return NextResponse.json({ ok: true, mode: "inline", ran: runs.length, synced });
+}


### PR DESCRIPTION
Closes #393. Part of the modern Next.js web rebuild (soma#385).

Adds the scheduled-trigger entry (Vercel cron / any scheduler), mirroring the Python `GET /api/cron/sync`.

`GET /api/cron/sync` requires `Authorization: Bearer <CRON_SECRET>`; then, like the live path of `POST /api/sync`, it hands off to the GitHub Action when `GITHUB_PAT` + `GITHUB_REPO` are set (the deployed path, off the request), else loops the tested `syncOneWorkout` engine up to a cap and reports the synced count.

### Verified
- **4 route tests** (86 web tests total, green): no `CRON_SECRET` → 401; wrong Bearer → 401; correct Bearer + `GITHUB_PAT/REPO` → dispatch (engine not looped); correct Bearer + no PAT → inline loop until `none` with the synced count.
- tsc + `next build` green. Route-only (no UI). Never runs live vs staging (`CRON_SECRET` unset there → 401).
