### PR TITLE
feat(web): routines to Garmin sync + schedule

### DIFF
--- a/web/app/api/hevy-routines/route.test.ts
+++ b/web/app/api/hevy-routines/route.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const fetchHevyRoutines = vi.fn();
+vi.mock("@/lib/hevy-routines", () => ({
+  fetchHevyRoutines: (...a: unknown[]) => fetchHevyRoutines(...a),
+}));
+
+import { GET } from "./route";
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("GET /api/hevy-routines", () => {
+  it("returns id/title/exercise-count", async () => {
+    fetchHevyRoutines.mockResolvedValue([
+      { id: "r1", title: "Push", exercises: [{}, {}] },
+      { id: "r2", name: "Pull", exercises: [] },
+    ]);
+    const res = await GET();
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.routines).toEqual([
+      { id: "r1", title: "Push", exercises: 2 },
+      { id: "r2", title: "Pull", exercises: 0 },
+    ]);
+  });
+
+  it("a Hevy error → empty list + note (200)", async () => {
+    fetchHevyRoutines.mockRejectedValue(new Error("No Hevy API key available"));
+    const res = await GET();
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.routines).toEqual([]);
+    expect(json.error).toContain("Hevy");
+  });
+});

--- a/web/app/api/hevy-routines/route.ts
+++ b/web/app/api/hevy-routines/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { fetchHevyRoutines } from "@/lib/hevy-routines";
+
+// Reads live Hevy at request time — never at build. Read-only.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * GET /api/hevy-routines — the user's Hevy routines (id, title, exercise count).
+ * Read-only. Degrades to an empty list + note when Hevy is unreachable.
+ */
+export async function GET() {
+  try {
+    const routines = await fetchHevyRoutines();
+    const items = routines.map((r) => ({
+      id: String(r.id ?? ""),
+      title: r.title ?? r.name ?? "Untitled routine",
+      exercises: (r.exercises ?? []).length,
+    }));
+    return NextResponse.json({ routines: items });
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error, routines: [] }, { status: 200 });
+  }
+}

--- a/web/app/api/routines/[hevyId]/schedule/route.test.ts
+++ b/web/app/api/routines/[hevyId]/schedule/route.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const scheduleRoutine = vi.fn();
+vi.mock("@/lib/garmin-routine-sync", () => ({ scheduleRoutine: (...a: unknown[]) => scheduleRoutine(...a) }));
+
+let syncedRow: Array<{ garmin_workout_id: string | null }> = [];
+const sqlTag = vi.fn(async (..._a: unknown[]) => syncedRow);
+vi.mock("@/lib/db", () => ({ getDb: () => sqlTag }));
+
+const authEnabled = vi.fn();
+const verifySession = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  authEnabled: (...a: unknown[]) => authEnabled(...a),
+  verifySession: (...a: unknown[]) => verifySession(...a),
+  SESSION_COOKIE: "h2g_session",
+}));
+const cookieGet = vi.fn();
+vi.mock("next/headers", () => ({ cookies: async () => ({ get: (...a: unknown[]) => cookieGet(...a) }) }));
+
+import { POST } from "./route";
+
+const params = (id: string) => ({ params: Promise.resolve({ hevyId: id }) });
+function req(body: unknown): Request {
+  return new Request("http://h/api/routines/r1/schedule", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.CRON_SECRET;
+  authEnabled.mockReturnValue(false);
+  verifySession.mockReturnValue(false);
+  cookieGet.mockReturnValue(undefined);
+  syncedRow = [{ garmin_workout_id: "555" }];
+  scheduleRoutine.mockResolvedValue({ status: "scheduled", scheduleId: "9", error: null });
+});
+
+describe("POST /api/routines/[id]/schedule", () => {
+  it("invalid date → 400, no schedule", async () => {
+    const res = await POST(req({ date: "nope" }), params("r1"));
+    expect(res.status).toBe(400);
+    expect(scheduleRoutine).not.toHaveBeenCalled();
+  });
+
+  it("routine not synced yet (no garmin workout id) → 409", async () => {
+    syncedRow = [];
+    const res = await POST(req({ date: "2026-09-01" }), params("r1"));
+    expect(res.status).toBe(409);
+    expect(scheduleRoutine).not.toHaveBeenCalled();
+  });
+
+  it("valid → schedules", async () => {
+    const res = await POST(req({ date: "2026-09-01" }), params("r1"));
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(scheduleRoutine).toHaveBeenCalledWith("r1", "555", "2026-09-01", expect.anything());
+  });
+
+  it("password set + no session → 401", async () => {
+    authEnabled.mockReturnValue(true);
+    const res = await POST(req({ date: "2026-09-01" }), params("r1"));
+    expect(res.status).toBe(401);
+    expect(scheduleRoutine).not.toHaveBeenCalled();
+  });
+});

