### PR TITLE
feat(web): unschedule a routine's calendar entry

### DIFF
--- a/web/app/api/routines/[hevyId]/unschedule/route.test.ts
+++ b/web/app/api/routines/[hevyId]/unschedule/route.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const unscheduleRoutine = vi.fn();
+vi.mock("@/lib/garmin-routine-sync", () => ({
+  unscheduleRoutine: (...a: unknown[]) => unscheduleRoutine(...a),
+}));
+vi.mock("@/lib/db", () => ({ getDb: () => ({}) }));
+
+const authEnabled = vi.fn();
+const verifySession = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  authEnabled: (...a: unknown[]) => authEnabled(...a),
+  verifySession: (...a: unknown[]) => verifySession(...a),
+  SESSION_COOKIE: "h2g_session",
+}));
+const cookieGet = vi.fn();
+vi.mock("next/headers", () => ({ cookies: async () => ({ get: (...a: unknown[]) => cookieGet(...a) }) }));
+
+import { POST } from "./route";
+
+const params = (id: string) => ({ params: Promise.resolve({ hevyId: id }) });
+function req(body: unknown): Request {
+  return new Request("http://h/api/routines/r1/unschedule", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.CRON_SECRET;
+  authEnabled.mockReturnValue(false);
+  verifySession.mockReturnValue(false);
+  cookieGet.mockReturnValue(undefined);
+  unscheduleRoutine.mockResolvedValue({ status: "unscheduled", error: null });
+});
+
+describe("POST /api/routines/[id]/unschedule", () => {
+  it("missing scheduleId → 400", async () => {
+    const res = await POST(req({}), params("r1"));
+    expect(res.status).toBe(400);
+    expect(unscheduleRoutine).not.toHaveBeenCalled();
+  });
+
+  it("authorized (no password) → unschedules", async () => {
+    const res = await POST(req({ scheduleId: "9" }), params("r1"));
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(unscheduleRoutine).toHaveBeenCalledWith("r1", "9", expect.anything());
+  });
+
+  it("password set + no session → 401", async () => {
+    authEnabled.mockReturnValue(true);
+    const res = await POST(req({ scheduleId: "9" }), params("r1"));
+    expect(res.status).toBe(401);
+    expect(unscheduleRoutine).not.toHaveBeenCalled();
+  });
+
+  it("engine error → 502", async () => {
+    unscheduleRoutine.mockResolvedValue({ status: "error", error: "Garmin DELETE → 500" });
+    const res = await POST(req({ scheduleId: "9" }), params("r1"));
+    expect(res.status).toBe(502);
+  });
+});

--- a/web/app/api/routines/[hevyId]/unschedule/route.ts
+++ b/web/app/api/routines/[hevyId]/unschedule/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { unscheduleRoutine } from "@/lib/garmin-routine-sync";
+import { getDb } from "@/lib/db";
+import { verifySession, SESSION_COOKIE, authEnabled } from "@/lib/auth";
+
+// Removes a Garmin calendar entry at request time.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * POST /api/routines/[hevyId]/unschedule
+ * Body: { scheduleId: "<workoutScheduleId>" }
+ *
+ * Removes the Garmin calendar entry and the local routine_schedules row. Same
+ * authorization gate as sync/schedule.
+ */
+async function isAuthorized(request: Request): Promise<boolean> {
+  const cronSecret = process.env.CRON_SECRET;
+  if (cronSecret) {
+    const auth = request.headers.get("authorization") ?? "";
+    const m = auth.match(/^Bearer\s+(.+)$/i);
+    if (m && m[1] === cronSecret) return true;
+  }
+  if (!authEnabled()) return true;
+  const store = await cookies();
+  return verifySession(store.get(SESSION_COOKIE)?.value ?? null);
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ hevyId: string }> },
+) {
+  const { hevyId } = await params;
+  if (!hevyId) {
+    return NextResponse.json({ error: "hevyId is required." }, { status: 400 });
+  }
+
+  let body: { scheduleId?: unknown } = {};
+  try {
+    const text = await request.text();
+    if (text) body = JSON.parse(text);
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+  const scheduleId = typeof body.scheduleId === "string" ? body.scheduleId.trim() : "";
+  if (!scheduleId) {
+    return NextResponse.json({ error: "A scheduleId is required." }, { status: 400 });
+  }
+
+  if (!(await isAuthorized(request))) {
+    return NextResponse.json(
+      { error: "Unauthorized: unscheduling requires a session or CRON_SECRET." },
+      { status: 401 },
+    );
+  }
+
+  let sql: ReturnType<typeof getDb>;
+  try {
+    sql = getDb();
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error: `DB unavailable: ${error}` }, { status: 503 });
+  }
+
+  try {
+    const result = await unscheduleRoutine(hevyId, scheduleId, sql);
+    const code = result.status === "error" ? 502 : 200;
+    return NextResponse.json({ ok: result.status === "unscheduled", ...result }, { status: code });
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ error }, { status: 502 });
+  }
+}

