### PR TITLE
Web parity: setup — manual Garmin ticket recovery (captcha/MFA fallback) + rate-limit

### DIFF
--- a/web/app/api/garmin-rate-limited/route.test.ts
+++ b/web/app/api/garmin-rate-limited/route.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+let stored: Record<string, unknown> | null = null;
+const captured: Array<Record<string, unknown>> = [];
+vi.mock("@/lib/db", () => {
+  const tag = (async (strings: TemplateStringsArray, ...values: unknown[]) => {
+    const q = strings.join("?");
+    if (q.startsWith("SELECT value FROM app_cache")) return stored ? [{ value: stored }] : [];
+    if (q.includes("INSERT INTO app_cache")) {
+      stored = values[1] as Record<string, unknown>;
+      captured.push(stored);
+      return [];
+    }
+    throw new Error("unexpected query: " + q);
+  }) as unknown as { (): unknown; json: <T>(v: T) => T };
+  tag.json = (v) => v;
+  return { getDb: () => tag };
+});
+
+import { POST } from "./route";
+
+beforeEach(() => {
+  stored = null;
+  captured.length = 0;
+});
+
+describe("POST /api/garmin-rate-limited", () => {
+  it("first hit → 2h cooldown", async () => {
+    const res = await POST();
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.cooldown_seconds).toBe(2 * 3600);
+    expect((captured[0].hits as number)).toBe(1);
+    expect(typeof captured[0].until).toBe("string");
+  });
+
+  it("backs off exponentially: 2h → 4h → 8h", async () => {
+    await POST();
+    await POST();
+    const res = await POST();
+    expect((await res.json()).cooldown_seconds).toBe(8 * 3600);
+  });
+
+  it("caps at 24h", async () => {
+    for (let i = 0; i < 10; i++) await POST();
+    const res = await POST();
+    expect((await res.json()).cooldown_seconds).toBe(24 * 3600);
+  });
+});

--- a/web/app/api/garmin-rate-limited/route.ts
+++ b/web/app/api/garmin-rate-limited/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const BASE_SECONDS = 2 * 60 * 60; // first cooldown: 2 hours
+const MAX_SECONDS = 24 * 60 * 60; // cap at 24 hours
+const RATELIMIT_KEY = "garmin_ratelimit";
+
+/**
+ * POST /api/garmin-rate-limited
+ *
+ * Record that Garmin rate-limited a sign-in/upload, so the app backs off before
+ * retrying. State is app_cache 'garmin_ratelimit' { until, hits, seconds } with
+ * an exponential backoff (2h → 4h → … → 24h cap). Mirrors Python
+ * record_rate_limit() / POST /api/garmin-rate-limited. Returns the cooldown.
+ */
+export async function POST() {
+  let sql: ReturnType<typeof getDb>;
+  try {
+    sql = getDb();
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ ok: false, error: `DB unavailable: ${error}` }, { status: 503 });
+  }
+
+  try {
+    const rows = (await sql`SELECT value FROM app_cache WHERE key = ${RATELIMIT_KEY} LIMIT 1`) as Array<{
+      value: unknown;
+    }>;
+    const cur = rows[0]?.value && typeof rows[0].value === "object" ? (rows[0].value as Record<string, unknown>) : {};
+    const hits = Number(cur.hits ?? 0) + 1;
+    const seconds = Math.min(BASE_SECONDS * 2 ** (hits - 1), MAX_SECONDS);
+    const until = new Date(Date.now() + seconds * 1000).toISOString();
+    await sql`
+      INSERT INTO app_cache (key, value, updated_at)
+      VALUES (${RATELIMIT_KEY}, ${sql.json({ until, hits, seconds })}, NOW())
+      ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()
+    `;
+    return NextResponse.json({ ok: true, cooldown_seconds: seconds });
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ ok: false, error }, { status: 500 });
+  }
+}