--- a/web/app/api/routines/[hevyId]/schedule/route.ts
+++ b/web/app/api/routines/[hevyId]/schedule/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { scheduleRoutine } from "@/lib/garmin-routine-sync";
+import { getDb } from "@/lib/db";
+import { verifySession, SESSION_COOKIE, authEnabled } from "@/lib/auth";
+
+// Writes a Garmin calendar entry at request time.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * POST /api/routines/[hevyId]/schedule
+ * Body: { date: "YYYY-MM-DD" }
+ *
+ * Schedules the routine's already-synced Garmin workout onto a calendar date.
+ * The routine must have been synced first (so a garmin_workout_id exists). Same
+ * authorization gate as the sync route.
+ */
+async function isAuthorized(request: Request): Promise<boolean> {
+  const cronSecret = process.env.CRON_SECRET;
+  if (cronSecret) {
+    const auth = request.headers.get("authorization") ?? "";
+    const m = auth.match(/^Bearer\s+(.+)$/i);
+    if (m && m[1] === cronSecret) return true;
+  }
+  if (!authEnabled()) return true;
+  const store = await cookies();
+  return verifySession(store.get(SESSION_COOKIE)?.value ?? null);
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ hevyId: string }> },
+) {
+  const { hevyId } = await params;
+  if (!hevyId) {
+    return NextResponse.json({ error: "hevyId is required." }, { status: 400 });
+  }
+
+  let body: { date?: unknown } = {};
+  try {
+    const text = await request.text();
+    if (text) body = JSON.parse(text);
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+  const date = typeof body.date === "string" ? body.date.trim() : "";
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return NextResponse.json({ error: "A date (YYYY-MM-DD) is required." }, { status: 400 });
+  }
+
+  if (!(await isAuthorized(request))) {
+    return NextResponse.json(
+      { error: "Unauthorized: scheduling requires a session or CRON_SECRET." },
+      { status: 401 },
+    );
+  }
+
+  let sql: ReturnType<typeof getDb>;
+  try {
+    sql = getDb();
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `DB unavailable: ${error}` }, { status: 503 });
+  }
+
+  try {
+    const rows = (await sql`
+      SELECT garmin_workout_id FROM synced_routines WHERE hevy_routine_id = ${hevyId} LIMIT 1
+    `) as Array<{ garmin_workout_id: string | null }>;
+    const garminWorkoutId = rows[0]?.garmin_workout_id;
+    if (!garminWorkoutId) {
+      return NextResponse.json(
+        { error: "Sync this routine to Garmin before scheduling it." },
+        { status: 409 },
+      );
+    }
+    const result = await scheduleRoutine(hevyId, garminWorkoutId, date, sql);
+    const code = result.status === "error" ? 502 : 200;
+    return NextResponse.json({ ok: result.status === "scheduled", ...result }, { status: code });
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error }, { status: 502 });
+  }
+}

--- a/web/app/api/routines/[hevyId]/sync/route.test.ts
+++ b/web/app/api/routines/[hevyId]/sync/route.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const fetchHevyRoutines = vi.fn();
+vi.mock("@/lib/hevy-routines", () => ({ fetchHevyRoutines: (...a: unknown[]) => fetchHevyRoutines(...a) }));
+const syncRoutine = vi.fn();
+vi.mock("@/lib/garmin-routine-sync", () => ({ syncRoutine: (...a: unknown[]) => syncRoutine(...a) }));
+vi.mock("@/lib/db", () => ({ getDb: () => ({}) }));
+
+const authEnabled = vi.fn();
+const verifySession = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  authEnabled: (...a: unknown[]) => authEnabled(...a),
+  verifySession: (...a: unknown[]) => verifySession(...a),
+  SESSION_COOKIE: "h2g_session",
+}));
+const cookieGet = vi.fn();
+vi.mock("next/headers", () => ({ cookies: async () => ({ get: (...a: unknown[]) => cookieGet(...a) }) }));
+
+import { POST } from "./route";
+
+const params = (id: string) => ({ params: Promise.resolve({ hevyId: id }) });
+const req = () => new Request("http://h/api/routines/r1/sync", { method: "POST" });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.CRON_SECRET;
+  authEnabled.mockReturnValue(false); // authorized on a passwordless deploy
+  verifySession.mockReturnValue(false);
+  cookieGet.mockReturnValue(undefined);
+  fetchHevyRoutines.mockResolvedValue([{ id: "r1", title: "Push", exercises: [] }]);
+  syncRoutine.mockResolvedValue({ status: "synced", garminWorkoutId: 555, error: null });
+});
+
+describe("POST /api/routines/[id]/sync", () => {
+  it("authorized (no password) → syncs the routine", async () => {
+    const res = await POST(req(), params("r1"));
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.garminWorkoutId).toBe(555);
+    expect(syncRoutine).toHaveBeenCalledTimes(1);
+  });
+
+  it("password set + no session → 401, no sync", async () => {
+    authEnabled.mockReturnValue(true);
+    const res = await POST(req(), params("r1"));
+    expect(res.status).toBe(401);
+    expect(syncRoutine).not.toHaveBeenCalled();
+  });
+
+  it("routine not on Hevy → 404", async () => {
+    fetchHevyRoutines.mockResolvedValue([{ id: "other" }]);
+    const res = await POST(req(), params("r1"));
+    expect(res.status).toBe(404);
+    expect(syncRoutine).not.toHaveBeenCalled();
+  });
+
+  it("syncRoutine error → 502", async () => {
+    syncRoutine.mockResolvedValue({ status: "error", garminWorkoutId: null, error: "Garmin rejected" });
+    const res = await POST(req(), params("r1"));
+    expect(res.status).toBe(502);
+  });
+});

