### PR TITLE
Web parity: /api/unsync-all confirm=RESET guard + demo-mode 403 + cache clear

### DIFF
--- a/web/app/api/unsync-all/route.test.ts
+++ b/web/app/api/unsync-all/route.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const unsyncAll = vi.fn();
+vi.mock("@/lib/pending-store", () => ({ unsyncAll: () => unsyncAll() }));
+
+const cacheWrites: string[] = [];
+vi.mock("@/lib/db", () => {
+  const tag = (async (strings: TemplateStringsArray, ...values: unknown[]) => {
+    if (strings.join("?").includes("INSERT INTO app_cache")) cacheWrites.push(values[0] as string);
+    return [];
+  }) as unknown as { (): unknown; json: <T>(v: T) => T };
+  tag.json = (v) => v;
+  return { getDb: () => tag };
+});
+
+let demo = false;
+vi.mock("@/lib/demo", () => ({ demoMode: () => demo }));
+
+import { POST } from "./route";
+
+function req(body?: unknown): Request {
+  return new Request("http://h/api/unsync-all", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  cacheWrites.length = 0;
+  demo = false;
+  unsyncAll.mockResolvedValue(7);
+});
+
+describe("POST /api/unsync-all", () => {
+  it("confirm=RESET → unsyncs, clears 10 cached pages, returns count", async () => {
+    const res = await POST(req({ confirm: "RESET" }));
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json).toEqual({ ok: true, count: 7 });
+    expect(unsyncAll).toHaveBeenCalled();
+    expect(cacheWrites).toHaveLength(10);
+    expect(cacheWrites).toContain("hevy_workouts_page_1");
+    expect(cacheWrites).toContain("hevy_workouts_page_10");
+  });
+
+  it("missing confirm → 400, no unsync", async () => {
+    const res = await POST(req({}));
+    expect(res.status).toBe(400);
+    expect(unsyncAll).not.toHaveBeenCalled();
+  });
+
+  it("wrong confirm → 400", async () => {
+    const res = await POST(req({ confirm: "reset" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("demo mode → 403 before anything runs", async () => {
+    demo = true;
+    const res = await POST(req({ confirm: "RESET" }));
+    expect(res.status).toBe(403);
+    expect(unsyncAll).not.toHaveBeenCalled();
+  });
+});

--- a/web/app/api/unsync-all/route.ts
+++ b/web/app/api/unsync-all/route.ts
@@ -1,26 +1,60 @@
 import { NextResponse } from "next/server";
 import { unsyncAll } from "@/lib/pending-store";
+import { getDb } from "@/lib/db";
+import { demoMode } from "@/lib/demo";
 
 // Deletes from the app's own synced_workouts table at request time — never at build.
 export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
 
 /**
  * POST /api/unsync-all
+ * Body: { confirm: "RESET" }
  *
  * Clears every terminal synced_workouts row so all workouts become sync
  * candidates again. DB-ONLY: it does NOT delete any Garmin activity (same
- * boundary as single /api/unsync). Mirrors the Python /api/unsync-all.
- *
- * NOTE: auth-gating (session cookie / middleware) is added in the login phase;
- * this route is intentionally unauthenticated for now.
+ * boundary as single /api/unsync). Mirrors the Python /api/unsync-all:
+ * refuses in demo mode (403), requires confirm=RESET (400), and clears the
+ * cached Hevy workout pages so the reset shows immediately. Session-gating is
+ * handled by the proxy (all /api/* except the public login routes).
  */
-export async function POST() {
+export async function POST(request: Request) {
+  if (demoMode()) {
+    return NextResponse.json({ ok: false, error: "Read-only in demo mode" }, { status: 403 });
+  }
+
+  let confirm = "";
+  try {
+    const text = await request.text();
+    if (text) confirm = String((JSON.parse(text) as { confirm?: unknown }).confirm ?? "");
+  } catch {
+    confirm = "";
+  }
+  if (confirm !== "RESET") {
+    return NextResponse.json({ ok: false, error: "Send confirm=RESET to proceed" }, { status: 400 });
+  }
+
   let count: number;
   try {
     count = await unsyncAll();
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);
-    return NextResponse.json({ error }, { status: 500 });
+    return NextResponse.json({ ok: false, error }, { status: 500 });
   }
+
+  // Clear cached Hevy workout pages so the reset is reflected on next load.
+  try {
+    const sql = getDb();
+    for (let page = 1; page <= 10; page++) {
+      await sql`
+        INSERT INTO app_cache (key, value, updated_at)
+        VALUES (${`hevy_workouts_page_${page}`}, ${sql.json({})}, NOW())
+        ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()
+      `;
+    }
+  } catch {
+    /* best-effort cache clear; the unsync already succeeded */
+  }
+
   return NextResponse.json({ ok: true, count });
 }

--- a/web/components/danger-zone.tsx
+++ b/web/components/danger-zone.tsx
@@ -21,7 +21,11 @@ export function DangerZone({ syncedCount }: { syncedCount: number }) {
     setBusy(true);
     setError(null);
     try {
-      const res = await fetch("/api/unsync-all", { method: "POST" });
+      const res = await fetch("/api/unsync-all", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ confirm: "RESET" }),
+      });
       const d = (await res.json().catch(() => ({}))) as { ok?: boolean; count?: number; error?: string };
       if (!res.ok || !d.ok) {
         setError(d.error ?? `Request failed (${res.status}).`);

--- a/web/lib/demo.ts
+++ b/web/lib/demo.ts
@@ -1,0 +1,9 @@
+/**
+ * Demo-mode flag — mirrors the Python is_demo_mode(). When DEMO_MODE is truthy
+ * the public demo is read-only: destructive/config-writing routes refuse with
+ * 403 so visitors can browse without mutating the maintainer's data.
+ */
+export function demoMode(): boolean {
+  const v = (process.env.DEMO_MODE ?? "").trim().toLowerCase();
+  return v === "1" || v === "true" || v === "yes" || v === "on";
+}


### PR DESCRIPTION
Parity + safety — the destructive `/api/unsync-all` was missing the Python guards. Adds: demo-mode 403, a `confirm=RESET` requirement (400 otherwise), and clearing the cached Hevy workout pages (`app_cache hevy_workouts_page_1..10`) so the reset shows immediately. New reusable `demoMode()` helper; DangerZone now sends `confirm=RESET`. Session-gating is already handled by the proxy.

## Verification
4 new tests (confirm=RESET unsyncs + clears 10 pages, missing/wrong confirm → 400, demo → 403 before anything runs), tsc clean. Backend/request-body change — no visual delta.

Closes #413
