### PR TITLE
Web parity: settings page — 15 missing editable config fields

### DIFF
--- a/web/app/api/settings/route.test.ts
+++ b/web/app/api/settings/route.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/** Auth disabled (no session needed); DB captured via a fake sql tag. */
+vi.mock("@/lib/auth", () => ({
+  authEnabled: () => false,
+  verifySession: async () => true,
+  SESSION_COOKIE: "h2g_session",
+}));
+
+const writes: Array<{ key: string; value: Record<string, unknown> }> = [];
+vi.mock("@/lib/db", () => {
+  const tag = (async (strings: TemplateStringsArray, ...values: unknown[]) => {
+    const q = strings.join("?");
+    if (q.startsWith("SELECT key, value FROM app_cache")) return []; // no existing config
+    if (q.includes("INSERT INTO app_cache")) {
+      writes.push({ key: values[0] as string, value: values[1] as Record<string, unknown> });
+      return [];
+    }
+    throw new Error("unexpected query: " + q);
+  }) as unknown as { (): unknown; json: <T>(v: T) => T };
+  tag.json = (v) => v;
+  return { getDb: () => tag };
+});
+
+import { POST } from "./route";
+
+function req(body: unknown): Request {
+  return new Request("http://h/api/settings", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+function saved(key: string): Record<string, unknown> | undefined {
+  return writes.find((w) => w.key === key)?.value;
+}
+
+beforeEach(() => {
+  writes.length = 0;
+});
+
+describe("POST /api/settings — extended config surface", () => {
+  it("saves profile fields with validation (sex whitelist, vo2max)", async () => {
+    const res = await POST(
+      req({ user_profile: { birth_year: 1994, sex: "FEMALE", vo2max: 52.34, timezone: " Europe/Athens " } }),
+    );
+    expect(res.status).toBe(200);
+    const p = saved("user_profile")!;
+    expect(p.birth_year).toBe(1994);
+    expect(p.sex).toBe("female");
+    expect(p.vo2max).toBe(52.3);
+    expect(p.timezone).toBe("Europe/Athens");
+  });
+
+  it("drops an out-of-whitelist sex but keeps valid siblings", async () => {
+    await POST(req({ user_profile: { sex: "other", weight_kg: 82 } }));
+    const p = saved("user_profile")!;
+    expect(p.sex).toBeUndefined();
+    expect(p.weight_kg).toBe(82);
+  });
+
+  it("clamps merge_overlap_pct to [50,95] and merge_max_drift_min to [5,60]", async () => {
+    await POST(req({ merge_settings: { merge_overlap_pct: 999, merge_max_drift_min: 1, merge_mode: true } }));
+    const m = saved("merge_settings")!;
+    expect(m.merge_overlap_pct).toBe(95);
+    expect(m.merge_max_drift_min).toBe(5);
+    expect(m.merge_mode).toBe(true);
+  });
+
+  it("normalizes merge_activity_types: strength_training first, deduped, snake_cased", async () => {
+    await POST(req({ merge_settings: { merge_activity_types: ["Indoor Cardio", "strength_training", "yoga", "yoga"] } }));
+    const m = saved("merge_settings")!;
+    expect(m.merge_activity_types).toEqual(["strength_training", "indoor_cardio", "yoga"]);
+  });
+
+  it("saves the timing key with rounded ints", async () => {
+    await POST(
+      req({ timing: { working_set_seconds: 45.6, warmup_set_seconds: 20, rest_between_sets_seconds: 90, rest_between_exercises_seconds: 150 } }),
+    );
+    const t = saved("timing")!;
+    expect(t.working_set_seconds).toBe(46);
+    expect(t.rest_between_exercises_seconds).toBe(150);
+  });
+
+  it("400 when nothing editable is provided", async () => {
+    const res = await POST(req({ nonsense: { x: 1 } }));
+    expect(res.status).toBe(400);
+    expect(writes).toHaveLength(0);
+  });
+});

--- a/web/app/api/settings/route.ts
+++ b/web/app/api/settings/route.ts
@@ -30,7 +30,17 @@ function isObj(v: unknown): v is Obj {
   return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
-/** Keep only the recognised, validated sub-fields for a given config key. */
+/** Clamp an integer to [lo, hi], or undefined when not a finite number. */
+function clampInt(v: unknown, lo: number, hi: number): number | undefined {
+  const n = Math.round(Number(v));
+  if (!Number.isFinite(n)) return undefined;
+  return Math.max(lo, Math.min(hi, n));
+}
+
+/**
+ * Keep only the recognised, validated sub-fields for a given config key. Ranges
+ * mirror the Python POST /settings handler (settings_save).
+ */
 function sanitise(key: string, raw: Obj): Obj {
   const out: Obj = {};
   if (key === "auto_sync") {
@@ -46,19 +56,58 @@ function sanitise(key: string, raw: Obj): Obj {
       const s = String(raw.merge_watch_strategy);
       out.merge_watch_strategy = WATCH_STRATEGIES.includes(s) ? s : "merge";
     }
+    if ("merge_mode" in raw) out.merge_mode = Boolean(raw.merge_mode);
+    if ("description_enabled" in raw) out.description_enabled = Boolean(raw.description_enabled);
+    if ("merge_overlap_pct" in raw) {
+      const n = clampInt(raw.merge_overlap_pct, 50, 95);
+      if (n !== undefined) out.merge_overlap_pct = n;
+    }
+    if ("merge_max_drift_min" in raw) {
+      const n = clampInt(raw.merge_max_drift_min, 5, 60);
+      if (n !== undefined) out.merge_max_drift_min = n;
+    }
     if (Array.isArray(raw.merge_activity_types)) {
-      out.merge_activity_types = (raw.merge_activity_types as unknown[]).map(String).filter(Boolean);
+      // Always keep strength_training first, dedupe, drop blanks (matches Python).
+      const extras = (raw.merge_activity_types as unknown[])
+        .map((t) => String(t).trim().toLowerCase().replace(/\s+/g, "_"))
+        .filter((t) => t && t !== "strength_training");
+      out.merge_activity_types = ["strength_training", ...Array.from(new Set(extras))];
     }
   } else if (key === "user_profile") {
     if ("weight_kg" in raw) {
       const w = Number(raw.weight_kg);
       if (Number.isFinite(w) && w > 0 && w < 500) out.weight_kg = Math.round(w * 10) / 10;
     }
+    if ("birth_year" in raw) {
+      const n = clampInt(raw.birth_year, 1900, 2025);
+      if (n !== undefined) out.birth_year = n;
+    }
+    if ("sex" in raw) {
+      const s = String(raw.sex).toLowerCase();
+      if (s === "male" || s === "female") out.sex = s;
+    }
+    if ("vo2max" in raw) {
+      const v = Number(raw.vo2max);
+      if (Number.isFinite(v) && v > 0 && v < 100) out.vo2max = Math.round(v * 10) / 10;
+    }
+    if ("timezone" in raw) out.timezone = String(raw.timezone).trim();
+  } else if (key === "timing") {
+    for (const [field, [lo, hi]] of Object.entries({
+      working_set_seconds: [1, 3600],
+      warmup_set_seconds: [1, 3600],
+      rest_between_sets_seconds: [0, 3600],
+      rest_between_exercises_seconds: [0, 3600],
+    }) as [string, [number, number]][]) {
+      if (field in raw) {
+        const n = clampInt(raw[field], lo, hi);
+        if (n !== undefined) out[field] = n;
+      }
+    }
   }
   return out;
 }
 
-const EDITABLE = ["auto_sync", "hr_fusion", "merge_settings", "user_profile"];
+const EDITABLE = ["auto_sync", "hr_fusion", "merge_settings", "user_profile", "timing"];
 
 export async function POST(request: Request) {
   // Gate only when a password is configured (prod). With no password set the app

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -128,6 +128,8 @@ export default async function SettingsPage() {
   const hrFusion = cfg("hr_fusion");
   const merge = cfg("merge_settings");
   const profile = cfg("user_profile");
+  const timing = cfg("timing");
+  const numOrNull = (v: unknown): number | null => (v == null || v === "" ? null : Number(v));
 
   return (
     <main className="mx-auto max-w-5xl px-4 py-8 md:px-6">
@@ -200,7 +202,20 @@ export default async function SettingsPage() {
           autoSyncInterval={Number(autoSync.interval_minutes) || 120}
           hrFusionEnabled={hrFusion.enabled == null ? true : Boolean(hrFusion.enabled)}
           mergeWatchStrategy={String(merge.merge_watch_strategy ?? "merge")}
-          weightKg={profile.weight_kg != null ? Number(profile.weight_kg) : null}
+          weightKg={numOrNull(profile.weight_kg)}
+          birthYear={numOrNull(profile.birth_year)}
+          sex={profile.sex != null ? String(profile.sex) : null}
+          vo2max={numOrNull(profile.vo2max)}
+          timezone={profile.timezone != null ? String(profile.timezone) : null}
+          mergeMode={Boolean(merge.merge_mode)}
+          descriptionEnabled={Boolean(merge.description_enabled)}
+          mergeOverlapPct={numOrNull(merge.merge_overlap_pct)}
+          mergeMaxDriftMin={numOrNull(merge.merge_max_drift_min)}
+          mergeActivityTypes={Array.isArray(merge.merge_activity_types) ? (merge.merge_activity_types as unknown[]).map(String) : []}
+          workingSetSeconds={numOrNull(timing.working_set_seconds)}
+          warmupSetSeconds={numOrNull(timing.warmup_set_seconds)}
+          restBetweenSetsSeconds={numOrNull(timing.rest_between_sets_seconds)}
+          restBetweenExercisesSeconds={numOrNull(timing.rest_between_exercises_seconds)}
         />
       </section>
 

--- a/web/components/settings-form.tsx
+++ b/web/components/settings-form.tsx
@@ -9,6 +9,22 @@ interface Props {
   hrFusionEnabled: boolean;
   mergeWatchStrategy: string;
   weightKg: number | null;
+  // Profile
+  birthYear: number | null;
+  sex: string | null;
+  vo2max: number | null;
+  timezone: string | null;
+  // Enhance-watch + description
+  mergeMode: boolean;
+  descriptionEnabled: boolean;
+  mergeOverlapPct: number | null;
+  mergeMaxDriftMin: number | null;
+  mergeActivityTypes: string[];
+  // FIT timing
+  workingSetSeconds: number | null;
+  warmupSetSeconds: number | null;
+  restBetweenSetsSeconds: number | null;
+  restBetweenExercisesSeconds: number | null;
 }
 
 const INTERVALS = [30, 60, 120, 240, 360, 720, 1440];
@@ -29,10 +45,24 @@ const labelCls = "mb-1 block text-xs text-text-muted";
 const controlCls =
   "w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text focus:border-teal focus:outline-none";
 
+function Toggle({ label, checked, onChange, hint }: { label: string; checked: boolean; onChange: (v: boolean) => void; hint?: string }) {
+  return (
+    <div className={cardCls}>
+      <label className="flex items-center justify-between gap-2">
+        <span className="text-sm font-semibold text-text">{label}</span>
+        <input type="checkbox" checked={checked} onChange={(e) => onChange(e.target.checked)} className="h-4 w-4 accent-teal" />
+      </label>
+      {hint && <p className="mt-0.5 text-xs text-text-muted">{hint}</p>}
+    </div>
+  );
+}
+
 /**
  * Editable configuration form for the settings page. Posts the changed config
  * keys to /api/settings (which upserts them into app_cache, matching the Python
- * config schema) and refreshes the server-rendered view on success.
+ * config schema in settings_save) and refreshes the server-rendered view.
+ * Covers every field the Python POST /settings edits except credentials, which
+ * are managed on /setup (connect-hevy / connect-garmin).
  */
 export function SettingsForm(p: Props) {
   const router = useRouter();
@@ -41,9 +71,34 @@ export function SettingsForm(p: Props) {
   const [hrFusion, setHrFusion] = useState(p.hrFusionEnabled);
   const [strategy, setStrategy] = useState(p.mergeWatchStrategy);
   const [weight, setWeight] = useState(p.weightKg != null ? String(p.weightKg) : "");
+  const [birthYear, setBirthYear] = useState(p.birthYear != null ? String(p.birthYear) : "");
+  const [sex, setSex] = useState(p.sex ?? "male");
+  const [vo2max, setVo2max] = useState(p.vo2max != null ? String(p.vo2max) : "");
+  const [timezone, setTimezone] = useState(p.timezone ?? "");
+  const [mergeMode, setMergeMode] = useState(p.mergeMode);
+  const [descEnabled, setDescEnabled] = useState(p.descriptionEnabled);
+  const [overlap, setOverlap] = useState(p.mergeOverlapPct != null ? String(p.mergeOverlapPct) : "70");
+  const [drift, setDrift] = useState(p.mergeMaxDriftMin != null ? String(p.mergeMaxDriftMin) : "20");
+  const [extraTypes, setExtraTypes] = useState(
+    p.mergeActivityTypes.filter((t) => t && t !== "strength_training").join(", "),
+  );
+  const [workingSet, setWorkingSet] = useState(p.workingSetSeconds != null ? String(p.workingSetSeconds) : "40");
+  const [warmupSet, setWarmupSet] = useState(p.warmupSetSeconds != null ? String(p.warmupSetSeconds) : "25");
+  const [restSets, setRestSets] = useState(p.restBetweenSetsSeconds != null ? String(p.restBetweenSetsSeconds) : "75");
+  const [restEx, setRestEx] = useState(p.restBetweenExercisesSeconds != null ? String(p.restBetweenExercisesSeconds) : "120");
+  const [showCalc, setShowCalc] = useState(false);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
+
+  function numOrUndef(s: string): number | undefined {
+    const t = s.trim();
+    if (!t) return undefined;
+    const n = Number(t);
+    return Number.isFinite(n) ? n : undefined;
+  }
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
@@ -51,12 +106,32 @@ export function SettingsForm(p: Props) {
     setSaved(false);
     setBusy(true);
     try {
-      const w = weight.trim();
+      const profile: Record<string, unknown> = {};
+      const w = numOrUndef(weight); if (w !== undefined) profile.weight_kg = w;
+      const by = numOrUndef(birthYear); if (by !== undefined) profile.birth_year = by;
+      profile.sex = sex;
+      const vo = numOrUndef(vo2max); if (vo !== undefined) profile.vo2max = vo;
+      if (timezone.trim()) profile.timezone = timezone.trim();
+
+      const extras = extraTypes.split(",").map((t) => t.trim()).filter(Boolean);
       const body = {
         auto_sync: { enabled: autoSync, interval_minutes: interval },
         hr_fusion: { enabled: hrFusion },
-        merge_settings: { merge_watch_strategy: strategy },
-        ...(w ? { user_profile: { weight_kg: Number(w) } } : {}),
+        merge_settings: {
+          merge_watch_strategy: strategy,
+          merge_mode: mergeMode,
+          description_enabled: descEnabled,
+          merge_overlap_pct: numOrUndef(overlap) ?? 70,
+          merge_max_drift_min: numOrUndef(drift) ?? 20,
+          merge_activity_types: ["strength_training", ...extras],
+        },
+        user_profile: profile,
+        timing: {
+          working_set_seconds: numOrUndef(workingSet) ?? 40,
+          warmup_set_seconds: numOrUndef(warmupSet) ?? 25,
+          rest_between_sets_seconds: numOrUndef(restSets) ?? 75,
+          rest_between_exercises_seconds: numOrUndef(restEx) ?? 120,
+        },
       };
       const res = await fetch("/api/settings", {
         method: "POST",
@@ -78,46 +153,140 @@ export function SettingsForm(p: Props) {
   }
 
   return (
-    <form onSubmit={submit} className="grid grid-cols-1 gap-4 md:grid-cols-2">
-      <div className={cardCls}>
-        <label className="flex items-center justify-between gap-2">
-          <span className="text-sm font-semibold text-text">Auto-sync</span>
-          <input type="checkbox" checked={autoSync} onChange={(e) => setAutoSync(e.target.checked)} className="h-4 w-4 accent-teal" />
-        </label>
-        <p className="mb-2 mt-0.5 text-xs text-text-muted">Poll Hevy and push new workouts on a schedule.</p>
-        <label className={labelCls} htmlFor="sf-interval">Interval</label>
-        <select id="sf-interval" value={interval} onChange={(e) => setIntervalMin(Number.parseInt(e.target.value, 10))} disabled={!autoSync} className={`${controlCls} disabled:opacity-50`}>
-          {INTERVALS.map((m) => (
-            <option key={m} value={m}>{fmtInterval(m)}</option>
-          ))}
-        </select>
+    <form onSubmit={submit} className="space-y-6">
+      {/* Sync */}
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className={cardCls}>
+          <label className="flex items-center justify-between gap-2">
+            <span className="text-sm font-semibold text-text">Auto-sync</span>
+            <input type="checkbox" checked={autoSync} onChange={(e) => setAutoSync(e.target.checked)} className="h-4 w-4 accent-teal" />
+          </label>
+          <p className="mb-2 mt-0.5 text-xs text-text-muted">Poll Hevy and push new workouts on a schedule.</p>
+          <label className={labelCls} htmlFor="sf-interval">Interval</label>
+          <select id="sf-interval" value={interval} onChange={(e) => setIntervalMin(Number.parseInt(e.target.value, 10))} disabled={!autoSync} className={`${controlCls} disabled:opacity-50`}>
+            {INTERVALS.map((m) => (<option key={m} value={m}>{fmtInterval(m)}</option>))}
+          </select>
+        </div>
+        <Toggle label="HR fusion" checked={hrFusion} onChange={setHrFusion} hint="Pull heart-rate from a matched Garmin activity into the synced workout." />
       </div>
 
-      <div className={cardCls}>
-        <label className="flex items-center justify-between gap-2">
-          <span className="text-sm font-semibold text-text">HR fusion</span>
-          <input type="checkbox" checked={hrFusion} onChange={(e) => setHrFusion(e.target.checked)} className="h-4 w-4 accent-teal" />
-        </label>
-        <p className="mt-0.5 text-xs text-text-muted">Pull heart-rate from a matched Garmin activity into the synced workout.</p>
+      {/* Profile */}
+      <div>
+        <h3 className="mb-2 text-sm font-semibold text-text">Your profile</h3>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <div className={cardCls}>
+            <label className={labelCls} htmlFor="sf-weight">Body weight (kg)</label>
+            <input id="sf-weight" type="number" min={1} max={499} step={0.1} value={weight} onChange={(e) => setWeight(e.target.value)} placeholder="80" className={controlCls} />
+          </div>
+          <div className={cardCls}>
+            <label className={labelCls} htmlFor="sf-birthyear">Birth year</label>
+            <input id="sf-birthyear" type="number" min={1900} max={2025} step={1} value={birthYear} onChange={(e) => setBirthYear(e.target.value)} placeholder="1990" className={controlCls} />
+          </div>
+          <div className={cardCls}>
+            <label className={labelCls} htmlFor="sf-sex">Sex</label>
+            <select id="sf-sex" value={sex} onChange={(e) => setSex(e.target.value)} className={controlCls}>
+              <option value="male">Male</option>
+              <option value="female">Female</option>
+            </select>
+          </div>
+          <div className={cardCls}>
+            <label className={labelCls} htmlFor="sf-vo2max">VO₂max</label>
+            <input id="sf-vo2max" type="number" min={1} max={99} step={0.1} value={vo2max} onChange={(e) => setVo2max(e.target.value)} placeholder="45" className={controlCls} />
+          </div>
+        </div>
+        <div className={`${cardCls} mt-4`}>
+          <label className={labelCls} htmlFor="sf-timezone">Timezone (IANA)</label>
+          <input id="sf-timezone" type="text" value={timezone} onChange={(e) => setTimezone(e.target.value)} placeholder="e.g. Europe/Athens" className={controlCls} list="sf-tz-list" />
+          <datalist id="sf-tz-list">
+            {["UTC", "Europe/Athens", "Europe/London", "America/New_York", "America/Los_Angeles", "Asia/Tokyo", "Australia/Sydney"].map((t) => (
+              <option key={t} value={t} />
+            ))}
+          </datalist>
+          <p className="mt-1.5 text-xs text-text-muted">Stamps local time into the FIT so Strava shows the correct workout time.</p>
+        </div>
+        <button type="button" onClick={() => setShowCalc((v) => !v)} className="mt-2 text-xs text-teal underline">
+          {showCalc ? "Hide" : "How are calories calculated?"}
+        </button>
+        {showCalc && (
+          <div className="mt-2 rounded-lg border border-border bg-surface p-3 text-xs text-text-secondary">
+            <p>Calories use the Keytel (2005) heart-rate equation, per minute:</p>
+            <p className="my-1 font-mono text-[11px] text-text">
+              male: (−55.0969 + 0.6309·HR + 0.1988·wt + 0.2017·age) / 4.184
+            </p>
+            <p className="font-mono text-[11px] text-text">
+              female: (−20.4022 + 0.4472·HR − 0.1263·wt + 0.074·age) / 4.184
+            </p>
+            <p className="mt-1">Weight, birth year, sex and VO₂max above feed this estimate.</p>
+          </div>
+        )}
       </div>
 
-      <div className={cardCls}>
-        <label className={labelCls} htmlFor="sf-strategy">Merge watch strategy</label>
-        <select id="sf-strategy" value={strategy} onChange={(e) => setStrategy(e.target.value)} className={controlCls}>
-          {STRATEGIES.map((s) => (
-            <option key={s.value} value={s.value}>{s.label}</option>
-          ))}
-        </select>
-        <p className="mt-1.5 text-xs text-text-muted">How a Hevy workout is combined with a same-time watch activity.</p>
+      {/* Enhance watch / description */}
+      <div>
+        <h3 className="mb-2 text-sm font-semibold text-text">Watch activities</h3>
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <Toggle label="Enhance watch activities" checked={mergeMode} onChange={setMergeMode} hint="Merge Hevy sets/reps into a same-time Garmin watch activity instead of uploading a separate strength activity." />
+          <Toggle label="Activity description" checked={descEnabled} onChange={setDescEnabled} hint="Write the exercise/sets summary into the Garmin activity's description." />
+        </div>
+        <div className={`${cardCls} mt-4`}>
+          <label className={labelCls} htmlFor="sf-strategy">Merge watch strategy</label>
+          <select id="sf-strategy" value={strategy} onChange={(e) => setStrategy(e.target.value)} className={controlCls}>
+            {STRATEGIES.map((s) => (<option key={s.value} value={s.value}>{s.label}</option>))}
+          </select>
+          <p className="mt-1.5 text-xs text-text-muted">How a Hevy workout is combined with a same-time watch activity.</p>
+        </div>
       </div>
 
-      <div className={cardCls}>
-        <label className={labelCls} htmlFor="sf-weight">Body weight (kg)</label>
-        <input id="sf-weight" type="number" min={1} max={499} step={0.1} value={weight} onChange={(e) => setWeight(e.target.value)} placeholder="e.g. 80" className={controlCls} />
-        <p className="mt-1.5 text-xs text-text-muted">Used for calorie estimation on synced workouts.</p>
+      {/* Advanced */}
+      <div>
+        <button type="button" onClick={() => setShowAdvanced((v) => !v)} className="text-sm font-semibold text-text underline">
+          {showAdvanced ? "▾ Advanced" : "▸ Advanced"}
+        </button>
+        {showAdvanced && (
+          <div className="mt-3 space-y-4">
+            <div>
+              <p className="mb-2 text-xs font-medium text-text-muted">Watch activity matching</p>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+                <div className={cardCls}>
+                  <label className={labelCls} htmlFor="sf-overlap">Min overlap %</label>
+                  <input id="sf-overlap" type="number" min={50} max={95} step={1} value={overlap} onChange={(e) => setOverlap(e.target.value)} className={controlCls} />
+                </div>
+                <div className={cardCls}>
+                  <label className={labelCls} htmlFor="sf-drift">Max drift (min)</label>
+                  <input id="sf-drift" type="number" min={5} max={60} step={1} value={drift} onChange={(e) => setDrift(e.target.value)} className={controlCls} />
+                </div>
+                <div className={cardCls}>
+                  <label className={labelCls} htmlFor="sf-extratypes">Extra activity types</label>
+                  <input id="sf-extratypes" type="text" value={extraTypes} onChange={(e) => setExtraTypes(e.target.value)} placeholder="indoor_cardio, yoga" className={controlCls} />
+                </div>
+              </div>
+            </div>
+            <div>
+              <p className="mb-2 text-xs font-medium text-text-muted">FIT file timing (seconds)</p>
+              <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+                <div className={cardCls}>
+                  <label className={labelCls} htmlFor="sf-working">Working set</label>
+                  <input id="sf-working" type="number" min={1} max={3600} step={1} value={workingSet} onChange={(e) => setWorkingSet(e.target.value)} className={controlCls} />
+                </div>
+                <div className={cardCls}>
+                  <label className={labelCls} htmlFor="sf-warmup">Warmup set</label>
+                  <input id="sf-warmup" type="number" min={1} max={3600} step={1} value={warmupSet} onChange={(e) => setWarmupSet(e.target.value)} className={controlCls} />
+                </div>
+                <div className={cardCls}>
+                  <label className={labelCls} htmlFor="sf-restsets">Rest / sets</label>
+                  <input id="sf-restsets" type="number" min={0} max={3600} step={1} value={restSets} onChange={(e) => setRestSets(e.target.value)} className={controlCls} />
+                </div>
+                <div className={cardCls}>
+                  <label className={labelCls} htmlFor="sf-restex">Rest / exercises</label>
+                  <input id="sf-restex" type="number" min={0} max={3600} step={1} value={restEx} onChange={(e) => setRestEx(e.target.value)} className={controlCls} />
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
 
-      <div className="flex items-center gap-3 md:col-span-2">
+      <div className="flex items-center gap-3">
         <button type="submit" disabled={busy} className="rounded-lg bg-teal/20 px-4 py-2 text-sm font-medium text-teal transition-colors hover:bg-teal/30 disabled:opacity-50">
           {busy ? "Saving…" : "Save settings"}
         </button>


### PR DESCRIPTION
Parity pass (2/N) — the settings page. The audit found the SettingsForm edited only 4 of the Python `POST /settings` 19 fields, so most of the app was unconfigurable from the web.

## What
Adds every missing editable field (credentials excepted — those live on `/setup` via connect-hevy / connect-garmin):
- **Profile**: birth_year, sex, vo2max, timezone (weight_kg already present) + a collapsible Keytel calorie-formula explainer.
- **Watch activities**: Enhance-watch (merge_mode) + Activity-description toggles.
- **Advanced** (collapsible): watch-matching (merge_overlap_pct 50–95, merge_max_drift_min 5–60, extra activity types) + FIT timing (working/warmup/rest seconds).
- `/api/settings` sanitiser extended to the new `user_profile`, `timing`, and `merge_settings` sub-fields with the same validation ranges as `settings_save()`; `merge_activity_types` is normalized strength_training-first + deduped.
- The settings page seeds every control from the stored `app_cache` config.

## Verification
- **150 web tests pass** (6 new settings-route tests: sex whitelist, vo2max rounding, tz trim, overlap/drift clamps, activity-types normalization, timing ints, 400-on-nothing), tsc clean.
- **Screenshot validated** (standalone Chromium): all 15 new fields render, the Keytel formula shows, the Advanced section expands, and the read-only "Stored config" cards mirror the form values — confirming the config round-trips through `app_cache`.

Part of the 1:1 parity effort. Closes #407