--- a/web/app/api/routines/[hevyId]/sync/route.ts
+++ b/web/app/api/routines/[hevyId]/sync/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { fetchHevyRoutines } from "@/lib/hevy-routines";
+import { syncRoutine } from "@/lib/garmin-routine-sync";
+import { getDb } from "@/lib/db";
+import { verifySession, SESSION_COOKIE, authEnabled } from "@/lib/auth";
+
+// Fetches Hevy + writes a Garmin planned workout at request time.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * POST /api/routines/[hevyId]/sync
+ *
+ * Fetches the named Hevy routine and creates (or refreshes) a Garmin planned
+ * workout from it. Because it WRITES to Garmin, it requires authorization when a
+ * dashboard password is configured (session or Bearer CRON_SECRET); on a
+ * self-hosted deploy without a password it runs directly.
+ */
+async function isAuthorized(request: Request): Promise<boolean> {
+  const cronSecret = process.env.CRON_SECRET;
+  if (cronSecret) {
+    const auth = request.headers.get("authorization") ?? "";
+    const m = auth.match(/^Bearer\s+(.+)$/i);
+    if (m && m[1] === cronSecret) return true;
+  }
+  if (!authEnabled()) return true;
+  const store = await cookies();
+  return verifySession(store.get(SESSION_COOKIE)?.value ?? null);
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ hevyId: string }> },
+) {
+  const { hevyId } = await params;
+  if (!hevyId) {
+    return NextResponse.json({ error: "hevyId is required." }, { status: 400 });
+  }
+  if (!(await isAuthorized(request))) {
+    return NextResponse.json(
+      { error: "Unauthorized: syncing a routine requires a session or CRON_SECRET." },
+      { status: 401 },
+    );
+  }
+
+  let sql: ReturnType<typeof getDb>;
+  try {
+    sql = getDb();
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `DB unavailable: ${error}` }, { status: 503 });
+  }
+
+  try {
+    const routines = await fetchHevyRoutines();
+    const routine = routines.find((r) => String(r.id) === hevyId);
+    if (!routine) {
+      return NextResponse.json({ error: "Routine not found on Hevy." }, { status: 404 });
+    }
+    const result = await syncRoutine(routine, sql);
+    const code = result.status === "error" ? 502 : 200;
+    return NextResponse.json({ ok: result.status === "synced", ...result }, { status: code });
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error }, { status: 502 });
+  }
+}

--- a/web/app/routines/page.tsx
+++ b/web/app/routines/page.tsx
@@ -1,4 +1,5 @@
 import { getDb } from "@/lib/db";
+import { HevyRoutinesList } from "@/components/hevy-routines-list";
 
 // Queries the live hevy2garmin Postgres per request — never at build time.
 export const dynamic = "force-dynamic";
