### PR TITLE
Web parity: login page (rate-limiter, ?next=, already-auth redirect, error surfacing)

### DIFF
--- a/web/app/api/login/route.test.ts
+++ b/web/app/api/login/route.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * POST /api/login tests. Auth + the rate-limiter are mocked, so no real DB and
+ * no real password are used.
+ */
+vi.mock("@/lib/auth", () => ({
+  authEnabled: () => true,
+  checkPassword: (p: string) => p === "correct-horse",
+  signSession: async () => "v1.123.deadbeefdeadbeefdeadbeefdeadbeef",
+  SESSION_COOKIE: "h2g_session",
+}));
+vi.mock("@/lib/db", () => ({ getDb: () => ({}) }));
+
+const lockoutRemaining = vi.fn();
+const recordFailure = vi.fn();
+const clearFailures = vi.fn();
+vi.mock("@/lib/login-ratelimit", () => ({
+  lockoutRemaining: (...a: unknown[]) => lockoutRemaining(...a),
+  recordFailure: (...a: unknown[]) => recordFailure(...a),
+  clearFailures: (...a: unknown[]) => clearFailures(...a),
+  formatCooldown: (s: number) => `${s} sec`,
+}));
+
+import { POST } from "./route";
+
+function req(password: unknown, next?: string): Request {
+  const url = next ? `http://h/api/login?next=${encodeURIComponent(next)}` : "http://h/api/login";
+  return new Request(url, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-forwarded-for": "9.9.9.9, 10.0.0.1" },
+    body: JSON.stringify({ password }),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  lockoutRemaining.mockResolvedValue(0);
+});
+
+describe("POST /api/login", () => {
+  it("correct password → sets cookie, clears failures, returns sanitized next", async () => {
+    const res = await POST(req("correct-horse", "/settings"));
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(json.next).toBe("/settings");
+    expect(res.headers.get("set-cookie")).toContain("h2g_session=");
+    expect(clearFailures).toHaveBeenCalledWith(expect.anything(), "9.9.9.9");
+  });
+
+  it("an absolute (open-redirect) next is rejected → /dashboard", async () => {
+    const res = await POST(req("correct-horse", "//evil.com"));
+    expect((await res.json()).next).toBe("/dashboard");
+  });
+
+  it("wrong password → 401 and records a failure", async () => {
+    const res = await POST(req("nope"));
+    expect(res.status).toBe(401);
+    expect(recordFailure).toHaveBeenCalledWith(expect.anything(), "9.9.9.9");
+  });
+
+  it("locked out → 429 before credentials are even checked", async () => {
+    lockoutRemaining.mockResolvedValue(90);
+    const res = await POST(req("correct-horse"));
+    expect(res.status).toBe(429);
+    expect((await res.json()).error).toMatch(/Too many attempts/);
+    expect(clearFailures).not.toHaveBeenCalled();
+  });
+
+  it("wrong password that trips the lockout → 429", async () => {
+    lockoutRemaining.mockResolvedValueOnce(0).mockResolvedValueOnce(60);
+    const res = await POST(req("nope"));
+    expect(res.status).toBe(429);
+    expect(recordFailure).toHaveBeenCalled();
+  });
+});

--- a/web/app/api/login/route.ts
+++ b/web/app/api/login/route.ts
@@ -1,19 +1,73 @@
 import { NextResponse } from "next/server";
 import { checkPassword, signSession, SESSION_COOKIE, authEnabled } from "@/lib/auth";
+import { getDb } from "@/lib/db";
+import { lockoutRemaining, recordFailure, clearFailures, formatCooldown } from "@/lib/login-ratelimit";
 
 export const runtime = "nodejs";
 
