### PR TITLE
feat(web): Garmin in-web login via CF Worker, incl. 2FA (#403)

### DIFF
--- a/web/app/api/garmin-login-mfa/route.test.ts
+++ b/web/app/api/garmin-login-mfa/route.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * Tests for POST /api/garmin-login-mfa. The login Worker and the token store are
+ * mocked, so NO real Garmin SSO runs and no real credentials are ever used.
+ */
+
+const workerLoginMfa = vi.fn();
+vi.mock("@/lib/garmin-login-worker", async (orig) => {
+  const actual = (await orig()) as Record<string, unknown>;
+  return { ...actual, workerLoginMfa: (...a: unknown[]) => workerLoginMfa(...a) };
+});
+
+const save = vi.fn();
+vi.mock("garmin-auth", () => ({
+  DBTokenStore: class {
+    constructor(..._a: unknown[]) {}
+    save(...a: unknown[]) {
+      return save(...a);
+    }
+  },
+}));
+const resetGarminClient = vi.fn();
+vi.mock("@/lib/garmin-upload", () => ({
+  GARMIN_TOKEN_PLATFORM: "garmin_tokens",
+  resetGarminClient: () => resetGarminClient(),
+}));
+
+import { POST } from "./route";
+
+function req(body: unknown): Request {
+  return new Request("http://h/api/garmin-login-mfa", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.DATABASE_URL = "postgres://ci:ci@localhost:5432/ci";
+});
+
+describe("POST /api/garmin-login-mfa", () => {
+  it("400 when session_id or mfa_code missing", async () => {
+    const res = await POST(req({ session_id: "s1" }));
+    expect(res.status).toBe(400);
+    expect(workerLoginMfa).not.toHaveBeenCalled();
+  });
+
+  it("success → persists tokens and returns connected", async () => {
+    workerLoginMfa.mockResolvedValue({
+      status: "success",
+      di_token: "a",
+      di_refresh_token: "b",
+      di_client_id: "c",
+    });
+    const res = await POST(req({ session_id: "s1", mfa_code: "123456" }));
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.status).toBe("connected");
+    expect(workerLoginMfa).toHaveBeenCalledWith("s1", "123456");
+    expect(save).toHaveBeenCalledWith({ di_token: "a", di_refresh_token: "b", di_client_id: "c" });
+    expect(resetGarminClient).toHaveBeenCalled();
+  });
+
+  it("wrong code → error surfaces (502), no persistence", async () => {
+    workerLoginMfa.mockResolvedValue({ status: "error", message: "bad code" });
+    const res = await POST(req({ session_id: "s1", mfa_code: "000000" }));
+    expect(res.status).toBe(502);
+    expect((await res.json()).error).toBe("bad code");
+    expect(save).not.toHaveBeenCalled();
+  });
+});