--- a/web/app/api/garmin-ticket/route.test.ts
+++ b/web/app/api/garmin-ticket/route.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const save = vi.fn();
+vi.mock("garmin-auth", () => ({
+  DBTokenStore: class {
+    constructor(..._a: unknown[]) {}
+    save(...a: unknown[]) {
+      return save(...a);
+    }
+  },
+}));
+const resetGarminClient = vi.fn();
+vi.mock("@/lib/garmin-upload", () => ({
+  GARMIN_TOKEN_PLATFORM: "garmin_tokens",
+  resetGarminClient: () => resetGarminClient(),
+}));
+
+import { POST } from "./route";
+
+function req(body: unknown): Request {
+  return new Request("http://h/api/garmin-ticket", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.DATABASE_URL = "postgres://ci:ci@localhost:5432/ci";
+});
+
+describe("POST /api/garmin-ticket", () => {
+  it("persists the three DI tokens (nested via DBTokenStore) and returns ok", async () => {
+    const res = await POST(req({ tokens: { di_token: "a", di_refresh_token: "b", di_client_id: "c" } }));
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+    expect(save).toHaveBeenCalledWith({ di_token: "a", di_refresh_token: "b", di_client_id: "c" });
+    expect(resetGarminClient).toHaveBeenCalled();
+  });
+
+  it("400 when a token field is missing", async () => {
+    const res = await POST(req({ tokens: { di_token: "a" } }));
+    expect(res.status).toBe(400);
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("503 when DATABASE_URL is unset", async () => {
+    delete process.env.DATABASE_URL;
+    const res = await POST(req({ tokens: { di_token: "a", di_refresh_token: "b", di_client_id: "c" } }));
+    expect(res.status).toBe(503);
+    expect(save).not.toHaveBeenCalled();
+  });
+});

--- a/web/app/api/garmin-ticket/route.ts
+++ b/web/app/api/garmin-ticket/route.ts
@@ -1,0 +1,58 @@
+import { NextResponse } from "next/server";
+import { DBTokenStore } from "garmin-auth";
+import { GARMIN_TOKEN_PLATFORM, resetGarminClient } from "@/lib/garmin-upload";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * POST /api/garmin-ticket
+ * Body: { tokens: { di_token, di_refresh_token, di_client_id } }
+ *
+ * The manual Garmin sign-in fallback used when Garmin forces the browser embed
+ * flow (captcha, or an MFA account hitting the 427 path) — the case the direct
+ * /api/garmin-login can't clear. The browser signs in on Garmin's own widget,
+ * pastes the resulting `ST-...` ticket, and the client exchanges it for DI
+ * tokens at the CF Worker `/exchange` (which returns DI tokens directly). This
+ * route just persists those tokens via DBTokenStore.save() — the same nested
+ * `{garmin_tokens:{…}}` shape the sync engine reads. Mirrors Python
+ * POST /api/garmin-ticket.
+ */
+export async function POST(request: Request) {
+  let body: { tokens?: unknown } = {};
+  try {
+    const text = await request.text();
+    if (text) body = JSON.parse(text);
+  } catch {
+    return NextResponse.json({ ok: false, error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const t = body.tokens as Record<string, unknown> | undefined;
+  const di_token = typeof t?.di_token === "string" ? t.di_token : "";
+  const di_refresh_token = typeof t?.di_refresh_token === "string" ? t.di_refresh_token : "";
+  const di_client_id = typeof t?.di_client_id === "string" ? t.di_client_id : "";
+  if (!di_token || !di_refresh_token || !di_client_id) {
+    return NextResponse.json(
+      { ok: false, error: "tokens must include di_token, di_refresh_token, and di_client_id." },
+      { status: 400 },
+    );
+  }
+
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    return NextResponse.json(
+      { ok: false, error: "DATABASE_URL is not configured; cannot store the session." },
+      { status: 503 },
+    );
+  }
+
+  try {
+    const store = new DBTokenStore(url, GARMIN_TOKEN_PLATFORM);
+    await store.save({ di_token, di_refresh_token, di_client_id });
+    resetGarminClient();
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ ok: false, error }, { status: 500 });
+  }
+}

--- a/web/components/connect-garmin.tsx
+++ b/web/components/connect-garmin.tsx
@@ -4,21 +4,45 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 /**
- * Connect-Garmin form for the setup page. A two-step flow:
+ * Connect-Garmin form for the setup page. Three modes:
  *   1. email/password → POST /api/garmin-login
- *   2. if the account has two-factor, the server replies needs_mfa with a
- *      session id; a code field appears → POST /api/garmin-login-mfa
+ *   2. two-factor code → POST /api/garmin-login-mfa (when step 1 returns needs_mfa)
+ *   3. manual ticket fallback → sign in on Garmin's own widget, paste the
+ *      resulting ST-… ticket, exchange it at the CF Worker /exchange for DI
+ *      tokens, then POST /api/garmin-ticket. Revealed when Garmin forces a
+ *      captcha (needs_captcha), or on demand via "having trouble?".
  *
- * The credentials are forwarded to the login Worker only to obtain a token and
- * are never stored or echoed back. Sign-in runs through a Cloudflare Worker so
- * it works from cloud deploys (where Garmin blocks direct SSO).
+ * Credentials are forwarded to the login Worker only to obtain a token and are
+ * never stored or echoed back.
  */
+
+// The Garmin embed sign-in widget (opens in a new tab); after login the URL
+// carries the ST-… ticket the user pastes back.
+const GARMIN_SSO_URL =
+  "https://sso.garmin.com/sso/signin?id=gauth-widget&embedWidget=true" +
+  "&gauthHost=https://sso.garmin.com/sso" +
+  "&service=https://sso.garmin.com/sso/embed" +
+  "&source=https://sso.garmin.com/sso/embed" +
+  "&redirectAfterAccountLoginUrl=https://sso.garmin.com/sso/embed" +
+  "&redirectAfterAccountCreationUrl=https://sso.garmin.com/sso/embed";
+const WORKER_EXCHANGE_URL = "https://hevy2garmin-exchange-di.gkos.workers.dev/exchange";
+
+/** Pull the ST-… ticket out of a pasted embed URL, or accept a raw ticket. */
+function extractTicket(raw: string): string | null {
+  const m = raw.match(/ticket=([^&\s]+)/);
+  if (m) return m[1];
+  const t = raw.trim();
+  return t.startsWith("ST-") ? t : null;
+}
+
 export function ConnectGarmin({ connected }: { connected: boolean }) {
   const router = useRouter();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [mfaCode, setMfaCode] = useState("");
   const [sessionId, setSessionId] = useState<string | null>(null);
+  const [manual, setManual] = useState(false);
+  const [ticketUrl, setTicketUrl] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [okMsg, setOkMsg] = useState<string | null>(null);
@@ -28,7 +52,9 @@ export function ConnectGarmin({ connected }: { connected: boolean }) {
   function onSuccess() {
     setPassword("");
     setMfaCode("");
+    setTicketUrl("");
     setSessionId(null);
+    setManual(false);
     setOkMsg("Garmin connected.");
     router.refresh();
   }
@@ -54,7 +80,12 @@ export function ConnectGarmin({ connected }: { connected: boolean }) {
       } else if (d.status === "needs_mfa") {
         setSessionId(d.session_id ?? "");
         setError(null);
+      } else if (d.status === "needs_captcha") {
+        // Garmin wants a captcha the automated flow can't clear → manual ticket.
+        setManual(true);
+        setError(null);
       } else {
+        if (d.status === "rate_limited") void recordCooldown();
         setError(d.error ?? `Request failed (${res.status}).`);
       }
     } catch (err) {
@@ -79,11 +110,8 @@ export function ConnectGarmin({ connected }: { connected: boolean }) {
         body: JSON.stringify({ session_id: sessionId, mfa_code: mfaCode.trim() }),
       });
       const d = (await res.json().catch(() => ({}))) as Reply;
-      if (d.status === "connected") {
-        onSuccess();
-      } else {
-        setError(d.error ?? `Request failed (${res.status}).`);
-      }
+      if (d.status === "connected") onSuccess();
+      else setError(d.error ?? `Request failed (${res.status}).`);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -91,16 +119,113 @@ export function ConnectGarmin({ connected }: { connected: boolean }) {
     }
   }
 
-  function cancelMfa() {
-    setSessionId(null);
-    setMfaCode("");
+  /** Best-effort record of a Garmin rate-limit cooldown. */
+  async function recordCooldown() {
+    try {
+      await fetch("/api/garmin-rate-limited", { method: "POST" });
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  async function submitTicket(e: React.FormEvent) {
+    e.preventDefault();
     setError(null);
+    const ticket = extractTicket(ticketUrl);
+    if (!ticket) {
+      setError("Paste the full URL after signing in (it contains ?ticket=ST-…).");
+      return;
+    }
+    setBusy(true);
+    try {
+      // Exchange the ticket for DI tokens at the CF Worker (returns them directly).
+      const ex = await fetch(WORKER_EXCHANGE_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ticket }),
+      });
+      const tokens = (await ex.json().catch(() => ({}))) as {
+        di_token?: string;
+        di_refresh_token?: string;
+        di_client_id?: string;
+        error?: string;
+      };
+      if (!ex.ok || !tokens.di_token || !tokens.di_refresh_token || !tokens.di_client_id) {
+        setError(tokens.error ?? "That ticket could not be exchanged. Sign in again for a fresh one.");
+        return;
+      }
+      const res = await fetch("/api/garmin-ticket", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          tokens: {
+            di_token: tokens.di_token,
+            di_refresh_token: tokens.di_refresh_token,
+            di_client_id: tokens.di_client_id,
+          },
+        }),
+      });
+      const d = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      if (res.ok && d.ok) onSuccess();
+      else setError(d.error ?? `Could not store the session (${res.status}).`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
   }
 
   const inputCls =
     "w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text focus:border-teal focus:outline-none";
 
-  // Step 2: verification code
+  // Mode 3: manual ticket-paste fallback
+  if (manual) {
+    return (
+      <form onSubmit={submitTicket} className="space-y-3">
+        <p className="text-xs text-text-muted">
+          Garmin needs you to sign in on its own page. Do these in order:
+        </p>
+        <ol className="ml-4 list-decimal space-y-1 text-xs text-text-secondary">
+          <li>
+            <a href={GARMIN_SSO_URL} target="_blank" rel="noreferrer" className="text-teal underline">
+              Sign in to Garmin
+            </a>{" "}
+            in the new tab (complete any verification there).
+          </li>
+          <li>When it finishes, copy the full URL from the address bar.</li>
+          <li>Paste it below and press Connect.</li>
+        </ol>
+        <input
+          type="text"
+          value={ticketUrl}
+          onChange={(e) => setTicketUrl(e.target.value)}
+          placeholder="https://sso.garmin.com/sso/embed?ticket=ST-…"
+          className={inputCls}
+          aria-label="Garmin ticket URL"
+        />
+        <div className="flex flex-wrap items-center gap-3">
+          <button
+            type="submit"
+            disabled={busy}
+            className="rounded-lg bg-teal/20 px-4 py-2 text-sm font-medium text-teal transition-colors hover:bg-teal/30 disabled:opacity-50"
+          >
+            {busy ? "Connecting…" : "Connect"}
+          </button>
+          <button
+            type="button"
+            onClick={() => { setManual(false); setError(null); }}
+            disabled={busy}
+            className="text-xs text-text-muted underline hover:text-text-secondary disabled:opacity-50"
+          >
+            Back to password sign-in
+          </button>
+          {error && <span className="text-xs text-danger" role="alert">{error}</span>}
+        </div>
+      </form>
+    );
+  }
+
+  // Mode 2: verification code
   if (sessionId !== null) {
     return (
       <form onSubmit={submitMfa} className="space-y-3">
@@ -119,32 +244,19 @@ export function ConnectGarmin({ connected }: { connected: boolean }) {
           aria-label="Verification code"
         />
         <div className="flex flex-wrap items-center gap-3">
-          <button
-            type="submit"
-            disabled={busy}
-            className="rounded-lg bg-teal/20 px-4 py-2 text-sm font-medium text-teal transition-colors hover:bg-teal/30 disabled:opacity-50"
-          >
+          <button type="submit" disabled={busy} className="rounded-lg bg-teal/20 px-4 py-2 text-sm font-medium text-teal transition-colors hover:bg-teal/30 disabled:opacity-50">
             {busy ? "Verifying…" : "Verify code"}
           </button>
-          <button
-            type="button"
-            onClick={cancelMfa}
-            disabled={busy}
-            className="text-xs text-text-muted underline hover:text-text-secondary disabled:opacity-50"
-          >
+          <button type="button" onClick={() => { setSessionId(null); setMfaCode(""); setError(null); }} disabled={busy} className="text-xs text-text-muted underline hover:text-text-secondary disabled:opacity-50">
             Start over
           </button>
-          {error && (
-            <span className="text-xs text-danger" role="alert">
-              {error}
-            </span>
-          )}
+          {error && <span className="text-xs text-danger" role="alert">{error}</span>}
         </div>
       </form>
     );
   }
 
-  // Step 1: email + password
+  // Mode 1: email + password
   return (
     <form onSubmit={startLogin} className="space-y-3">
       <p className="text-xs text-text-muted">
@@ -152,43 +264,22 @@ export function ConnectGarmin({ connected }: { connected: boolean }) {
           ? "Garmin is connected. Sign in again to refresh the session."
           : "Sign in with your Garmin Connect account. Your password is used only to get a token and is never stored."}
       </p>
-      <input
-        type="email"
-        autoComplete="off"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        placeholder="Garmin email"
-        className={inputCls}
-        aria-label="Garmin email"
-      />
-      <input
-        type="password"
-        autoComplete="off"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-        placeholder="Garmin password"
-        className={inputCls}
-        aria-label="Garmin password"
-      />
+      <input type="email" autoComplete="off" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="Garmin email" className={inputCls} aria-label="Garmin email" />
+      <input type="password" autoComplete="off" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Garmin password" className={inputCls} aria-label="Garmin password" />
       <div className="flex flex-wrap items-center gap-3">
-        <button
-          type="submit"
-          disabled={busy}
-          className="rounded-lg bg-teal/20 px-4 py-2 text-sm font-medium text-teal transition-colors hover:bg-teal/30 disabled:opacity-50"
-        >
+        <button type="submit" disabled={busy} className="rounded-lg bg-teal/20 px-4 py-2 text-sm font-medium text-teal transition-colors hover:bg-teal/30 disabled:opacity-50">
           {busy ? "Connecting…" : "Connect Garmin"}
         </button>
         {okMsg && <span className="text-xs text-success">{okMsg}</span>}
-        {error && (
-          <span className="text-xs text-danger" role="alert">
-            {error}
-          </span>
-        )}
+        {error && <span className="text-xs text-danger" role="alert">{error}</span>}
       </div>
       <p className="text-xs text-text-muted">
-        Two-factor accounts are supported: after sign-in you&apos;ll be asked for
-        a verification code. Sign-in runs through a proxy so it works on cloud
-        deploys.
+        Two-factor accounts are supported. Having trouble, or Garmin asking for a
+        captcha?{" "}
+        <button type="button" onClick={() => { setManual(true); setError(null); }} className="text-teal underline">
+          Sign in on Garmin&apos;s site instead
+        </button>
+        .
       </p>
     </form>
   );


### PR DESCRIPTION
Parity pass (4/N) — the setup page's **manual Garmin ticket recovery**, the audit's most critical gap: the rebuild had **no recovery path** when Garmin forces the browser embed flow (a captcha, or an MFA account hitting the 427 path), so those accounts couldn't connect at all.

## What
- **`/api/garmin-ticket`**: accepts `{tokens:{di_token,di_refresh_token,di_client_id}}` and persists via `DBTokenStore.save()` (the nested `{garmin_tokens:{…}}` shape the sync engine reads) — the same persist path as the #404 login.
- **`/api/garmin-rate-limited`**: records a Garmin cooldown in `app_cache` `garmin_ratelimit` with exponential backoff (2h → 4h → … → 24h cap), returns `{cooldown_seconds}`. Mirrors `record_rate_limit()`.
- **ConnectGarmin** gains a third mode alongside password + 2FA: on `needs_captcha` (or on demand via "Sign in on Garmin's site instead") it reveals the manual flow — a Garmin embed sign-in link, a ticket-URL input, and Connect that extracts the `ST-` ticket, exchanges it at the CF Worker `/exchange` (which returns DI tokens directly), and stores them. `rate_limited` records the cooldown.

## Verification
- **150 web tests pass** (6 new: ticket persists nested tokens / 400 on missing field / 503 no DB; rate-limit 2h first hit, exponential 2h→4h→8h, 24h cap), tsc clean.
- **Screenshot validated** (standalone Chromium): the manual fallback renders the ordered steps, the "Sign in to Garmin" SSO link, the ticket-URL input, and Connect / Back-to-password.

Part of the 1:1 parity effort. Closes #411
