### PR TITLE
feat(web): Hevy webhook receiver (POST /api/cron/webhook)

### DIFF
--- a/web/app/api/cron/webhook/route.test.ts
+++ b/web/app/api/cron/webhook/route.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const syncOneWorkout = vi.fn();
+vi.mock("@/lib/sync-one", () => ({ syncOneWorkout: (...a: unknown[]) => syncOneWorkout(...a) }));
+vi.mock("@/lib/db", () => ({ getDb: () => ({}) }));
+
+import { POST } from "./route";
+
+function req(headers: Record<string, string> = {}): Request {
+  return new Request("http://h/api/cron/webhook", { method: "POST", headers });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.CRON_SECRET;
+  delete process.env.GITHUB_PAT;
+  delete process.env.GITHUB_REPO;
+});
+afterEach(() => vi.unstubAllGlobals());
+
+describe("POST /api/cron/webhook", () => {
+  it("CRON_SECRET unset → 503 (can't authenticate a webhook)", async () => {
+    const res = await POST(req({ authorization: "Bearer x" }));
+    expect(res.status).toBe(503);
+    expect(syncOneWorkout).not.toHaveBeenCalled();
+  });
+
+  it("wrong Bearer → 401", async () => {
+    process.env.CRON_SECRET = "s3cret";
+    const res = await POST(req({ authorization: "Bearer nope" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("correct Bearer + GITHUB_PAT/REPO → dispatches", async () => {
+    process.env.CRON_SECRET = "s3cret";
+    process.env.GITHUB_PAT = "pat";
+    process.env.GITHUB_REPO = "drkostas/hevy2garmin";
+    vi.stubGlobal("fetch", vi.fn(async (..._a: unknown[]) => new Response(null, { status: 204 })));
+    const res = await POST(req({ authorization: "Bearer s3cret" }));
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.mode).toBe("dispatch");
+    expect(syncOneWorkout).not.toHaveBeenCalled();
+  });
+
+  it("correct Bearer + no PAT → inline sync", async () => {
+    process.env.CRON_SECRET = "s3cret";
+    syncOneWorkout.mockResolvedValue({ status: "synced" });
+    const res = await POST(req({ authorization: "Bearer s3cret" }));
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.mode).toBe("inline");
+    expect(syncOneWorkout).toHaveBeenCalledWith(expect.anything(), { dryRun: false });
+  });
+});

--- a/web/app/api/cron/webhook/route.ts
+++ b/web/app/api/cron/webhook/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from "next/server";
+import { syncOneWorkout } from "@/lib/sync-one";
+import { getDb } from "@/lib/db";
+
+// Runs a sync at request time — never at build.
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * POST /api/cron/webhook — the Hevy webhook, fired when a workout is saved.
+ *
+ * Mirrors the Python /api/cron/webhook: it MUST be authenticated with a Bearer
+ * CRON_SECRET (Hevy is configured with that secret), and when CRON_SECRET is
+ * unset there is no way to authenticate a caller, so it refuses with 503. On a
+ * (serverless) accept it triggers a sync right away — handing off to the GitHub
+ * Action when GITHUB_PAT + GITHUB_REPO are set, else running the tested
+ * single-workout engine inline.
+ */
+async function triggerViaActions(pat: string, repo: string): Promise<boolean> {
+  const res = await fetch(`https://api.github.com/repos/${repo}/dispatches`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${pat}`,
+      Accept: "application/vnd.github+json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ event_type: "sync-trigger" }),
+  });
+  return res.ok;
+}
+
+export async function POST(request: Request) {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) {
+    return NextResponse.json(
+      { error: "Webhook not configured: CRON_SECRET is unset." },
+      { status: 503 },
+    );
+  }
+  const auth = request.headers.get("authorization") ?? "";
+  const m = auth.match(/^Bearer\s+(.+)$/i);
+  if (!m || m[1] !== secret) {
+    return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+  }
+
+  const pat = process.env.GITHUB_PAT;
+  const repo = process.env.GITHUB_REPO;
+  if (pat && repo) {
+    try {
+      const ok = await triggerViaActions(pat, repo);
+      return NextResponse.json({ ok, mode: "dispatch", triggered: ok }, { status: ok ? 200 : 502 });
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      return NextResponse.json({ ok: false, error }, { status: 502 });
+    }
+  }
+
+  let sql: ReturnType<typeof getDb>;
+  try {
+    sql = getDb();
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ ok: false, error: `DB unavailable: ${error}` }, { status: 503 });
+  }
+
+  try {
+    const result = await syncOneWorkout(sql, { dryRun: false });
+    return NextResponse.json({ ok: true, mode: "inline", status: result.status });
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ ok: false, error }, { status: 500 });
+  }
+}


### PR DESCRIPTION
Closes #401. Part of the modern Next.js web rebuild (soma#385).

Ports the Python `POST /api/cron/webhook` — the Hevy webhook, fired when a workout is saved.

It MUST be authenticated with a Bearer `CRON_SECRET` (Hevy is configured with that secret); when `CRON_SECRET` is unset there's no way to authenticate a caller, so it refuses with **503** (matching the Python). On an authenticated call it triggers a sync immediately — handing off to the GitHub Action when `GITHUB_PAT` + `GITHUB_REPO` are set (the serverless-safe path), else running the tested `syncOneWorkout` inline.

### Verified
- **4 route tests** (green): `CRON_SECRET` unset → 503; wrong Bearer → 401; correct Bearer + `GITHUB_PAT/REPO` → dispatch (engine not called); correct Bearer + no PAT → inline `syncOneWorkout`.
- tsc + `next build` green. Route-only. Never runs live vs staging (`CRON_SECRET` unset → 503).