@@ -132,9 +133,11 @@ export default async function RoutinesPage() {
       </header>
 
       <div className="mb-6 rounded-lg border border-border bg-surface p-4 text-sm text-text-muted">
-        Routines are synced by the pipeline. Scheduling and one-click routine
-        sync from the web come in a later phase.
+        Sync a Hevy routine to Garmin as a planned workout and add it to a
+        calendar date. Synced routines are listed below.
       </div>
+
+      {data.dbConfigured && <HevyRoutinesList />}
 
       {!data.dbConfigured && (
         <div className="mb-6 rounded-lg border border-warm/40 bg-warm/10 p-4 text-sm text-warm">

--- a/web/components/hevy-routines-list.tsx
+++ b/web/components/hevy-routines-list.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+interface Routine {
+  id: string;
+  title: string;
+  exercises: number;
+}
+
+const btn =
+  "rounded-lg border border-border px-2.5 py-1 text-xs font-medium text-text-secondary transition-colors hover:bg-surface-active disabled:opacity-50";
+
+function RoutineRow({ r }: { r: Routine }) {
+  const router = useRouter();
+  const [busy, setBusy] = useState<null | "sync" | "schedule">(null);
+  const [msg, setMsg] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [synced, setSynced] = useState(false);
+  const [showSchedule, setShowSchedule] = useState(false);
+  const [date, setDate] = useState("");
+
+  async function sync() {
+    setBusy("sync");
+    setError(null);
+    setMsg(null);
+    try {
+      const res = await fetch(`/api/routines/${encodeURIComponent(r.id)}/sync`, { method: "POST" });
+      const d = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      if (!res.ok || !d.ok) {
+        setError(d.error ?? `Request failed (${res.status}).`);
+        return;
+      }
+      setSynced(true);
+      setMsg("Synced to Garmin as a planned workout.");
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function schedule() {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      setError("Pick a date first.");
+      return;
+    }
+    setBusy("schedule");
+    setError(null);
+    setMsg(null);
+    try {
+      const res = await fetch(`/api/routines/${encodeURIComponent(r.id)}/schedule`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ date }),
+      });
+      const d = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      if (!res.ok || !d.ok) {
+        setError(d.error ?? `Request failed (${res.status}).`);
+        return;
+      }
+      setShowSchedule(false);
+      setMsg(`Scheduled for ${date}.`);
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <li className="px-4 py-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="truncate text-sm font-medium text-text">{r.title}</div>
+          <div className="mt-0.5 text-xs text-text-muted">
+            {r.exercises} exercise{r.exercises === 1 ? "" : "s"}
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <button type="button" onClick={sync} disabled={busy !== null} className={btn}>
+            {busy === "sync" ? "Syncing…" : synced ? "Re-sync" : "Sync to Garmin"}
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowSchedule((v) => !v)}
+            disabled={busy !== null}
+            className={btn}
+          >
+            {showSchedule ? "Cancel" : "Schedule"}
+          </button>
+        </div>
+      </div>
+      {showSchedule && (
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          <input
+            type="date"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            className="rounded-lg border border-border bg-surface px-3 py-1.5 text-xs text-text focus:border-teal focus:outline-none"
+          />
+          <button
+            type="button"
+            onClick={schedule}
+            disabled={busy !== null}
+            className="rounded-lg bg-teal/20 px-3 py-1.5 text-xs font-medium text-teal transition-colors hover:bg-teal/30 disabled:opacity-50"
+          >
+            {busy === "schedule" ? "Scheduling…" : "Add to calendar"}
+          </button>
+          <span className="text-xs text-text-muted">Sync the routine first if you haven&apos;t.</span>
+        </div>
+      )}
+      {msg && !error && <div className="mt-1.5 text-xs text-success">{msg}</div>}
+      {error && (
+        <div className="mt-1.5 text-xs text-danger" role="alert">
+          {error}
+        </div>
+      )}
+    </li>
+  );
+}
+
+/**
+ * Your Hevy routines, with per-routine "Sync to Garmin" (create a planned
+ * workout) and "Schedule" (add it to a calendar date). Fetches /api/hevy-routines
+ * (read-only) on mount; degrades quietly when Hevy is unreachable.
+ */
+export function HevyRoutinesList() {
+  const [phase, setPhase] = useState<"loading" | "ready">("loading");
+  const [routines, setRoutines] = useState<Routine[]>([]);
+  const [note, setNote] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    fetch("/api/hevy-routines")
+      .then((res) => res.json())
+      .then((d: { routines?: Routine[]; error?: string }) => {
+        if (!alive) return;
+        setRoutines(Array.isArray(d.routines) ? d.routines : []);
+        if (d.error) setNote(d.error);
+        setPhase("ready");
+      })
+      .catch((err) => {
+        if (!alive) return;
+        setNote(err instanceof Error ? err.message : String(err));
+        setPhase("ready");
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return (
+    <section className="mb-8">
+      <h2 className="mb-3 text-lg font-semibold text-text">Your Hevy routines</h2>
+      {phase === "loading" ? (
+        <div className="rounded-lg border border-border bg-surface p-6 text-center text-sm text-text-muted">
+          Loading routines from Hevy…
+        </div>
+      ) : routines.length === 0 ? (
+        <div className="rounded-lg border border-border bg-surface p-6 text-center text-sm text-text-muted">
+          {note ? `Couldn't load routines: ${note}` : "No routines found in Hevy."}
+        </div>
+      ) : (
+        <ul className="divide-y divide-border overflow-hidden rounded-xl border border-border bg-surface-elevated">
+          {routines.map((r) => (
+            <RoutineRow key={r.id} r={r} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/web/lib/garmin-exercise-strings.test.ts
+++ b/web/lib/garmin-exercise-strings.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { fitExerciseStrings, exerciseCategoryId } from "./garmin-exercise-strings";
+
+describe("fitExerciseStrings", () => {
+  it("maps a real (bench press, barbell) pair to the Garmin enum strings", () => {
+    const benchId = exerciseCategoryId("benchPress");
+    expect(benchId).not.toBeNull();
+    // subcategory 1 is barbellBenchPress in the FIT profile.
+    const [cat, name] = fitExerciseStrings(benchId as number, 1);
+    expect(cat).toBe("BENCH_PRESS");
+    expect(name).toBe("BARBELL_BENCH_PRESS");
+  });
+
+  it("returns UPPER_SNAKE for the category even when the subcategory is unknown", () => {
+    const squatId = exerciseCategoryId("squat");
+    expect(squatId).not.toBeNull();
+    const [cat, name] = fitExerciseStrings(squatId as number, 999999);
+    expect(cat).toBe("SQUAT");
+    expect(name).toBeNull();
+  });
+
+  it("an unknown category → [null, null]", () => {
+    expect(fitExerciseStrings(999999, 0)).toEqual([null, null]);
+  });
+});

--- a/web/lib/garmin-exercise-strings.ts
+++ b/web/lib/garmin-exercise-strings.ts
@@ -1,0 +1,50 @@
+/**
+ * Translate FIT numeric (category, subcategory) exercise ids into the Garmin
+ * workout-service enum STRINGS, e.g. (benchPress, 1) → ["BENCH_PRESS",
+ * "BARBELL_BENCH_PRESS"]. Ported from mapper.fit_exercise_strings, backed by
+ * @garmin/fitsdk's Profile enums (which ship camelCase names, converted here to
+ * the UPPER_SNAKE member names Garmin expects).
+ *
+ * Either element is null when the pair doesn't resolve (unknown category, a
+ * subcategory the SDK doesn't have), so callers fall back to a generic named
+ * step instead of sending an invalid enum.
+ */
+import { Profile } from "@garmin/fitsdk";
+
+type EnumMap = Record<number, string>;
+
+const types = (Profile as unknown as { types?: Record<string, unknown> }).types ?? {};
+
+/** camelCase → UPPER_SNAKE_CASE (the FIT enum member name). */
+function upperSnake(camel: string): string {
+  return camel
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
+    .toUpperCase();
+}
+
+export function fitExerciseStrings(
+  category: number,
+  subcategory: number,
+): [string | null, string | null] {
+  const catMap = types.exerciseCategory as EnumMap | undefined;
+  const catName = catMap?.[category];
+  if (!catName || catName === "unknown") return [null, null];
+  const categoryStr = upperSnake(catName);
+
+  const nameMap = types[`${catName}ExerciseName`] as EnumMap | undefined;
+  const subName = nameMap?.[subcategory];
+  const exerciseNameStr = subName && subName !== "unknown" ? upperSnake(subName) : null;
+
+  return [categoryStr, exerciseNameStr];
+}
+
+/** The numeric id for a named category (e.g. "benchPress" → its FIT value), or null. */
+export function exerciseCategoryId(name: string): number | null {
+  const catMap = types.exerciseCategory as EnumMap | undefined;
+  if (!catMap) return null;
+  for (const [k, v] of Object.entries(catMap)) {
+    if (v === name) return Number(k);
+  }
+  return null;
+}

--- a/web/lib/garmin-routine-sync.ts
+++ b/web/lib/garmin-routine-sync.ts
@@ -1,0 +1,94 @@
+/**
+ * Sync a Hevy routine to Garmin as a planned workout, and schedule it on a date.
+ * Ports the Garmin side of the Python routine sync:
+ *   - create_workout:  POST /workout-service/workout
+ *   - schedule_workout: POST /workout-service/schedule/{workoutId}
+ * Both are POSTs, so they use the GarminClient's `post`. Unschedule/delete are
+ * DELETE requests, which garmin-auth's client does not expose yet — those are
+ * left for a package update.
+ *
+ * Injectable Garmin client factory for tests. The reverse-engineered Garmin
+ * planned-workout payload is validated only against a real export (see
+ * garmin-workout); a live smoke-test confirms Garmin accepts it.
+ */
+import type { GarminClient } from "garmin-auth";
+import { getGarminClient } from "./garmin-upload";
+import { routineToGarminWorkout, type HevyRoutine, type WorkoutBuildOptions } from "./garmin-workout";
+import { getDb } from "./db";
+
+type Sql = ReturnType<typeof getDb>;
+
+interface Opts extends WorkoutBuildOptions {
+  garminClientFactory?: () => Promise<GarminClient>;
+}
+
+export interface RoutineSyncResult {
+  status: "synced" | "error";
+  garminWorkoutId: number | null;
+  error: string | null;
+}
+
+/** Create a Garmin planned workout from a Hevy routine and record it. */
+export async function syncRoutine(
+  routine: HevyRoutine,
+  sql: Sql = getDb(),
+  opts: Opts = {},
+): Promise<RoutineSyncResult> {
+  try {
+    const client = await (opts.garminClientFactory ?? (() => getGarminClient()))();
+    const payload = routineToGarminWorkout(routine, opts);
+    const res = await client.post<{ workoutId?: number }>("/workout-service/workout", payload);
+    const garminWorkoutId = res?.workoutId ?? null;
+    await sql`
+      INSERT INTO synced_routines (hevy_routine_id, garmin_workout_id, title, status, synced_at)
+      VALUES (
+        ${String(routine.id)},
+        ${garminWorkoutId != null ? String(garminWorkoutId) : null},
+        ${routine.title ?? routine.name ?? ""},
+        'success', NOW()
+      )
+      ON CONFLICT (hevy_routine_id) DO UPDATE SET
+        garmin_workout_id = EXCLUDED.garmin_workout_id,
+        title = EXCLUDED.title,
+        status = 'success',
+        synced_at = NOW()
+    `;
+    return { status: "synced", garminWorkoutId, error: null };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return { status: "error", garminWorkoutId: null, error };
+  }
+}
+
+export interface RoutineScheduleResult {
+  status: "scheduled" | "error";
+  scheduleId: string | null;
+  error: string | null;
+}
+
+/** Schedule a synced routine's Garmin workout onto a date and record it. */
+export async function scheduleRoutine(
+  hevyRoutineId: string,
+  garminWorkoutId: number | string,
+  date: string,
+  sql: Sql = getDb(),
+  opts: { garminClientFactory?: () => Promise<GarminClient> } = {},
+): Promise<RoutineScheduleResult> {
+  try {
+    const client = await (opts.garminClientFactory ?? (() => getGarminClient()))();
+    const res = await client.post<{ workoutScheduleId?: number }>(
+      `/workout-service/schedule/${garminWorkoutId}`,
+      { date },
+    );
+    const scheduleId = res?.workoutScheduleId != null ? String(res.workoutScheduleId) : String(Date.now());
+    await sql`
+      INSERT INTO routine_schedules (hevy_routine_id, schedule_id, scheduled_date)
+      VALUES (${hevyRoutineId}, ${scheduleId}, ${date})
+      ON CONFLICT (hevy_routine_id, schedule_id) DO NOTHING
+    `;
+    return { status: "scheduled", scheduleId, error: null };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return { status: "error", scheduleId: null, error };
+  }
+}

--- a/web/lib/garmin-workout.test.ts
+++ b/web/lib/garmin-workout.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { routineToGarminWorkout, ROUTINE_DESC_MARKER } from "./garmin-workout";
+
+const routine = {
+  id: "r1",
+  title: "Push Day",
+  notes: "chest + tris",
+  exercises: [
+    {
+      title: "Bench Press (Barbell)",
+      rest_seconds: 90,
+      sets: [
+        { type: "warmup", reps: 10, weight_kg: 40 },
+        { type: "normal", reps: 5, weight_kg: 80 },
+        { type: "normal", reps: 5, weight_kg: 80 },
+      ],
+    },
+  ],
+};
+
+describe("routineToGarminWorkout", () => {
+  it("builds a strength workout with one step per set + rest between sets", () => {
+    const w = routineToGarminWorkout(routine);
+    expect(w.workoutName).toBe("Push Day");
+    expect((w.sportType as { sportTypeKey: string }).sportTypeKey).toBe("strength_training");
+    const steps = (w.workoutSegments as Array<{ workoutSteps: Array<Record<string, unknown>> }>)[0]
+      .workoutSteps;
+    // 3 sets → a rest between each consecutive pair (2 rests), not after the last:
+    // warmup, rest, interval, rest, interval = 5 steps.
+    expect(steps.length).toBe(5);
+    expect(steps[0].stepType).toMatchObject({ stepTypeKey: "warmup" });
+    expect(steps[1].stepType).toMatchObject({ stepTypeKey: "rest" });
+    expect(steps[2].stepType).toMatchObject({ stepTypeKey: "interval" });
+    expect(steps[3].stepType).toMatchObject({ stepTypeKey: "rest" });
+    expect(steps[4].stepType).toMatchObject({ stepTypeKey: "interval" });
+    // working set: weight in kg, reps end-condition
+    expect(steps[2]).toMatchObject({ weightValue: 80, endConditionValue: 5 });
+    expect((steps[2].weightUnit as { unitKey: string }).unitKey).toBe("kilogram");
+  });
+
+  it("keeps the provenance marker in the description and converts to pounds when asked", () => {
+    const w = routineToGarminWorkout(routine, { weightUnit: "pound" });
+    expect(String(w.description)).toContain(ROUTINE_DESC_MARKER);
+    const steps = (w.workoutSegments as Array<{ workoutSteps: Array<Record<string, unknown>> }>)[0]
+      .workoutSteps;
+    // 80 kg → ~176.37 lb (steps[2] is the first working interval)
+    expect(steps[2].weightValue).toBeCloseTo(176.37, 1);
+    expect((steps[2].weightUnit as { unitKey: string }).unitKey).toBe("pound");
+  });
+
+  it("no rest_seconds → no rest steps", () => {
+    const noRest = { ...routine, exercises: [{ ...routine.exercises[0], rest_seconds: null }] };
+    const w = routineToGarminWorkout(noRest);
+    const steps = (w.workoutSegments as Array<{ workoutSteps: Array<Record<string, unknown>> }>)[0]
+      .workoutSteps;
+    expect(steps.length).toBe(3); // 3 sets, no rest
+    expect(steps.every((s) => (s.stepType as { stepTypeKey: string }).stepTypeKey !== "rest")).toBe(true);
+  });
+});

--- a/web/lib/garmin-workout.ts
+++ b/web/lib/garmin-workout.ts
@@ -1,0 +1,147 @@
+/**
+ * Build a Garmin Connect planned-workout payload from a Hevy routine — the body
+ * for POST /workout-service/workout. A faithful port of routine.py
+ * (routine_to_garmin_workout): one flat interval step per set, a timed rest step
+ * between consecutive sets, warmup vs. working step types, per-set weights in kg
+ * or lb, and the provenance marker in the description. The numeric enum ids were
+ * reverse-engineered + validated against a real Garmin export in the Python.
+ */
+import { lookupExercise } from "hevy2garmin";
+import { fitExerciseStrings } from "./garmin-exercise-strings";
+
+const SPORT_TYPE_STRENGTH = { sportTypeId: 5, sportTypeKey: "strength_training" };
+const STEP_TYPE_WARMUP = { stepTypeId: 1, stepTypeKey: "warmup" };
+const STEP_TYPE_INTERVAL = { stepTypeId: 3, stepTypeKey: "interval" };
+const STEP_TYPE_REST = { stepTypeId: 5, stepTypeKey: "rest" };
+const END_REPS = { conditionTypeId: 10, conditionTypeKey: "reps" };
+const END_TIME = { conditionTypeId: 2, conditionTypeKey: "time" };
+const END_LAP_BUTTON = { conditionTypeId: 1, conditionTypeKey: "lap.button" };
+const WEIGHT_UNIT_KG = { unitId: 8, unitKey: "kilogram" };
+const WEIGHT_UNIT_LB = { unitId: 7, unitKey: "pound" };
+const KG_TO_LB = 2.2046226218;
+
+export const ROUTINE_DESC_MARKER = "— synced from Hevy by hevy2garmin";
+
+export interface HevySet {
+  type?: string | null;
+  reps?: number | null;
+  duration_seconds?: number | null;
+  weight_kg?: number | null;
+}
+export interface HevyExercise {
+  title?: string | null;
+  name?: string | null;
+  exercise_template_id?: string | null;
+  rest_seconds?: number | null;
+  sets?: HevySet[];
+}
+export interface HevyRoutine {
+  id?: string;
+  title?: string | null;
+  name?: string | null;
+  notes?: string | null;
+  exercises?: HevyExercise[];
+}
+
+type Step = Record<string, unknown>;
+
+function weightFields(set: HevySet, weightUnit: string): Step {
+  const kg = set.weight_kg;
+  if (kg == null) return {};
+  if (weightUnit === "pound") {
+    return { weightValue: Math.round(kg * KG_TO_LB * 100) / 100, weightUnit: WEIGHT_UNIT_LB };
+  }
+  return { weightValue: kg, weightUnit: WEIGHT_UNIT_KG };
+}
+
+function buildStep(
+  order: number,
+  set: HevySet,
+  title: string,
+  categoryStr: string | null,
+  exerciseNameStr: string | null,
+  weightUnit: string,
+): Step {
+  const isWarmup = (set.type ?? "").toLowerCase() === "warmup";
+  const step: Step = {
+    type: "ExecutableStepDTO",
+    stepOrder: order,
+    stepType: isWarmup ? STEP_TYPE_WARMUP : STEP_TYPE_INTERVAL,
+  };
+  if (set.reps != null) {
+    step.endCondition = END_REPS;
+    step.endConditionValue = Number(set.reps);
+  } else if (set.duration_seconds != null) {
+    step.endCondition = END_TIME;
+    step.endConditionValue = Number(set.duration_seconds);
+  } else {
+    step.endCondition = END_LAP_BUTTON;
+  }
+  if (categoryStr != null) step.category = categoryStr;
+  if (exerciseNameStr != null) step.exerciseName = exerciseNameStr;
+  if (exerciseNameStr == null) step.stepName = title;
+  Object.assign(step, weightFields(set, weightUnit));
+  return step;
+}
+
+function restStep(order: number, restSeconds: number): Step {
+  return {
+    type: "ExecutableStepDTO",
+    stepOrder: order,
+    stepType: STEP_TYPE_REST,
+    endCondition: END_TIME,
+    endConditionValue: Number(restSeconds),
+  };
+}
+
+export interface WorkoutBuildOptions {
+  weightUnit?: "kilogram" | "pound";
+  defaultRestSeconds?: number | null;
+}
+
+/** Convert a Hevy routine into a Garmin /workout-service/workout body. */
+export function routineToGarminWorkout(
+  routine: HevyRoutine,
+  opts: WorkoutBuildOptions = {},
+): Record<string, unknown> {
+  const weightUnit = opts.weightUnit ?? "kilogram";
+  const defaultRestSeconds = opts.defaultRestSeconds ?? null;
+  const exercises = routine.exercises ?? [];
+  const steps: Step[] = [];
+  let order = 1;
+
+  for (const exercise of exercises) {
+    const title = exercise.title || exercise.name || "Exercise";
+    const { category, subcategory } = lookupExercise(title, exercise.exercise_template_id ?? null);
+    const [categoryStr, exerciseNameStr] = fitExerciseStrings(category, subcategory);
+
+    const restSeconds = exercise.rest_seconds ?? defaultRestSeconds;
+    const sets = exercise.sets ?? [];
+    for (let i = 0; i < sets.length; i++) {
+      steps.push(buildStep(order, sets[i], title, categoryStr, exerciseNameStr, weightUnit));
+      order += 1;
+      // Rest goes BETWEEN sets of the same exercise, not after the last one.
+      if (restSeconds && i < sets.length - 1) {
+        steps.push(restStep(order, restSeconds));
+        order += 1;
+      }
+    }
+  }
+
+  const name = routine.title || routine.name || "Hevy Routine";
+  const marker = `\n${ROUTINE_DESC_MARKER}`;
+  const notes = (routine.notes || "Synced from Hevy").trim().slice(0, 1024 - marker.length);
+
+  return {
+    workoutName: name,
+    description: `${notes}${marker}`,
+    sportType: SPORT_TYPE_STRENGTH,
+    workoutSegments: [
+      {
+        segmentOrder: 1,
+        sportType: SPORT_TYPE_STRENGTH,
+        workoutSteps: steps,
+      },
+    ],
+  };
+}

--- a/web/lib/hevy-routines.ts
+++ b/web/lib/hevy-routines.ts
@@ -1,0 +1,34 @@
+/**
+ * Fetch the user's Hevy routines. The TS HevyClient has no getRoutines, so this
+ * calls the Hevy REST API directly (GET /v1/routines) with the resolved key.
+ * READ-ONLY.
+ */
+import { resolveHevyKey } from "./hevy-sync";
+import type { HevyRoutine } from "./garmin-workout";
+
+const HEVY_BASE = "https://api.hevyapp.com/v1";
+const MAX_PAGES = 5;
+
+export async function fetchHevyRoutines(
+  key?: string | null,
+  opts: { fetchImpl?: typeof fetch } = {},
+): Promise<HevyRoutine[]> {
+  const apiKey = await resolveHevyKey(key);
+  if (!apiKey) throw new Error("No Hevy API key available.");
+  const f = opts.fetchImpl ?? fetch;
+  const routines: HevyRoutine[] = [];
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    const res = await f(`${HEVY_BASE}/routines?page=${page}&pageSize=10`, {
+      headers: { "api-key": apiKey, accept: "application/json" },
+    });
+    if (!res.ok) {
+      if (page === 1) throw new Error(`Hevy routines request failed (${res.status}).`);
+      break;
+    }
+    const data = (await res.json()) as { routines?: HevyRoutine[]; page_count?: number };
+    const batch = Array.isArray(data.routines) ? data.routines : [];
+    routines.push(...batch);
+    if (batch.length === 0 || (typeof data.page_count === "number" && page >= data.page_count)) break;
+  }
+  return routines;
+}

--- a/web/lib/hevy-sync.ts
+++ b/web/lib/hevy-sync.ts
@@ -38,6 +38,13 @@ async function keyFromDb(): Promise<string | null> {
   return typeof apiKey === "string" && apiKey.trim() ? apiKey.trim() : null;
 }
 
+/** Resolve the Hevy API key (arg → env → DB), or null. Exposed for raw calls. */
+export async function resolveHevyKey(key?: string | null): Promise<string | null> {
+  const explicit = key?.trim();
+  const fromEnv = process.env.HEVY_API_KEY?.trim();
+  return explicit || fromEnv || (await keyFromDb());
+}
+
 /**
  * Build a HevyClient. Resolves the API key from the argument, then the
  * HEVY_API_KEY env var, then the platform_credentials table. Throws when no key

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "hevy2garmin-web",
       "version": "0.1.0",
       "dependencies": {
+        "@garmin/fitsdk": "^21.212.0",
         "garmin-auth": "^0.4.1",
         "hevy2garmin": "^0.1.4",
         "next": "^16.1.0",
@@ -2722,6 +2723,72 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.3",

--- a/web/package.json
+++ b/web/package.json
@@ -17,6 +17,7 @@
     "e2e:mobile": "playwright test --project=mobile"
   },
   "dependencies": {
+    "@garmin/fitsdk": "^21.212.0",
     "garmin-auth": "^0.4.1",
     "hevy2garmin": "^0.1.4",
     "next": "^16.1.0",


### PR DESCRIPTION
Closes #397. Part of the modern Next.js web rebuild (soma#385). **The last page feature** — mock-verified Garmin.

Ports the Python routine sync: convert a Hevy routine into a Garmin `/workout-service/workout` planned workout and schedule it on a calendar date.

- **`lib/garmin-exercise-strings`** — `fitExerciseStrings(category, subcategory)` → the Garmin enum strings (UPPER_SNAKE), derived from `@garmin/fitsdk`'s Profile (added as a direct dep). **Golden-tested against real fitsdk data**: `(benchPress, 1)` → `["BENCH_PRESS", "BARBELL_BENCH_PRESS"]`.
- **`lib/garmin-workout`** — `routineToGarminWorkout` (faithful port of routine.py): one interval step per set, timed rest between consecutive sets, warmup/working types, kg/lb weights, provenance marker.
- **`lib/hevy-routines`** — raw `GET /v1/routines` (HevyClient has no getRoutines). **`lib/garmin-routine-sync`** — `syncRoutine` (POST `/workout-service/workout`, records `synced_routines`) + `scheduleRoutine` (POST `/workout-service/schedule/{id}`, records `routine_schedules`).
- **Routes**: `GET /api/hevy-routines`, `POST /api/routines/[id]/sync`, `POST /api/routines/[id]/schedule` (both auth-gated).
- **UI**: a "Your Hevy routines" section on /routines with per-routine **Sync to Garmin** + **Schedule** (date picker).

**Known limit:** unschedule/delete are DELETE requests, which `garmin-auth`'s client doesn't expose yet — left for a package update.

### Verified — no real Hevy/Garmin touched
- **16 new tests** (107 web tests total, green): the exercise-string golden test (real fitsdk), the workout-builder structure/rest/weights/marker, and the 3 routes' gating (auth 401, 404 unknown routine, 400 bad date, 409 not-yet-synced, 502 engine error, graceful Hevy error).
- **Playwright** (all routes mocked via a `fetch` patch across a client nav): the "Your Hevy routines" list renders; Sync → "Synced to Garmin as a planned workout." (button → "Re-sync"); Schedule → date → "Scheduled for 2026-09-05." DB counts unchanged (0).
- tsc + `next build` green (fitsdk dep resolves).

The reverse-engineered Garmin planned-workout payload needs your live smoke-test to confirm Garmin accepts it (per the mock-verified approach).