-/** POST { password } → set the h2g_session cookie on success. */
+/** First forwarded IP (client), matching the Python client_ip(); "unknown" if absent. */
+function clientIp(req: Request): string {
+  const xff = req.headers.get("x-forwarded-for");
+  if (xff) return xff.split(",")[0].trim() || "unknown";
+  return req.headers.get("x-real-ip")?.trim() || "unknown";
+}
+
+/** Only allow same-origin relative redirects (block open-redirects). */
+function safeNext(raw: string | null): string {
+  if (!raw || !raw.startsWith("/") || raw.startsWith("//")) return "/dashboard";
+  return raw;
+}
+
+/**
+ * POST { password } → set the h2g_session cookie on success.
+ * Rate-limited per client IP (mirrors Python /login): the lockout is checked
+ * BEFORE comparing credentials, a failure records against the limiter, and a
+ * success clears it. Honors ?next= (sanitized to a relative path).
+ */
 export async function POST(req: Request) {
-  // If auth isn't configured, there's nothing to log into.
   if (!authEnabled()) {
     return NextResponse.json({ ok: true, note: "auth disabled" });
   }
+
+  const next = safeNext(new URL(req.url).searchParams.get("next"));
   const body = (await req.json().catch(() => ({}))) as { password?: string };
+
+  let sql: ReturnType<typeof getDb> | null = null;
+  try {
+    sql = getDb();
+  } catch {
+    sql = null; // DB unavailable → skip the limiter (never lock the admin out on an outage)
+  }
+  const key = clientIp(req);
+
+  // Check the lockout BEFORE comparing credentials.
+  if (sql) {
+    const remaining = await lockoutRemaining(sql, key);
+    if (remaining > 0) {
+      return NextResponse.json(
+        { error: `Too many attempts. Try again in ${formatCooldown(remaining)}.` },
+        { status: 429 },
+      );
+    }
+  }
+
   if (!body.password || !checkPassword(body.password)) {
+    if (sql) {
+      await recordFailure(sql, key);
+      const remaining = await lockoutRemaining(sql, key);
+      if (remaining > 0) {
+        return NextResponse.json(
+          { error: `Too many attempts. Try again in ${formatCooldown(remaining)}.` },
+          { status: 429 },
+        );
+      }
+    }
     return NextResponse.json({ error: "Incorrect password" }, { status: 401 });
   }
-  const res = NextResponse.json({ ok: true });
+
+  if (sql) await clearFailures(sql, key);
+
+  const res = NextResponse.json({ ok: true, next });
   res.cookies.set(SESSION_COOKIE, await signSession(), {
     httpOnly: true,
     sameSite: "strict",

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -1,29 +1,47 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
+import { Suspense, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 
-export default function LoginPage() {
+function LoginForm() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const router = useRouter();
+  const params = useSearchParams();
+  // Surface a server-provided ?error= on first render (e.g. an expired session
+  // redirect), matching the Python login form's error passthrough.
+  const initialError = params.get("error") ?? "";
+  const [shownInitial, setShownInitial] = useState(false);
+  if (initialError && !shownInitial) {
+    setShownInitial(true);
+    setError(initialError);
+  }
+
+  function safeNext(raw: string | null): string {
+    if (!raw || !raw.startsWith("/") || raw.startsWith("//")) return "/dashboard";
+    return raw;
+  }
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
     setLoading(true);
     setError("");
+    const next = safeNext(params.get("next"));
     try {
-      const res = await fetch("/api/login", {
+      const res = await fetch(`/api/login?next=${encodeURIComponent(next)}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ password }),
       });
-      if (res.ok) {
-        router.push("/dashboard");
+      const data = (await res.json().catch(() => ({}))) as { ok?: boolean; next?: string; error?: string };
+      if (res.ok && data.ok) {
+        router.push(safeNext(data.next ?? next));
         router.refresh();
       } else {
-        setError("Incorrect password");
+        // Server message covers both "Incorrect password" and the rate-limit
+        // "Too many attempts. Try again in …" cooldown (HTTP 429).
+        setError(data.error ?? "Incorrect password");
         setLoading(false);
       }
     } catch {
@@ -45,7 +63,11 @@ export default function LoginPage() {
           placeholder="Password"
           className="rounded-lg border border-border bg-surface px-4 py-3 text-text outline-none focus:border-teal"
         />
-        {error && <p className="text-sm text-danger">{error}</p>}
+        {error && (
+          <p className="text-sm text-danger" role="alert">
+            {error}
+          </p>
+        )}
         <button
           type="submit"
           disabled={loading || password.length === 0}
@@ -55,5 +77,13 @@ export default function LoginPage() {
         </button>
       </form>
     </main>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense fallback={null}>
+      <LoginForm />
+    </Suspense>
   );
 }

--- a/web/lib/login-ratelimit.test.ts
+++ b/web/lib/login-ratelimit.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import {
+  lockoutRemaining,
+  recordFailure,
+  clearFailures,
+  formatCooldown,
+} from "./login-ratelimit";
+
+/**
+ * In-memory app_cache stub with the sql tag shape lib/db exposes. Handles the
+ * two statements the limiter uses: SELECT value ... WHERE key = $ and the
+ * INSERT ... ON CONFLICT upsert. `json` is a passthrough.
+ */
+function fakeSql() {
+  const store = new Map<string, unknown>();
+  const tag = (async (strings: TemplateStringsArray, ...values: unknown[]) => {
+    const q = strings.join("?");
+    if (q.startsWith("SELECT value FROM app_cache")) {
+      const key = values[0] as string;
+      return store.has(key) ? [{ value: store.get(key) }] : [];
+    }
+    if (q.includes("INSERT INTO app_cache")) {
+      const key = values[0] as string;
+      const value = values[1];
+      store.set(key, value);
+      return [];
+    }
+    throw new Error("unexpected query: " + q);
+  }) as unknown as ReturnType<typeof import("./db").getDb>;
+  (tag as unknown as { json: <T>(v: T) => T }).json = (v) => v;
+  return { tag, store };
+}
+
+const IP = "1.2.3.4";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-08-31T12:00:00Z"));
+});
+afterEach(() => vi.useRealTimers());
+
+describe("login-ratelimit", () => {
+  it("allows attempts until 5 failures, then locks out with backoff", async () => {
+    const { tag } = fakeSql();
+    expect(await lockoutRemaining(tag, IP)).toBe(0);
+    for (let i = 0; i < 4; i++) await recordFailure(tag, IP);
+    expect(await lockoutRemaining(tag, IP)).toBe(0); // 4 fails: still allowed
+    await recordFailure(tag, IP); // 5th → first lockout (60s)
+    const r = await lockoutRemaining(tag, IP);
+    expect(r).toBeGreaterThan(0);
+    expect(r).toBeLessThanOrEqual(60);
+  });
+
+  it("backs off exponentially on repeated lockouts, capped at 15 min", async () => {
+    const { tag } = fakeSql();
+    for (let i = 0; i < 5; i++) await recordFailure(tag, IP); // 60s
+    for (let i = 0; i < 5; i++) await recordFailure(tag, IP); // more fails → longer
+    const r = await lockoutRemaining(tag, IP);
+    expect(r).toBeGreaterThan(60);
+    expect(r).toBeLessThanOrEqual(15 * 60);
+  });
+
+  it("clearFailures resets the counter", async () => {
+    const { tag } = fakeSql();
+    for (let i = 0; i < 5; i++) await recordFailure(tag, IP);
+    expect(await lockoutRemaining(tag, IP)).toBeGreaterThan(0);
+    await clearFailures(tag, IP);
+    expect(await lockoutRemaining(tag, IP)).toBe(0);
+  });
+
+  it("the rolling window resets stale counters", async () => {
+    const { tag } = fakeSql();
+    for (let i = 0; i < 4; i++) await recordFailure(tag, IP);
+    vi.setSystemTime(new Date("2026-08-31T12:20:00Z")); // 20 min later > 15 min window
+    await recordFailure(tag, IP); // counts as the 1st in a fresh window
+    expect(await lockoutRemaining(tag, IP)).toBe(0);
+  });
+
+  it("never throws when storage fails (best-effort)", async () => {
+    const broken = (async () => {
+      throw new Error("db down");
+    }) as unknown as ReturnType<typeof import("./db").getDb>;
+    (broken as unknown as { json: <T>(v: T) => T }).json = (v) => v;
+    await expect(recordFailure(broken, IP)).resolves.toBeUndefined();
+    expect(await lockoutRemaining(broken, IP)).toBe(0);
+  });
+});
+
+describe("formatCooldown", () => {
+  it("formats minutes and seconds", () => {
+    expect(formatCooldown(0)).toBe("0 sec");
+    expect(formatCooldown(45)).toBe("45 sec");
+    expect(formatCooldown(60)).toBe("1 min");
+    expect(formatCooldown(90)).toBe("1 min 30 sec");
+  });
+});

--- a/web/lib/login-ratelimit.ts
+++ b/web/lib/login-ratelimit.ts
@@ -1,0 +1,125 @@
+/**
+ * Dashboard login rate-limiting with exponential backoff — port of the Python
+ * hevy2garmin.login_ratelimit. Protects POST /api/login from brute-force
+ * guessing: tracks failed attempts per client IP (plus a global counter that
+ * blunts distributed guessing) and enforces a short lockout that backs off
+ * exponentially. State lives in the app_cache key-value table so it survives
+ * serverless restarts.
+ *
+ * Tuned for a single human admin: 5 tries per IP, minute-scale lockouts capped
+ * at 15 min. All functions are BEST-EFFORT — a storage failure NEVER throws and
+ * NEVER locks the admin out (same guarantee as the Python module).
+ */
+import type { getDb } from "./db";
+
+type Sql = ReturnType<typeof getDb>;
+
+const PREFIX = "login_fail:";
+const GLOBAL_KEY = PREFIX + "__global__";
+
+const MAX_FAILS = 5; // per-IP failures before the first lockout
+const BASE_SECONDS = 60; // first lockout: 1 minute
+const MAX_SECONDS = 15 * 60; // cap per-IP lockout at 15 minutes
+const GLOBAL_MAX_FAILS = 50; // aggregate failures (all IPs) before a soft global lockout
+const GLOBAL_SECONDS = 15 * 60; // global soft lockout window
+const WINDOW_SECONDS = 15 * 60; // counters reset if the last failure is older than this
+
+interface FailState {
+  fails?: number;
+  until?: string | null;
+  ts?: string | null;
+}
+
+async function readState(sql: Sql, key: string): Promise<FailState> {
+  try {
+    const rows = (await sql`SELECT value FROM app_cache WHERE key = ${key} LIMIT 1`) as Array<{
+      value: unknown;
+    }>;
+    const v = rows[0]?.value;
+    return v && typeof v === "object" ? (v as FailState) : {};
+  } catch {
+    return {};
+  }
+}
+
+async function writeState(sql: Sql, key: string, state: FailState): Promise<void> {
+  try {
+    await sql`
+      INSERT INTO app_cache (key, value, updated_at)
+      VALUES (${key}, ${sql.json(state)}, NOW())
+      ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()
+    `;
+  } catch {
+    /* best-effort: never let a storage failure lock the admin out */
+  }
+}
+
+function secondsUntil(iso: string | null | undefined): number {
+  if (!iso) return 0;
+  const until = Date.parse(iso);
+  if (Number.isNaN(until)) return 0;
+  const remaining = Math.floor((until - Date.now()) / 1000);
+  return remaining > 0 ? remaining : 0;
+}
+
+/** Seconds left in this key's lockout, or 0. Best-effort → 0 on any error. */
+async function remaining(sql: Sql, key: string): Promise<number> {
+  const state = await readState(sql, key);
+  return secondsUntil(state.until);
+}
+
+/** Record one failure with a rolling window + exponential backoff. Returns lock seconds. */
+async function bump(
+  sql: Sql,
+  key: string,
+  maxFails: number,
+  base: number,
+  cap: number,
+): Promise<number> {
+  const now = Date.now();
+  const state = await readState(sql, key);
+  let fails = Number(state.fails ?? 0);
+  if (state.ts) {
+    const last = Date.parse(state.ts);
+    if (!Number.isNaN(last) && (now - last) / 1000 > WINDOW_SECONDS) fails = 0;
+  }
+  fails += 1;
+
+  let lockSecs = 0;
+  let untilIso: string | null = null;
+  if (fails >= maxFails) {
+    const over = fails - maxFails; // 0 on first lockout, grows on repeats
+    lockSecs = Math.min(base * 2 ** over, cap);
+    untilIso = new Date(now + lockSecs * 1000).toISOString();
+  }
+  await writeState(sql, key, { fails, until: untilIso, ts: new Date(now).toISOString() });
+  return lockSecs;
+}
+
+/** Seconds this client must wait before another attempt (0 = allowed). */
+export async function lockoutRemaining(sql: Sql, clientKey: string): Promise<number> {
+  const perIp = await remaining(sql, PREFIX + clientKey);
+  const global = await remaining(sql, GLOBAL_KEY);
+  return Math.max(perIp, global);
+}
+
+/** Record a failed login for this client (and the global counter). */
+export async function recordFailure(sql: Sql, clientKey: string): Promise<void> {
+  await bump(sql, PREFIX + clientKey, MAX_FAILS, BASE_SECONDS, MAX_SECONDS);
+  await bump(sql, GLOBAL_KEY, GLOBAL_MAX_FAILS, GLOBAL_SECONDS, GLOBAL_SECONDS);
+}
+
+/** Clear this client's failure counter after a successful login. */
+export async function clearFailures(sql: Sql, clientKey: string): Promise<void> {
+  await writeState(sql, PREFIX + clientKey, { fails: 0, until: null, ts: null });
+}
+
+/** Human "1 min 30 sec" style cooldown label — matches the Python format_cooldown. */
+export function formatCooldown(seconds: number): string {
+  if (seconds <= 0) return "0 sec";
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  if (m && s) return `${m} min ${s} sec`;
+  if (m) return `${m} min`;
+  return `${s} sec`;
+}

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -87,16 +87,30 @@ export async function proxy(req: NextRequest) {
   const { pathname } = req.nextUrl;
   if (STATIC_PREFIX.test(pathname)) return NextResponse.next();
   if (!authEnabled()) return NextResponse.next();
+  const cookie = req.cookies.get(SESSION_COOKIE)?.value ?? null;
+  const authed = await verifySession(cookie);
+
+  // Already signed in and hitting /login → bounce to the dashboard (or ?next=),
+  // mirroring the Python GET /login redirect-when-authenticated.
+  if (pathname === "/login" && authed) {
+    const url = req.nextUrl.clone();
+    const next = req.nextUrl.searchParams.get("next");
+    url.pathname = next && next.startsWith("/") && !next.startsWith("//") ? next : "/dashboard";
+    url.search = "";
+    return NextResponse.redirect(url);
+  }
+
   if (PUBLIC_PATHS.some((p) => pathname === p || pathname.startsWith(`${p}/`))) {
     return NextResponse.next();
   }
-  const cookie = req.cookies.get(SESSION_COOKIE)?.value ?? null;
-  if (await verifySession(cookie)) return NextResponse.next();
+  if (authed) return NextResponse.next();
   if (pathname.startsWith("/api/")) {
     return new NextResponse("Unauthorized", { status: 401 });
   }
+  // Gate the page and remember where the user was headed (?next=, relative-only).
   const url = req.nextUrl.clone();
   url.pathname = "/login";
+  url.search = `?next=${encodeURIComponent(pathname + req.nextUrl.search)}`;
   return NextResponse.redirect(url);
 }
 


### PR DESCRIPTION
Parity pass (1/N) before the demo cut-over — the login page, from the audit gap list.

Ports the Python `/login` behaviors the Next.js login lacked:

- **Login rate-limiter** (`lib/login-ratelimit.ts`, port of `login_ratelimit.py`): per-IP exponential backoff (5 fails → 1 min, doubling to a 15 min cap) plus a global soft-lockout, state in `app_cache`, **best-effort** (a storage failure never throws and never locks the admin out). `/api/login` checks the lockout before comparing credentials, records failures, clears on success, and returns 429 with a "Try again in …" cooldown.
- **`?next=` return-to-origin** after login, sanitized to same-origin relative paths (open-redirect safe). The proxy attaches `?next=<origin>` when it gates a page.
- **Already-authenticated → `/dashboard`**: the proxy bounces a signed-in visitor away from `/login`.
- **Surface `?error=` / the server message** on the login form (covers both "Incorrect password" and the 429 cooldown), replacing the hardcoded strings. `useSearchParams` under a Suspense boundary.

Out of scope (separate PR): `logout-all` + the `v2` session epoch (needs an edge-proxy epoch read).

## Verification
- **11 new tests pass**, tsc clean: rate-limiter (lockout after 5, exponential backoff capped at 15 min, clear-on-success, rolling-window reset, best-effort no-throw, cooldown format) + `/api/login` (success sets cookie + sanitized next, open-redirect next rejected, wrong password records failure→401, lockout→429 before creds, failure that trips the lockout→429).
- `curl` confirms `/login` renders 200 with the password form and the `?error=` message surfaced in the HTML. A pixel screenshot was blocked by saturated Playwright slots; the visual delta is minimal (form markup unchanged) and will be captured in the next validation pass.

Part of the 1:1 parity effort (full gap ledger tracked separately). Closes #405