--- a/web/app/api/garmin-login-mfa/route.ts
+++ b/web/app/api/garmin-login-mfa/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { workerLoginMfa } from "@/lib/garmin-login-worker";
+import { toResponse } from "@/app/api/garmin-login/route";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * POST /api/garmin-login-mfa
+ * Body: { session_id, mfa_code }
+ *
+ * Step 2 of the Garmin sign-in, used only when /api/garmin-login returned
+ * needs_mfa. Posts the verification code to the direct-login Cloudflare Worker,
+ * which completes the SSO and returns the DI tokens. Success persists them and
+ * responds { status: "connected" } exactly like step 1 (shared toResponse).
+ */
+export async function POST(request: Request) {
+  let body: { session_id?: unknown; mfa_code?: unknown } = {};
+  try {
+    const text = await request.text();
+    if (text) body = JSON.parse(text);
+  } catch {
+    return NextResponse.json({ status: "error", error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const sessionId = typeof body.session_id === "string" ? body.session_id.trim() : "";
+  const code = typeof body.mfa_code === "string" ? body.mfa_code.trim() : "";
+  if (!sessionId || !code) {
+    return NextResponse.json(
+      { status: "error", error: "A session and verification code are required." },
+      { status: 400 },
+    );
+  }
+
+  const result = await workerLoginMfa(sessionId, code);
+  return toResponse(process.env.DATABASE_URL, result);
+}

--- a/web/app/api/garmin-login/route.test.ts
+++ b/web/app/api/garmin-login/route.test.ts
@@ -1,26 +1,29 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 /**
- * Tests for POST /api/garmin-login. GarminAuth is mocked, so NO real Garmin SSO
- * runs and no real credentials are ever used.
+ * Tests for POST /api/garmin-login. The login Worker and the token store are
+ * mocked, so NO real Garmin SSO runs and no real credentials are ever used.
  */
 
-const loginMock = vi.fn();
+const workerLogin = vi.fn();
+vi.mock("@/lib/garmin-login-worker", async (orig) => {
+  const actual = (await orig()) as Record<string, unknown>;
+  return { ...actual, workerLogin: (...a: unknown[]) => workerLogin(...a) };
+});
+
+const save = vi.fn();
 vi.mock("garmin-auth", () => ({
-  GarminAuth: class {
-    constructor(_o: unknown) {}
-    login() {
-      return loginMock();
-    }
-  },
   DBTokenStore: class {
     constructor(..._a: unknown[]) {}
+    save(...a: unknown[]) {
+      return save(...a);
+    }
   },
-  NEEDS_MFA: "needs_mfa",
 }));
+const resetGarminClient = vi.fn();
 vi.mock("@/lib/garmin-upload", () => ({
   GARMIN_TOKEN_PLATFORM: "garmin_tokens",
-  resetGarminClient: vi.fn(),
+  resetGarminClient: () => resetGarminClient(),
 }));
 
 import { POST } from "./route";
@@ -39,46 +42,70 @@ beforeEach(() => {
 });
 
 describe("POST /api/garmin-login", () => {
-  it("missing email/password → 400, no login attempt", async () => {
-    const res = await POST(req({ email: "", password: "" }));
+  it("400 when email/password missing", async () => {
+    const res = await POST(req({ email: "" }));
     expect(res.status).toBe(400);
-    expect(loginMock).not.toHaveBeenCalled();
+    expect(workerLogin).not.toHaveBeenCalled();
   });
 
-  it("successful login → status connected", async () => {
-    loginMock.mockResolvedValue({ domain: "garmin.com" });
-    const res = await POST(req({ email: "a@b.com", password: "pw" }));
+  it("success → persists nested DI tokens and returns connected", async () => {
+    workerLogin.mockResolvedValue({
+      status: "success",
+      di_token: "a",
+      di_refresh_token: "b",
+      di_client_id: "c",
+    });
+    const res = await POST(req({ email: "me@x.com", password: "pw" }));
     const json = await res.json();
     expect(res.status).toBe(200);
     expect(json.status).toBe("connected");
-    expect(loginMock).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenCalledWith({ di_token: "a", di_refresh_token: "b", di_client_id: "c" });
+    expect(resetGarminClient).toHaveBeenCalled();
   });
 
-  it("NEEDS_MFA → status needs_mfa (200, with guidance)", async () => {
-    loginMock.mockResolvedValue("needs_mfa");
-    const res = await POST(req({ email: "a@b.com", password: "pw" }));
+  it("success but DATABASE_URL unset → 503, no store call", async () => {
+    delete process.env.DATABASE_URL;
+    workerLogin.mockResolvedValue({ status: "success", di_token: "a", di_refresh_token: "b", di_client_id: "c" });
+    const res = await POST(req({ email: "me@x.com", password: "pw" }));
+    expect(res.status).toBe(503);
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("needs_mfa → passes session_id through, no persistence", async () => {
+    workerLogin.mockResolvedValue({ status: "needs_mfa", session_id: "s1", mfa_method: "TOTP" });
+    const res = await POST(req({ email: "me@x.com", password: "pw" }));
     const json = await res.json();
     expect(res.status).toBe(200);
     expect(json.status).toBe("needs_mfa");
-    expect(json.error).toMatch(/two-factor|verification/i);
+    expect(json.session_id).toBe("s1");
+    expect(save).not.toHaveBeenCalled();
   });
 
-  it("login throws (bad creds / blocked) → 502 error", async () => {
-    loginMock.mockRejectedValue(new Error("SSO rejected"));
-    const res = await POST(req({ email: "a@b.com", password: "pw" }));
+  it("invalid_credentials → 401", async () => {
+    workerLogin.mockResolvedValue({ status: "invalid_credentials" });
+    const res = await POST(req({ email: "me@x.com", password: "bad" }));
+    expect(res.status).toBe(401);
+    expect((await res.json()).status).toBe("invalid_credentials");
+  });
+
+  it("rate_limited → 429 with a human retry hint", async () => {
+    workerLogin.mockResolvedValue({ status: "rate_limited", retry_after_seconds: 120 });
+    const res = await POST(req({ email: "me@x.com", password: "pw" }));
     const json = await res.json();
-    expect(res.status).toBe(502);
-    expect(json.status).toBe("error");
+    expect(res.status).toBe(429);
+    expect(json.error).toMatch(/2 min/);
   });
 
-  it("invalid JSON → 400", async () => {
-    const bad = new Request("http://h/api/garmin-login", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: "{no",
-    });
-    const res = await POST(bad);
-    expect(res.status).toBe(400);
-    expect(loginMock).not.toHaveBeenCalled();
+  it("needs_captcha → 409", async () => {
+    workerLogin.mockResolvedValue({ status: "needs_captcha" });
+    const res = await POST(req({ email: "me@x.com", password: "pw" }));
+    expect(res.status).toBe(409);
+  });
+
+  it("error → 502 carrying the worker message", async () => {
+    workerLogin.mockResolvedValue({ status: "error", message: "boom" });
+    const res = await POST(req({ email: "me@x.com", password: "pw" }));
+    expect(res.status).toBe(502);
+    expect((await res.json()).error).toBe("boom");
   });
 });

--- a/web/app/api/garmin-login/route.ts
+++ b/web/app/api/garmin-login/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
-import { GarminAuth, DBTokenStore, NEEDS_MFA } from "garmin-auth";
+import { DBTokenStore } from "garmin-auth";
 import { GARMIN_TOKEN_PLATFORM, resetGarminClient } from "@/lib/garmin-upload";
+import { workerLogin, tokensFromResult, type WorkerLoginResult } from "@/lib/garmin-login-worker";
 
-// Performs a live Garmin SSO login at request time — never at build.
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
@@ -10,17 +10,84 @@ export const runtime = "nodejs";
  * POST /api/garmin-login
  * Body: { email, password }
  *
- * Runs the garmin-auth SSO login and persists the resulting DI tokens into
- * platform_credentials ('garmin_tokens') via DBTokenStore, so the sync engine
- * can use them. Mirrors the Python self-hosted Garmin login — the password is
- * used only to obtain a token and is never stored.
+ * Step 1 of the Garmin sign-in. Sends the credentials to the direct-login
+ * Cloudflare Worker (which runs the SSO from a non-blocked edge IP), and on a
+ * clean success persists the returned DI tokens into platform_credentials
+ * ('garmin_tokens') via DBTokenStore so the sync engine can use them. The
+ * password is forwarded to the Worker only to obtain a token and is never
+ * stored or echoed back.
  *
- * KNOWN LIMITS (surfaced to the user in the form):
- *   - MFA accounts: login() returns needs_mfa, and the package does not yet
- *     expose an MFA-code submission, so those must use the CLI / scheduled job.
- *   - From a cloud IP (e.g. Vercel), Garmin SSO is blocked and needs the CF
- *     Worker proxy; a self-hosted deploy logs in directly.
+ * When the account has two-factor enabled the Worker returns needs_mfa with a
+ * session_id; the client then posts the code to /api/garmin-login-mfa.
  */
+
+/** Persist the DI tokens (nested {garmin_tokens:{...}}) for the sync engine. */
+async function persist(url: string, result: WorkerLoginResult): Promise<void> {
+  const tokens = tokensFromResult(result);
+  if (!tokens) throw new Error("Login succeeded but no DI tokens were returned.");
+  const store = new DBTokenStore(url, GARMIN_TOKEN_PLATFORM);
+  await store.save(tokens);
+  resetGarminClient();
+}
+
+/** Map a Worker result to the HTTP response the client consumes. */
+export function toResponse(url: string | undefined, result: WorkerLoginResult): Promise<NextResponse> | NextResponse {
+  switch (result.status) {
+    case "success": {
+      if (!url) {
+        return NextResponse.json(
+          { status: "error", error: "DATABASE_URL is not configured; cannot store the session." },
+          { status: 503 },
+        );
+      }
+      return persist(url, result)
+        .then(() => NextResponse.json({ status: "connected" }))
+        .catch((err) =>
+          NextResponse.json(
+            { status: "error", error: err instanceof Error ? err.message : String(err) },
+            { status: 500 },
+          ),
+        );
+    }
+    case "needs_mfa":
+      return NextResponse.json({
+        status: "needs_mfa",
+        session_id: result.session_id ?? "",
+        mfa_method: result.mfa_method ?? "",
+      });
+    case "needs_captcha":
+      return NextResponse.json(
+        {
+          status: "needs_captcha",
+          error:
+            "Garmin asked for a captcha. Automated sign-in can't clear it — sign in on Garmin's site and use the manual token flow.",
+        },
+        { status: 409 },
+      );
+    case "invalid_credentials":
+      return NextResponse.json(
+        { status: "invalid_credentials", error: "Incorrect Garmin email or password." },
+        { status: 401 },
+      );
+    case "rate_limited":
+      return NextResponse.json(
+        {
+          status: "rate_limited",
+          retry_after_seconds: result.retry_after_seconds ?? null,
+          error: result.retry_after_seconds
+            ? `Garmin is rate-limiting sign-ins. Try again in about ${Math.ceil(result.retry_after_seconds / 60)} min.`
+            : "Garmin is rate-limiting sign-ins. Try again later.",
+        },
+        { status: 429 },
+      );
+    default:
+      return NextResponse.json(
+        { status: "error", error: result.message ?? "Garmin login failed." },
+        { status: 502 },
+      );
+  }
+}
+
 export async function POST(request: Request) {
   let body: { email?: unknown; password?: unknown } = {};
   try {
@@ -39,30 +106,6 @@ export async function POST(request: Request) {
     );
   }
 
-  const url = process.env.DATABASE_URL;
-  if (!url) {
-    return NextResponse.json(
-      { status: "error", error: "DATABASE_URL is not configured." },
-      { status: 503 },
-    );
-  }
-
-  try {
-    const store = new DBTokenStore(url, GARMIN_TOKEN_PLATFORM);
-    const auth = new GarminAuth({ email, password, store });
-    const result = await auth.login();
-    if (result === NEEDS_MFA) {
-      return NextResponse.json({
-        status: "needs_mfa",
-        error:
-          "This Garmin account uses two-factor auth. Web verification-code entry isn't supported yet — use the CLI or the scheduled job to establish the session.",
-      });
-    }
-    // Fresh tokens were persisted by the store; drop the cached client.
-    resetGarminClient();
-    return NextResponse.json({ status: "connected" });
-  } catch (err) {
-    const error = err instanceof Error ? err.message : String(err);
-    return NextResponse.json({ status: "error", error }, { status: 502 });
-  }
+  const result = await workerLogin(email, password);
+  return toResponse(process.env.DATABASE_URL, result);
 }

--- a/web/components/connect-garmin.tsx
+++ b/web/components/connect-garmin.tsx
@@ -4,19 +4,36 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 /**
- * Connect-Garmin form for the setup page. Sends email/password to
- * /api/garmin-login, which runs the SSO and persists the DI tokens. The password
- * is used only to log in and is never stored or echoed back.
+ * Connect-Garmin form for the setup page. A two-step flow:
+ *   1. email/password → POST /api/garmin-login
+ *   2. if the account has two-factor, the server replies needs_mfa with a
+ *      session id; a code field appears → POST /api/garmin-login-mfa
+ *
+ * The credentials are forwarded to the login Worker only to obtain a token and
+ * are never stored or echoed back. Sign-in runs through a Cloudflare Worker so
+ * it works from cloud deploys (where Garmin blocks direct SSO).
  */
 export function ConnectGarmin({ connected }: { connected: boolean }) {
   const router = useRouter();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [mfaCode, setMfaCode] = useState("");
+  const [sessionId, setSessionId] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [okMsg, setOkMsg] = useState<string | null>(null);
 
-  async function submit(e: React.FormEvent) {
+  type Reply = { status?: string; error?: string; session_id?: string };
+
+  function onSuccess() {
+    setPassword("");
+    setMfaCode("");
+    setSessionId(null);
+    setOkMsg("Garmin connected.");
+    router.refresh();
+  }
+
+  async function startLogin(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
     setOkMsg(null);
@@ -31,13 +48,13 @@ export function ConnectGarmin({ connected }: { connected: boolean }) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email: email.trim(), password }),
       });
-      const d = (await res.json().catch(() => ({}))) as { status?: string; error?: string };
+      const d = (await res.json().catch(() => ({}))) as Reply;
       if (d.status === "connected") {
-        setPassword("");
-        setOkMsg("Garmin connected.");
-        router.refresh();
+        onSuccess();
+      } else if (d.status === "needs_mfa") {
+        setSessionId(d.session_id ?? "");
+        setError(null);
       } else {
-        // needs_mfa or error both carry a message
         setError(d.error ?? `Request failed (${res.status}).`);
       }
     } catch (err) {
@@ -47,11 +64,89 @@ export function ConnectGarmin({ connected }: { connected: boolean }) {
     }
   }
 
+  async function submitMfa(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (!mfaCode.trim()) {
+      setError("Enter the verification code Garmin sent you.");
+      return;
+    }
+    setBusy(true);
+    try {
+      const res = await fetch("/api/garmin-login-mfa", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ session_id: sessionId, mfa_code: mfaCode.trim() }),
+      });
+      const d = (await res.json().catch(() => ({}))) as Reply;
+      if (d.status === "connected") {
+        onSuccess();
+      } else {
+        setError(d.error ?? `Request failed (${res.status}).`);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function cancelMfa() {
+    setSessionId(null);
+    setMfaCode("");
+    setError(null);
+  }
+
   const inputCls =
     "w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text focus:border-teal focus:outline-none";
 
+  // Step 2: verification code
+  if (sessionId !== null) {
+    return (
+      <form onSubmit={submitMfa} className="space-y-3">
+        <p className="text-xs text-text-muted">
+          This Garmin account uses two-factor authentication. Enter the
+          verification code from your authenticator app or SMS.
+        </p>
+        <input
+          type="text"
+          inputMode="numeric"
+          autoComplete="one-time-code"
+          value={mfaCode}
+          onChange={(e) => setMfaCode(e.target.value)}
+          placeholder="Verification code"
+          className={inputCls}
+          aria-label="Verification code"
+        />
+        <div className="flex flex-wrap items-center gap-3">
+          <button
+            type="submit"
+            disabled={busy}
+            className="rounded-lg bg-teal/20 px-4 py-2 text-sm font-medium text-teal transition-colors hover:bg-teal/30 disabled:opacity-50"
+          >
+            {busy ? "Verifying…" : "Verify code"}
+          </button>
+          <button
+            type="button"
+            onClick={cancelMfa}
+            disabled={busy}
+            className="text-xs text-text-muted underline hover:text-text-secondary disabled:opacity-50"
+          >
+            Start over
+          </button>
+          {error && (
+            <span className="text-xs text-danger" role="alert">
+              {error}
+            </span>
+          )}
+        </div>
+      </form>
+    );
+  }
+
+  // Step 1: email + password
   return (
-    <form onSubmit={submit} className="space-y-3">
+    <form onSubmit={startLogin} className="space-y-3">
       <p className="text-xs text-text-muted">
         {connected
           ? "Garmin is connected. Sign in again to refresh the session."
@@ -64,6 +159,7 @@ export function ConnectGarmin({ connected }: { connected: boolean }) {
         onChange={(e) => setEmail(e.target.value)}
         placeholder="Garmin email"
         className={inputCls}
+        aria-label="Garmin email"
       />
       <input
         type="password"
@@ -72,6 +168,7 @@ export function ConnectGarmin({ connected }: { connected: boolean }) {
         onChange={(e) => setPassword(e.target.value)}
         placeholder="Garmin password"
         className={inputCls}
+        aria-label="Garmin password"
       />
       <div className="flex flex-wrap items-center gap-3">
         <button
@@ -89,8 +186,9 @@ export function ConnectGarmin({ connected }: { connected: boolean }) {
         )}
       </div>
       <p className="text-xs text-text-muted">
-        Two-factor accounts and cloud deploys: web sign-in isn&apos;t supported
-        yet — use the CLI or scheduled job to establish the Garmin session.
+        Two-factor accounts are supported: after sign-in you&apos;ll be asked for
+        a verification code. Sign-in runs through a proxy so it works on cloud
+        deploys.
       </p>
     </form>
   );

--- a/web/lib/garmin-login-worker.test.ts
+++ b/web/lib/garmin-login-worker.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  workerLogin,
+  workerLoginMfa,
+  tokensFromResult,
+  DEFAULT_GARMIN_LOGIN_WORKER_URL,
+  type FetchImpl,
+  type WorkerLoginResult,
+} from "./garmin-login-worker";
+
+/** A FetchImpl stub that records the call and returns a canned JSON payload. */
+function stub(status: number, payload: unknown) {
+  const calls: Array<{ url: string; init?: unknown }> = [];
+  const impl: FetchImpl = async (url, init) => {
+    calls.push({ url, init });
+    return { status, json: async () => payload };
+  };
+  return { impl, calls };
+}
+
+beforeEach(() => {
+  delete process.env.GARMIN_LOGIN_WORKER_URL;
+});
+afterEach(() => vi.unstubAllGlobals());
+
+describe("workerLogin", () => {
+  it("POSTs {email,password} to <worker>/login and returns the JSON verbatim", async () => {
+    const payload: WorkerLoginResult = {
+      status: "success",
+      di_token: "a",
+      di_refresh_token: "b",
+      di_client_id: "c",
+    };
+    const { impl, calls } = stub(200, payload);
+    const r = await workerLogin("me@x.com", "pw", impl);
+    expect(r).toEqual(payload);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe(`${DEFAULT_GARMIN_LOGIN_WORKER_URL}/login`);
+    const init = calls[0].init as { method: string; body: string };
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body)).toEqual({ email: "me@x.com", password: "pw" });
+  });
+
+  it("passes needs_mfa (with session_id) straight through", async () => {
+    const { impl } = stub(200, { status: "needs_mfa", session_id: "s1", mfa_method: "TOTP" });
+    const r = await workerLogin("me@x.com", "pw", impl);
+    expect(r.status).toBe("needs_mfa");
+    expect(r.session_id).toBe("s1");
+  });
+
+  it("honours GARMIN_LOGIN_WORKER_URL (trailing slash trimmed)", async () => {
+    process.env.GARMIN_LOGIN_WORKER_URL = "https://custom.example.dev/";
+    const { impl, calls } = stub(200, { status: "invalid_credentials" });
+    await workerLogin("me@x.com", "pw", impl);
+    expect(calls[0].url).toBe("https://custom.example.dev/login");
+  });
+
+  it("returns status:error when the network call throws", async () => {
+    const impl: FetchImpl = async () => {
+      throw new Error("ECONNREFUSED");
+    };
+    const r = await workerLogin("me@x.com", "pw", impl);
+    expect(r.status).toBe("error");
+    expect(r.message).toContain("ECONNREFUSED");
+  });
+
+  it("returns status:error when the body is not the expected shape", async () => {
+    const { impl } = stub(500, { oops: true });
+    const r = await workerLogin("me@x.com", "pw", impl);
+    expect(r.status).toBe("error");
+  });
+});
+
+describe("workerLoginMfa", () => {
+  it("POSTs {session_id,mfa_code} to <worker>/login-mfa", async () => {
+    const { impl, calls } = stub(200, { status: "success", di_token: "a", di_refresh_token: "b", di_client_id: "c" });
+    const r = await workerLoginMfa("s1", "123456", impl);
+    expect(r.status).toBe("success");
+    expect(calls[0].url).toBe(`${DEFAULT_GARMIN_LOGIN_WORKER_URL}/login-mfa`);
+    expect(JSON.parse((calls[0].init as { body: string }).body)).toEqual({
+      session_id: "s1",
+      mfa_code: "123456",
+    });
+  });
+});
+
+describe("tokensFromResult", () => {
+  it("extracts the three DI tokens from a success result", () => {
+    expect(
+      tokensFromResult({ status: "success", di_token: "a", di_refresh_token: "b", di_client_id: "c" }),
+    ).toEqual({ di_token: "a", di_refresh_token: "b", di_client_id: "c" });
+  });
+  it("returns null for a non-success result", () => {
+    expect(tokensFromResult({ status: "needs_mfa", session_id: "s" })).toBeNull();
+  });
+  it("returns null when a token field is missing", () => {
+    expect(tokensFromResult({ status: "success", di_token: "a" })).toBeNull();
+  });
+});

--- a/web/lib/garmin-login-worker.ts
+++ b/web/lib/garmin-login-worker.ts
@@ -43,12 +43,16 @@ export interface WorkerLoginResult {
   message?: string;
 }
 
-/** DI tokens as garmin-auth's DBTokenStore.save() expects them. */
-export interface GarminDiTokens {
+/**
+ * DI tokens as garmin-auth's DBTokenStore.save() expects them. A `type` alias
+ * (not an interface) so it's assignable to the store's `Record<string,unknown>`
+ * parameter — interfaces lack the implicit index signature that grants that.
+ */
+export type GarminDiTokens = {
   di_token: string;
   di_refresh_token: string;
   di_client_id: string;
-}
+};
 
 export type FetchImpl = (
   input: string,

--- a/web/lib/garmin-login-worker.ts
+++ b/web/lib/garmin-login-worker.ts
@@ -1,0 +1,124 @@
+/**
+ * Client for the Garmin direct-login Cloudflare Worker (worker-di, deployed at
+ * hevy2garmin-exchange-di.gkos.workers.dev).
+ *
+ * Garmin blocks SSO + token exchange from cloud IP ranges (Vercel, GitHub
+ * Actions), so the web can't log in to Garmin directly. The Worker runs on
+ * Cloudflare's edge, which is not blocked, and does the whole credential flow
+ * (including two-factor) there. The web sends the user's credentials to the
+ * Worker and stores the DI tokens it returns.
+ *
+ *   POST /login      { email, password }
+ *     → { status: "success", di_token, di_refresh_token, di_client_id }
+ *     → { status: "needs_mfa", session_id, mfa_method }
+ *     → { status: "needs_captcha" }          (fall back to manual sign-in)
+ *     → { status: "invalid_credentials" }
+ *     → { status: "rate_limited", retry_after_seconds }
+ *     → { status: "error", message }
+ *
+ *   POST /login-mfa  { session_id, mfa_code }
+ *     → { status: "success", di_token, di_refresh_token, di_client_id }
+ *     → (error variants above)
+ */
+
+export const DEFAULT_GARMIN_LOGIN_WORKER_URL =
+  "https://hevy2garmin-exchange-di.gkos.workers.dev";
+
+export type WorkerLoginStatus =
+  | "success"
+  | "needs_mfa"
+  | "needs_captcha"
+  | "invalid_credentials"
+  | "rate_limited"
+  | "error";
+
+export interface WorkerLoginResult {
+  status: WorkerLoginStatus;
+  di_token?: string;
+  di_refresh_token?: string;
+  di_client_id?: string;
+  session_id?: string;
+  mfa_method?: string;
+  retry_after_seconds?: number;
+  message?: string;
+}
+
+/** DI tokens as garmin-auth's DBTokenStore.save() expects them. */
+export interface GarminDiTokens {
+  di_token: string;
+  di_refresh_token: string;
+  di_client_id: string;
+}
+
+export type FetchImpl = (
+  input: string,
+  init?: { method?: string; headers?: Record<string, string>; body?: string },
+) => Promise<{ status: number; json: () => Promise<unknown> }>;
+
+function workerBase(): string {
+  const raw = process.env.GARMIN_LOGIN_WORKER_URL?.trim();
+  return (raw && raw.length > 0 ? raw : DEFAULT_GARMIN_LOGIN_WORKER_URL).replace(/\/$/, "");
+}
+
+async function callWorker(
+  path: string,
+  body: Record<string, string>,
+  fetchImpl: FetchImpl,
+): Promise<WorkerLoginResult> {
+  let res: { status: number; json: () => Promise<unknown> };
+  try {
+    res = await fetchImpl(`${workerBase()}${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { status: "error", message: `Could not reach the Garmin login service: ${message}` };
+  }
+
+  let data: unknown = {};
+  try {
+    data = await res.json();
+  } catch {
+    return { status: "error", message: `Garmin login service returned a non-JSON response (${res.status}).` };
+  }
+
+  const status = (data as { status?: unknown } | null)?.status;
+  if (typeof status === "string") {
+    return data as WorkerLoginResult;
+  }
+  return {
+    status: "error",
+    message: `Garmin login service returned an unexpected response (${res.status}).`,
+  };
+}
+
+/** Extract the three DI tokens from a success result, or null if incomplete. */
+export function tokensFromResult(r: WorkerLoginResult): GarminDiTokens | null {
+  if (r.status !== "success") return null;
+  if (!r.di_token || !r.di_refresh_token || !r.di_client_id) return null;
+  return {
+    di_token: r.di_token,
+    di_refresh_token: r.di_refresh_token,
+    di_client_id: r.di_client_id,
+  };
+}
+
+/** Step 1: submit email + password. */
+export function workerLogin(
+  email: string,
+  password: string,
+  fetchImpl: FetchImpl = fetch as unknown as FetchImpl,
+): Promise<WorkerLoginResult> {
+  return callWorker("/login", { email, password }, fetchImpl);
+}
+
+/** Step 2 (only when step 1 returned needs_mfa): submit the verification code. */
+export function workerLoginMfa(
+  sessionId: string,
+  mfaCode: string,
+  fetchImpl: FetchImpl = fetch as unknown as FetchImpl,
+): Promise<WorkerLoginResult> {
+  return callWorker("/login-mfa", { session_id: sessionId, mfa_code: mfaCode }, fetchImpl);
+}


### PR DESCRIPTION
Wires the web setup page's Connect-Garmin form to the already-deployed direct-login Cloudflare Worker (`worker-di`, `hevy2garmin-exchange-di.gkos.workers.dev`), which runs the Garmin SSO from a non-blocked edge IP and handles two-factor.

## Why
The #396 form called `GarminAuth.login()`, which only replays cached tokens and returns `NEEDS_MFA` for a fresh account, so it never actually logged anyone in. The real, 2FA-capable path is the Worker. No garmin-auth package change is needed: MFA lives in the Worker.

## What
- **`lib/garmin-login-worker.ts`** — typed Worker client (`POST /login`, `POST /login-mfa`), injectable fetch, URL from `GARMIN_LOGIN_WORKER_URL` (defaults to the deployed Worker).
- **`/api/garmin-login`** — forwards credentials to the Worker; on `success` persists the DI tokens via `DBTokenStore.save()` (nested `{garmin_tokens:{...}}`, the shape the sync engine reads); maps `needs_mfa` / `needs_captcha` / `invalid_credentials` / `rate_limited` / `error` to the right HTTP status.
- **`/api/garmin-login-mfa`** — the code-submit step, sharing `toResponse`.
- **`ConnectGarmin`** — two-step UI: email/password, then a verification-code field when the account has 2FA (with Start over), plus captcha/invalid/rate-limited messaging.

The password is forwarded to the Worker only to obtain a token and is never stored or echoed back.

## Verification
- **133 web tests pass** (20 new): Worker client (URL/body, status pass-through, env override, network/shape errors, `tokensFromResult`), both routes (success persists nested tokens, every status mapping, DATABASE_URL-unset guard).
- **Live Worker contract**: `POST /login` with a fake account returns `{"status":"invalid_credentials"}` over `node`/`undici` UAs (what Node's `fetch` sends), confirming the Vercel path is not Cloudflare-blocked.
- **Playwright**: the two-step flow validated end-to-end with a mocked fetch (step 1 → needs_mfa → code field → connected → reset). Staging `garmin_tokens` untouched.

The `success` / `needs_mfa` completion paths against a real Garmin account are the maintainer's live smoke-test.

Closes #403