--- a/web/app/routines/page.tsx
+++ b/web/app/routines/page.tsx
@@ -1,5 +1,6 @@
 import { getDb } from "@/lib/db";
 import { HevyRoutinesList } from "@/components/hevy-routines-list";
+import { RoutineSchedules } from "@/components/routine-schedules";
 
 // Queries the live hevy2garmin Postgres per request — never at build time.
 export const dynamic = "force-dynamic";
@@ -11,6 +12,7 @@ interface RoutineRow {
   garmin_workout_id: string | null;
   scheduled_date: string | null;
   synced_at: string | null;
+  schedules: Array<{ scheduleId: string; date: string }>;
   schedule_count: number;
 }
 
@@ -32,7 +34,7 @@ async function loadRoutines(): Promise<RoutinesData> {
     return EMPTY;
   }
 
-  const [rows, scheduleCounts] = await Promise.all([
+  const [rows, scheduleEntries] = await Promise.all([
     sql`
       SELECT hevy_routine_id, title, COALESCE(status, 'success') AS status,
              garmin_workout_id, scheduled_date, synced_at
@@ -51,13 +53,20 @@ async function loadRoutines(): Promise<RoutinesData> {
         }>,
     ),
     sql`
-      SELECT hevy_routine_id, COUNT(*)::int AS n
+      SELECT hevy_routine_id, schedule_id, scheduled_date
       FROM routine_schedules
-      GROUP BY hevy_routine_id
-    `.catch(() => [] as Array<{ hevy_routine_id: string; n: number }>),
+      ORDER BY scheduled_date ASC
+    `.catch(
+      () => [] as Array<{ hevy_routine_id: string; schedule_id: string; scheduled_date: string | null }>,
+    ),
   ]);
 
-  const counts = new Map(scheduleCounts.map((c) => [c.hevy_routine_id, Number(c.n)]));
+  const schedules = new Map<string, Array<{ scheduleId: string; date: string }>>();
+  for (const e of scheduleEntries) {
+    const list = schedules.get(e.hevy_routine_id) ?? [];
+    list.push({ scheduleId: String(e.schedule_id), date: e.scheduled_date ?? "" });
+    schedules.set(e.hevy_routine_id, list);
+  }
 
   const mapped: RoutineRow[] = rows.map((r) => ({
     hevy_routine_id: r.hevy_routine_id,
@@ -66,7 +75,8 @@ async function loadRoutines(): Promise<RoutinesData> {
     garmin_workout_id: r.garmin_workout_id ?? null,
     scheduled_date: r.scheduled_date ?? null,
     synced_at: r.synced_at ?? null,
-    schedule_count: counts.get(r.hevy_routine_id) ?? 0,
+    schedules: schedules.get(r.hevy_routine_id) ?? [],
+    schedule_count: (schedules.get(r.hevy_routine_id) ?? []).length,
   }));
 
   return {
@@ -177,11 +187,6 @@ export default async function RoutinesPage() {
                 <tr key={r.hevy_routine_id}>
                   <td className="px-4 py-2 font-medium text-text">
                     {r.title || "Untitled routine"}
-                    {r.schedule_count > 0 && (
-                      <span className="ml-2 rounded-full bg-teal/15 px-2 py-0.5 text-xs font-medium text-teal">
-                        {r.schedule_count} scheduled
-                      </span>
-                    )}
                   </td>
                   <td className="px-4 py-2">
                     <StatusPill status={r.status} />
@@ -189,8 +194,8 @@ export default async function RoutinesPage() {
                   <td className="px-4 py-2 tabular-nums text-text-secondary">
                     {r.garmin_workout_id || "—"}
                   </td>
-                  <td className="whitespace-nowrap px-4 py-2 tabular-nums text-text-muted">
-                    {fmtDay(r.scheduled_date)}
+                  <td className="px-4 py-2">
+                    <RoutineSchedules hevyRoutineId={r.hevy_routine_id} entries={r.schedules} />
                   </td>
                   <td className="whitespace-nowrap px-4 py-2 tabular-nums text-text-muted">
                     {fmtDate(r.synced_at)}

--- a/web/components/routine-schedules.tsx
+++ b/web/components/routine-schedules.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+interface Entry {
+  scheduleId: string;
+  date: string;
+}
+
+/**
+ * The scheduled calendar dates for a synced routine, each with an unschedule
+ * (×) control that POSTs to /api/routines/[id]/unschedule (removes the Garmin
+ * calendar entry + the local record).
+ */
+export function RoutineSchedules({
+  hevyRoutineId,
+  entries,
+}: {
+  hevyRoutineId: string;
+  entries: Entry[];
+}) {
+  const router = useRouter();
+  const [items, setItems] = useState(entries);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function unschedule(scheduleId: string) {
+    setBusy(scheduleId);
+    setError(null);
+    try {
+      const res = await fetch(`/api/routines/${encodeURIComponent(hevyRoutineId)}/unschedule`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ scheduleId }),
+      });
+      const d = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      if (!res.ok || !d.ok) {
+        setError(d.error ?? `Request failed (${res.status}).`);
+        return;
+      }
+      setItems((x) => x.filter((e) => e.scheduleId !== scheduleId));
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  if (items.length === 0) {
+    return <span className="text-xs text-text-muted">—</span>;
+  }
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {items.map((e) => (
+        <span
+          key={e.scheduleId}
+          className="inline-flex items-center gap-1 rounded-full bg-teal/15 px-2 py-0.5 text-xs font-medium text-teal"
+        >
+          {e.date}
+          <button
+            type="button"
+            onClick={() => unschedule(e.scheduleId)}
+            disabled={busy !== null}
+            title="Unschedule"
+            className="leading-none text-teal/70 transition-colors hover:text-danger disabled:opacity-50"
+          >
+            ×
+          </button>
+        </span>
+      ))}
+      {error && (
+        <span className="text-xs text-danger" role="alert">
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/web/lib/garmin-delete.test.ts
+++ b/web/lib/garmin-delete.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from "vitest";
+import { garminDelete } from "./garmin-delete";
+import type { GarminClient } from "garmin-auth";
+
+const client = {
+  domain: "garmin.com",
+  di_token: "tok",
+  refreshDiToken: vi.fn(async () => {}),
+} as unknown as GarminClient;
+
+describe("garminDelete", () => {
+  it("DELETEs the connectapi URL with the Bearer token + native headers", async () => {
+    const fetchImpl = vi.fn(async (..._a: unknown[]) => new Response(null, { status: 204 }));
+    await garminDelete(client, "/workout-service/schedule/9", {
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const url = fetchImpl.mock.calls[0]?.[0] as string;
+    const init = fetchImpl.mock.calls[0]?.[1] as RequestInit;
+    expect(url).toBe("https://connectapi.garmin.com/workout-service/schedule/9");
+    expect(init.method).toBe("DELETE");
+    expect((init.headers as Record<string, string>).Authorization).toBe("Bearer tok");
+  });
+
+  it("retries once after a 401 (token refresh)", async () => {
+    const fetchImpl = vi
+      .fn<(...a: unknown[]) => Promise<Response>>()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+    (client.refreshDiToken as unknown as ReturnType<typeof vi.fn>).mockClear();
+    await garminDelete(client, "/x", { fetchImpl: fetchImpl as unknown as typeof fetch });
+    expect(client.refreshDiToken).toHaveBeenCalledTimes(1);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws on a non-ok response", async () => {
+    const fetchImpl = vi.fn(async (..._a: unknown[]) => new Response(null, { status: 500 }));
+    await expect(
+      garminDelete(client, "/x", { fetchImpl: fetchImpl as unknown as typeof fetch }),
+    ).rejects.toThrow(/500/);
+  });
+});

--- a/web/lib/garmin-delete.ts
+++ b/web/lib/garmin-delete.ts
@@ -1,0 +1,51 @@
+/**
+ * Authenticated Garmin connectapi DELETE.
+ *
+ * garmin-auth's GarminClient exposes GET (connectapi), POST and PUT but no
+ * DELETE, so this replicates the client's request — the connectapi base URL, the
+ * di_token Bearer, the native headers, and one 401 token-refresh retry — using
+ * only the client's PUBLIC members (di_token, domain, refreshDiToken). Replace
+ * with client.delete() once garmin-auth ships one. Injectable fetch for tests.
+ */
+import type { GarminClient } from "garmin-auth";
+import { NATIVE_API_USER_AGENT, NATIVE_X_GARMIN_USER_AGENT } from "garmin-auth";
+
+interface DeletableClient {
+  domain: string;
+  di_token: string | null;
+  refreshDiToken(): Promise<void>;
+}
+
+/** Mirrors garmin-auth's private nativeHeaders() + the connectapi auth header. */
+function headers(client: DeletableClient): Record<string, string> {
+  return {
+    Authorization: `Bearer ${client.di_token ?? ""}`,
+    Accept: "application/json",
+    "User-Agent": NATIVE_API_USER_AGENT,
+    "X-Garmin-User-Agent": NATIVE_X_GARMIN_USER_AGENT,
+    "X-Garmin-Paired-App-Version": "10861",
+    "X-Garmin-Client-Platform": "Android",
+    "X-App-Ver": "10861",
+    "X-Lang": "en",
+    "X-GCExperience": "GC5",
+    "Accept-Language": "en-US,en;q=0.9",
+  };
+}
+
+export async function garminDelete(
+  client: GarminClient,
+  path: string,
+  opts: { fetchImpl?: typeof fetch } = {},
+): Promise<void> {
+  const c = client as unknown as DeletableClient;
+  const url = `https://connectapi.${c.domain}${path}`;
+  const f = opts.fetchImpl ?? fetch;
+  let res = await f(url, { method: "DELETE", headers: headers(c) });
+  if (res.status === 401 && typeof c.refreshDiToken === "function") {
+    await c.refreshDiToken();
+    res = await f(url, { method: "DELETE", headers: headers(c) });
+  }
+  if (!res.ok) {
+    throw new Error(`Garmin DELETE ${path} → ${res.status}`);
+  }
+}

--- a/web/lib/garmin-routine-sync.ts
+++ b/web/lib/garmin-routine-sync.ts
@@ -13,6 +13,7 @@
  */
 import type { GarminClient } from "garmin-auth";
 import { getGarminClient } from "./garmin-upload";
+import { garminDelete } from "./garmin-delete";
 import { routineToGarminWorkout, type HevyRoutine, type WorkoutBuildOptions } from "./garmin-workout";
 import { getDb } from "./db";
 
@@ -90,5 +91,31 @@ export async function scheduleRoutine(
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);
     return { status: "error", scheduleId: null, error };
+  }
+}
+
+export interface RoutineUnscheduleResult {
+  status: "unscheduled" | "error";
+  error: string | null;
+}
+
+/** Remove a Garmin calendar entry (workoutScheduleId) and its local record. */
+export async function unscheduleRoutine(
+  hevyRoutineId: string,
+  scheduleId: string,
+  sql: Sql = getDb(),
+  opts: { garminClientFactory?: () => Promise<GarminClient> } = {},
+): Promise<RoutineUnscheduleResult> {
+  try {
+    const client = await (opts.garminClientFactory ?? (() => getGarminClient()))();
+    await garminDelete(client, `/workout-service/schedule/${scheduleId}`);
+    await sql`
+      DELETE FROM routine_schedules
+      WHERE hevy_routine_id = ${hevyRoutineId} AND schedule_id = ${scheduleId}
+    `;
+    return { status: "unscheduled", error: null };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return { status: "error", error };
   }
 }


### PR DESCRIPTION
Closes #399. Part of the modern Next.js web rebuild (soma#385). The last web-buildable parity gap.

Routine **schedule** (#398) worked; **unschedule** is a DELETE, and `garmin-auth`'s client exposes only GET/POST/PUT. This adds a faithful authenticated DELETE and wires unschedule end-to-end.

- **`lib/garmin-delete`** — `garminDelete(client, path)` replicates the client's request (connectapi base + `di_token` Bearer + native headers + one 401 token-refresh retry) using only the client's **public** `di_token`/`domain`/`refreshDiToken`. (Replace with `client.delete()` once `garmin-auth` ships one.)
- **`unscheduleRoutine`** — DELETE `/workout-service/schedule/{id}` + remove the `routine_schedules` row.
- **`POST /api/routines/[id]/unschedule`** (auth-gated).
- **UI** — the routines table's Scheduled column now lists each date as a chip with an unschedule (×) control.

### Verified — no real Garmin touched
- **7 new tests** (112 web tests total, green): `garminDelete` hits the connectapi DELETE URL with the Bearer, retries once on 401, throws on non-ok; the route gates (400 no scheduleId, 401 unauthorized, 502 engine error).
- **Playwright** (unschedule mocked, hevy-routines mocked): a seeded schedule renders as a `2026-09-10 ×` chip; clicking × removes it. Seeded rows cleaned up (DB back to 0).
- tsc + `next build` green.

The real Garmin DELETE (native-header replication) needs your live smoke-test.
