### PR TITLE
feat(web): connect Garmin (email/password login) on setup

### DIFF
--- a/web/app/api/garmin-login/route.test.ts
+++ b/web/app/api/garmin-login/route.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Tests for POST /api/garmin-login. GarminAuth is mocked, so NO real Garmin SSO
+ * runs and no real credentials are ever used.
+ */
+
+const loginMock = vi.fn();
+vi.mock("garmin-auth", () => ({
+  GarminAuth: class {
+    constructor(_o: unknown) {}
+    login() {
+      return loginMock();
+    }
+  },
+  DBTokenStore: class {
+    constructor(..._a: unknown[]) {}
+  },
+  NEEDS_MFA: "needs_mfa",
+}));
+vi.mock("@/lib/garmin-upload", () => ({
+  GARMIN_TOKEN_PLATFORM: "garmin_tokens",
+  resetGarminClient: vi.fn(),
+}));
+
+import { POST } from "./route";
+
+function req(body: unknown): Request {
+  return new Request("http://h/api/garmin-login", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.DATABASE_URL = "postgres://ci:ci@localhost:5432/ci";
+});
+
+describe("POST /api/garmin-login", () => {
+  it("missing email/password → 400, no login attempt", async () => {
+    const res = await POST(req({ email: "", password: "" }));
+    expect(res.status).toBe(400);
+    expect(loginMock).not.toHaveBeenCalled();
+  });
+
+  it("successful login → status connected", async () => {
+    loginMock.mockResolvedValue({ domain: "garmin.com" });
+    const res = await POST(req({ email: "a@b.com", password: "pw" }));
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.status).toBe("connected");
+    expect(loginMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("NEEDS_MFA → status needs_mfa (200, with guidance)", async () => {
+    loginMock.mockResolvedValue("needs_mfa");
+    const res = await POST(req({ email: "a@b.com", password: "pw" }));
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.status).toBe("needs_mfa");
+    expect(json.error).toMatch(/two-factor|verification/i);
+  });
+
+  it("login throws (bad creds / blocked) → 502 error", async () => {
+    loginMock.mockRejectedValue(new Error("SSO rejected"));
+    const res = await POST(req({ email: "a@b.com", password: "pw" }));
+    const json = await res.json();
+    expect(res.status).toBe(502);
+    expect(json.status).toBe("error");
+  });
+
+  it("invalid JSON → 400", async () => {
+    const bad = new Request("http://h/api/garmin-login", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{no",
+    });
+    const res = await POST(bad);
+    expect(res.status).toBe(400);
+    expect(loginMock).not.toHaveBeenCalled();
+  });
+});

--- a/web/app/api/garmin-login/route.ts
+++ b/web/app/api/garmin-login/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { GarminAuth, DBTokenStore, NEEDS_MFA } from "garmin-auth";
+import { GARMIN_TOKEN_PLATFORM, resetGarminClient } from "@/lib/garmin-upload";
+
+// Performs a live Garmin SSO login at request time — never at build.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * POST /api/garmin-login
+ * Body: { email, password }
+ *
+ * Runs the garmin-auth SSO login and persists the resulting DI tokens into
+ * platform_credentials ('garmin_tokens') via DBTokenStore, so the sync engine
+ * can use them. Mirrors the Python self-hosted Garmin login — the password is
+ * used only to obtain a token and is never stored.
+ *
+ * KNOWN LIMITS (surfaced to the user in the form):
+ *   - MFA accounts: login() returns needs_mfa, and the package does not yet
+ *     expose an MFA-code submission, so those must use the CLI / scheduled job.
+ *   - From a cloud IP (e.g. Vercel), Garmin SSO is blocked and needs the CF
+ *     Worker proxy; a self-hosted deploy logs in directly.
+ */
+export async function POST(request: Request) {
+  let body: { email?: unknown; password?: unknown } = {};
+  try {
+    const text = await request.text();
+    if (text) body = JSON.parse(text);
+  } catch {
+    return NextResponse.json({ status: "error", error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const email = typeof body.email === "string" ? body.email.trim() : "";
+  const password = typeof body.password === "string" ? body.password : "";
+  if (!email || !password) {
+    return NextResponse.json(
+      { status: "error", error: "Email and password are required." },
+      { status: 400 },
+    );
+  }
+
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    return NextResponse.json(
+      { status: "error", error: "DATABASE_URL is not configured." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const store = new DBTokenStore(url, GARMIN_TOKEN_PLATFORM);
+    const auth = new GarminAuth({ email, password, store });
+    const result = await auth.login();
+    if (result === NEEDS_MFA) {
+      return NextResponse.json({
+        status: "needs_mfa",
+        error:
+          "This Garmin account uses two-factor auth. Web verification-code entry isn't supported yet — use the CLI or the scheduled job to establish the session.",
+      });
+    }
+    // Fresh tokens were persisted by the store; drop the cached client.
+    resetGarminClient();
+    return NextResponse.json({ status: "connected" });
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ status: "error", error }, { status: 502 });
+  }
+}

--- a/web/app/setup/page.tsx
+++ b/web/app/setup/page.tsx
@@ -1,5 +1,6 @@
 import { getDb } from "@/lib/db";
 import { ConnectHevy } from "@/components/connect-hevy";
+import { ConnectGarmin } from "@/components/connect-garmin";
 
 // Queries the live hevy2garmin Postgres per request — never at build time.
 export const dynamic = "force-dynamic";
@@ -100,19 +101,12 @@ export default async function SetupPage() {
           <h2 className="text-lg font-semibold text-text">Garmin Connect</h2>
           <StatusDot connected={garminConnected} />
         </div>
-        {garminConnected ? (
-          <p className="text-sm text-text-secondary">
-            Garmin is connected{data.garmin?.connected_at ? ` (${fmtDate(data.garmin.connected_at)})` : ""}.
-            Re-connecting from the web is coming next; for now the scheduled job
-            refreshes the Garmin session.
-          </p>
-        ) : (
-          <p className="text-sm text-text-secondary">
-            Garmin sign-in from the web (including the verification code step) is
-            coming next. Until then, the scheduled job establishes the Garmin
-            session.
+        {garminConnected && data.garmin?.connected_at && (
+          <p className="mb-3 text-xs text-text-muted">
+            Connected {fmtDate(data.garmin.connected_at)}.
           </p>
         )}
+        <ConnectGarmin connected={garminConnected} />
       </section>
     </main>
   );

--- a/web/components/connect-garmin.tsx
+++ b/web/components/connect-garmin.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+/**
+ * Connect-Garmin form for the setup page. Sends email/password to
+ * /api/garmin-login, which runs the SSO and persists the DI tokens. The password
+ * is used only to log in and is never stored or echoed back.
+ */
+export function ConnectGarmin({ connected }: { connected: boolean }) {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [okMsg, setOkMsg] = useState<string | null>(null);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setOkMsg(null);
+    if (!email.trim() || !password) {
+      setError("Enter your Garmin email and password.");
+      return;
+    }
+    setBusy(true);
+    try {
+      const res = await fetch("/api/garmin-login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: email.trim(), password }),
+      });
+      const d = (await res.json().catch(() => ({}))) as { status?: string; error?: string };
+      if (d.status === "connected") {
+        setPassword("");
+        setOkMsg("Garmin connected.");
+        router.refresh();
+      } else {
+        // needs_mfa or error both carry a message
+        setError(d.error ?? `Request failed (${res.status}).`);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const inputCls =
+    "w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text focus:border-teal focus:outline-none";
+
+  return (
+    <form onSubmit={submit} className="space-y-3">
+      <p className="text-xs text-text-muted">
+        {connected
+          ? "Garmin is connected. Sign in again to refresh the session."
+          : "Sign in with your Garmin Connect account. Your password is used only to get a token and is never stored."}
+      </p>
+      <input
+        type="email"
+        autoComplete="off"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="Garmin email"
+        className={inputCls}
+      />
+      <input
+        type="password"
+        autoComplete="off"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="Garmin password"
+        className={inputCls}
+      />
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="submit"
+          disabled={busy}
+          className="rounded-lg bg-teal/20 px-4 py-2 text-sm font-medium text-teal transition-colors hover:bg-teal/30 disabled:opacity-50"
+        >
+          {busy ? "Connecting…" : "Connect Garmin"}
+        </button>
+        {okMsg && <span className="text-xs text-success">{okMsg}</span>}
+        {error && (
+          <span className="text-xs text-danger" role="alert">
+            {error}
+          </span>
+        )}
+      </div>
+      <p className="text-xs text-text-muted">
+        Two-factor accounts and cloud deploys: web sign-in isn&apos;t supported
+        yet — use the CLI or scheduled job to establish the Garmin session.
+      </p>
+    </form>
+  );
+}


### PR DESCRIPTION
Closes #395. Part of the modern Next.js web rebuild (soma#385). Completes the Garmin half of /setup.

`garmin-auth`'s `GarminAuth({email,password,store}).login()` performs the SSO and persists the DI tokens via `DBTokenStore('garmin_tokens')`, returning a client or `NEEDS_MFA`. This wires it to a **Connect Garmin** form on /setup.

- **`POST /api/garmin-login`** validates email/password, runs `GarminAuth.login()` with a `DBTokenStore`, and returns `connected` / `needs_mfa` / `error`. The password is used only to obtain a token and is never stored.
- **`ConnectGarmin`** form (email + password) with the limitations noted inline.

**Known limits (flagged in the UI):** the package doesn't expose MFA-code submission yet (2FA accounts must use the CLI/scheduled job), and Garmin SSO from a cloud IP needs the CF Worker (self-hosted logs in directly).

### Verified — no real Garmin SSO, no real credentials
- **5 route tests** (91 web tests total, green): missing fields → 400 (no login); success → `connected`; `NEEDS_MFA` → `needs_mfa` (200 + guidance); `login()` throws → 502; bad JSON → 400. `GarminAuth` fully mocked.
- **Playwright**: the /setup Garmin form renders (email + password + Connect Garmin + the MFA/cloud note); client validation rejects empty; with **bogus** creds and `/api/garmin-login` **mocked** to `needs_mfa`, submitting shows the 2FA message. The real `platform_credentials.garmin_tokens` md5 was **unchanged** (no real login ran).
- tsc + `next build` green.

The real SSO (the `connected` path with your real credentials) needs your live smoke-test on a non-2FA self-hosted deploy.
