### PR TITLE
Web parity: dashboard live sync loop (progress + Stop + error branches)

### DIFF
--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -1,5 +1,6 @@
 import { getDb } from "@/lib/db";
 import { SyncPanel } from "@/components/sync-panel";
+import { SyncLoop } from "@/components/sync-loop";
 import { BatchSync } from "@/components/batch-sync";
 import { AutoSyncToggle } from "@/components/autosync-toggle";
 
@@ -223,7 +224,12 @@ export default async function DashboardPage() {
 
       {/* Sync controls (preview is dry-run; live upload is gated) */}
       <SyncPanel ready={data.hevyConnected && data.garminConnected} />
-      <BatchSync ready={data.hevyConnected && data.garminConnected} />
+      <div className="mt-3">
+        <SyncLoop ready={data.hevyConnected && data.garminConnected} />
+      </div>
+      <div className="mt-3">
+        <BatchSync ready={data.hevyConnected && data.garminConnected} />
+      </div>
 
       <div className="mb-8">
         <AutoSyncToggle enabled={data.autoSyncEnabled} />

--- a/web/components/sync-loop.tsx
+++ b/web/components/sync-loop.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  initialLoopState,
+  stepLoop,
+  loopPercent,
+  errorHint,
+  type LoopState,
+  type SyncOneLike,
+} from "@/lib/sync-loop";
+
+/**
+ * Live "Sync all" for the dashboard — ports the Python syncNow() loop. Clicking
+ * Start runs /api/sync-one?live=1 repeatedly, advancing a pure reducer
+ * (lib/sync-loop) and showing a live progress bar + per-status counts until
+ * nothing is left, an error, or Stop. Because each iteration performs a real
+ * Garmin upload, Start is behind an inline confirmation and the server also
+ * requires authorization for ?live=1.
+ */
+export function SyncLoop({ ready }: { ready: boolean }) {
+  const router = useRouter();
+  const [state, setState] = useState<LoopState>(initialLoopState);
+  const [running, setRunning] = useState(false);
+  const [confirming, setConfirming] = useState(false);
+  const stopRef = useRef(false);
+
+  async function runLoop() {
+    setConfirming(false);
+    setRunning(true);
+    stopRef.current = false;
+    let cur: LoopState = { ...initialLoopState };
+    setState(cur);
+    try {
+      // Cap iterations defensively so a misbehaving server can't spin forever.
+      for (let i = 0; i < 500; i++) {
+        if (stopRef.current) {
+          cur = { ...cur, done: true, message: `Paused after ${cur.synced + cur.skipped} workout(s).` };
+          setState(cur);
+          break;
+        }
+        let httpStatus = 0;
+        let result: SyncOneLike = {};
+        try {
+          const res = await fetch("/api/sync-one?live=1", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ live: 1 }),
+          });
+          httpStatus = res.status;
+          result = (await res.json().catch(() => ({}))) as SyncOneLike;
+        } catch (err) {
+          cur = { ...cur, done: true, errorKind: "generic", message: err instanceof Error ? err.message : "Network error." };
+          setState(cur);
+          break;
+        }
+        const { state: next, cont } = stepLoop(cur, { httpStatus, result });
+        cur = next;
+        setState(cur);
+        if (!cont) break;
+      }
+    } finally {
+      setRunning(false);
+      if (cur.synced > 0) router.refresh();
+    }
+  }
+
+  const pct = loopPercent(state);
+  const onGarmin = state.total > 0 ? state.total - state.remaining : state.synced;
+
+  return (
+    <div className="rounded-xl border border-border bg-surface-elevated p-4">
+      <div className="mb-2 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold text-text">Sync all</h3>
+          <p className="mt-0.5 text-xs text-text-muted">
+            Upload every pending Hevy workout to Garmin, one at a time, with live progress.
+          </p>
+        </div>
+        {running ? (
+          <button
+            type="button"
+            onClick={() => { stopRef.current = true; }}
+            className="rounded-lg border border-warm/50 px-3 py-1.5 text-xs font-medium text-warm transition-colors hover:bg-warm/15"
+          >
+            Stop
+          </button>
+        ) : !confirming ? (
+          <button
+            type="button"
+            onClick={() => setConfirming(true)}
+            disabled={!ready}
+            title={!ready ? "Connect Hevy and Garmin first" : undefined}
+            className="rounded-lg bg-teal/20 px-4 py-1.5 text-xs font-medium text-teal transition-colors hover:bg-teal/30 disabled:opacity-50"
+          >
+            Sync all now
+          </button>
+        ) : (
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-text-muted">Upload all pending to Garmin?</span>
+            <button type="button" onClick={runLoop} className="rounded-lg bg-teal px-3 py-1.5 text-xs font-medium text-black">
+              Start
+            </button>
+            <button type="button" onClick={() => setConfirming(false)} className="text-xs text-text-muted underline">
+              Cancel
+            </button>
+          </div>
+        )}
+      </div>
+
+      {(running || state.started || state.done) && (
+        <div className="mt-3" aria-live="polite">
+          <div className="h-2 w-full overflow-hidden rounded-full bg-surface-active">
+            <div
+              className="h-full rounded-full bg-teal transition-all duration-300"
+              style={{ width: `${pct}%` }}
+              role="progressbar"
+              aria-valuenow={pct}
+              aria-valuemin={0}
+              aria-valuemax={100}
+            />
+          </div>
+          <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs tabular-nums text-text-secondary">
+            <span>On Garmin: <span className="font-semibold text-text">{onGarmin}</span></span>
+            <span>Pending: <span className="font-semibold text-text">{state.remaining}</span></span>
+            <span>Synced: <span className="font-semibold text-success">{state.synced}</span></span>
+            {state.skipped > 0 && <span>Skipped: <span className="font-semibold text-text-muted">{state.skipped}</span></span>}
+            {running && state.currentTitle && <span className="text-text-muted">· {state.currentTitle}…</span>}
+          </div>
+          {state.done && state.message && (
+            <p className={`mt-2 text-xs ${state.errorKind ? "text-danger" : "text-text-secondary"}`} role={state.errorKind ? "alert" : undefined}>
+              {state.errorKind ? errorHint(state.errorKind) : state.message}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/lib/sync-loop.test.ts
+++ b/web/lib/sync-loop.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import {
+  initialLoopState,
+  stepLoop,
+  classifyError,
+  loopPercent,
+  errorHint,
+  type LoopState,
+} from "./sync-loop";
+
+function ok(result: Record<string, unknown>) {
+  return { httpStatus: 200, result };
+}
+
+/** Drive a full sequence of responses through the reducer. */
+function drive(seq: Array<{ httpStatus: number; result: Record<string, unknown> }>): LoopState {
+  let s = { ...initialLoopState };
+  for (const step of seq) {
+    const { state, cont } = stepLoop(s, step);
+    s = state;
+    if (!cont) break;
+  }
+  return s;
+}
+
+describe("classifyError", () => {
+  it("maps error strings to branches", () => {
+    expect(classifyError("Garmin requires upload consent")).toBe("consent");
+    expect(classifyError("Your Hevy API key is invalid")).toBe("hevy_key");
+    expect(classifyError("Login failed: bad token")).toBe("garmin_auth");
+    expect(classifyError("OAuth expired")).toBe("garmin_auth");
+    expect(classifyError("kaboom")).toBe("generic");
+  });
+});
+
+describe("stepLoop — clean 3-workout run", () => {
+  it("counts 3 synced, seeds total, ends caught-up at 100%", () => {
+    const final = drive([
+      ok({ status: "synced", remaining: 2, workout: { title: "Push A" } }),
+      ok({ status: "synced", remaining: 1, workout: { title: "Pull B" } }),
+      ok({ status: "synced", remaining: 0, workout: { title: "Legs C" } }),
+      ok({ status: "none", remaining: 0, dedupDecision: "no_candidates" }),
+    ]);
+    expect(final.synced).toBe(3);
+    expect(final.total).toBe(3);
+    expect(final.remaining).toBe(0);
+    expect(final.done).toBe(true);
+    expect(final.message).toBe("All caught up.");
+    expect(loopPercent(final)).toBe(100);
+  });
+
+  it("finishes without a trailing none when remaining hits 0", () => {
+    const final = drive([
+      ok({ status: "synced", remaining: 1, workout: { title: "A" } }),
+      ok({ status: "synced", remaining: 0, workout: { title: "B" } }),
+    ]);
+    expect(final.synced).toBe(2);
+    expect(final.done).toBe(true);
+  });
+});
+
+describe("stepLoop — termination branches", () => {
+  it("busy (claim_lost) stops immediately", () => {
+    const { state, cont } = stepLoop(initialLoopState, ok({ status: "deferred", dedupDecision: "claim_lost", remaining: 5 }));
+    expect(cont).toBe(false);
+    expect(state.message).toMatch(/already running/);
+  });
+
+  it("error stops and classifies the branch", () => {
+    const { state, cont } = stepLoop(initialLoopState, ok({ status: "error", error: "Garmin requires upload consent" }));
+    expect(cont).toBe(false);
+    expect(state.errorKind).toBe("consent");
+    expect(errorHint(state.errorKind!)).toMatch(/consent/i);
+  });
+
+  it("401 stops with an unauthorized prompt before any work", () => {
+    const { state, cont } = stepLoop(initialLoopState, { httpStatus: 401, result: {} });
+    expect(cont).toBe(false);
+    expect(state.errorKind).toBe("unauthorized");
+    expect(state.message).toMatch(/Sign in/);
+  });
+
+  it("nothing to sync (immediate none) → caught up, 0 synced", () => {
+    const { state, cont } = stepLoop(initialLoopState, ok({ status: "none", remaining: 0, dedupDecision: "no_candidates" }));
+    expect(cont).toBe(false);
+    expect(state.synced).toBe(0);
+    expect(state.message).toBe("All caught up.");
+  });
+
+  it("a mid-run error after one synced keeps the synced count", () => {
+    const final = drive([
+      ok({ status: "synced", remaining: 2, workout: { title: "A" } }),
+      ok({ status: "error", error: "Login failed" }),
+      ok({ status: "synced", remaining: 0 }), // never reached
+    ]);
+    expect(final.synced).toBe(1);
+    expect(final.errorKind).toBe("garmin_auth");
+  });
+});
+
+describe("loopPercent", () => {
+  it("is 0 before the total is known", () => {
+    expect(loopPercent(initialLoopState)).toBe(0);
+  });
+});

--- a/web/lib/sync-loop.ts
+++ b/web/lib/sync-loop.ts
@@ -1,0 +1,135 @@
+/**
+ * Pure reducer for the dashboard live sync loop — ports the Python syncNow()
+ * client loop over /api/sync-one. Kept free of fetch/DOM so it can be unit
+ * tested exhaustively; the SyncLoop component drives it.
+ *
+ * Each step feeds the HTTP status + the SyncOneResult of one /api/sync-one call
+ * and returns the next state plus whether the loop should continue. The loop
+ * terminates on: nothing-left (status "none"), unauthorized (401), a busy claim
+ * (dedupDecision "claim_lost"), any error, or a caught network failure.
+ */
+
+export interface SyncOneLike {
+  status?: "synced" | "skipped" | "deferred" | "dry_run" | "none" | "error";
+  remaining?: number;
+  dedupDecision?: string;
+  workout?: { title?: string | null } | null;
+  garminActivityId?: number | null;
+  error?: string | null;
+}
+
+export type ErrorKind = "consent" | "hevy_key" | "garmin_auth" | "generic" | "unauthorized";
+
+export interface LoopState {
+  started: boolean;
+  total: number;
+  synced: number;
+  skipped: number;
+  remaining: number;
+  currentTitle: string | null;
+  done: boolean;
+  message: string | null;
+  errorKind: ErrorKind | null;
+}
+
+export const initialLoopState: LoopState = {
+  started: false,
+  total: 0,
+  synced: 0,
+  skipped: 0,
+  remaining: 0,
+  currentTitle: null,
+  done: false,
+  message: null,
+  errorKind: null,
+};
+
+/** Classify an /api/sync-one error string into an actionable branch. */
+export function classifyError(error: string): ErrorKind {
+  if (/consent|upload consent/i.test(error)) return "consent";
+  if (/Hevy API key/i.test(error)) return "hevy_key";
+  if (/login failed|\bauth\b|oauth|\btoken\b/i.test(error)) return "garmin_auth";
+  return "generic";
+}
+
+/** Percent complete (0–100) for the progress bar. */
+export function loopPercent(s: LoopState): number {
+  if (!s.total) return 0;
+  return Math.min(100, Math.round(((s.synced + s.skipped) / s.total) * 100));
+}
+
+export interface StepInput {
+  httpStatus: number;
+  result: SyncOneLike;
+}
+
+export interface StepOutput {
+  state: LoopState;
+  cont: boolean;
+}
+
+/** Advance the loop one iteration. */
+export function stepLoop(prev: LoopState, input: StepInput): StepOutput {
+  const { httpStatus, result } = input;
+  const s = { ...prev };
+
+  // Unauthorized live sync → stop and prompt to sign in.
+  if (httpStatus === 401) {
+    return { state: { ...s, done: true, errorKind: "unauthorized", message: "Sign in to sync." }, cont: false };
+  }
+  // Any non-OK HTTP → stop with the server message.
+  if (httpStatus >= 400) {
+    return {
+      state: { ...s, done: true, errorKind: "generic", message: result.error ?? `Sync failed (${httpStatus}).` },
+      cont: false,
+    };
+  }
+
+  const status = result.status;
+  const remaining = typeof result.remaining === "number" ? result.remaining : s.remaining;
+
+  if (status === "error") {
+    const kind = classifyError(result.error ?? "");
+    return { state: { ...s, done: true, errorKind: kind, message: result.error ?? "Sync error." }, cont: false };
+  }
+  if (result.dedupDecision === "claim_lost") {
+    return { state: { ...s, done: true, message: "Another sync is already running." }, cont: false };
+  }
+  if (status === "none") {
+    return { state: { ...s, remaining: 0, done: true, message: "All caught up." }, cont: false };
+  }
+
+  if (status === "synced") {
+    s.synced += 1;
+    s.currentTitle = result.workout?.title ?? s.currentTitle;
+  } else if (status === "skipped" || status === "deferred") {
+    s.skipped += 1;
+    s.currentTitle = result.workout?.title ?? s.currentTitle;
+  }
+  // Seed the total from the first productive iteration (done + remaining).
+  if (!s.started && (status === "synced" || status === "skipped" || status === "deferred")) {
+    s.started = true;
+    s.total = s.synced + s.skipped + remaining;
+  }
+  s.remaining = remaining;
+
+  // Keep going while work remains; otherwise finish.
+  if (remaining > 0) return { state: s, cont: true };
+  return { state: { ...s, done: true, message: "All caught up." }, cont: false };
+}
+
+/** Human message for an error kind (with an actionable hint). */
+export function errorHint(kind: ErrorKind): string {
+  switch (kind) {
+    case "consent":
+      return "Garmin needs upload consent. Enable third-party uploads in your Garmin Connect settings, then retry.";
+    case "hevy_key":
+      return "Your Hevy API key looks expired. Update it on Setup, then retry.";
+    case "garmin_auth":
+      return "Garmin sign-in expired. Reconnect Garmin on Setup, then retry.";
+    case "unauthorized":
+      return "Sign in to run a sync.";
+    default:
+      return "Something went wrong during the sync.";
+  }
+}


### PR DESCRIPTION
Parity pass — the dashboard **live sync loop**, the audit's headline gap. The Next.js dashboard fired `/api/sync-one` once; the Python `syncNow()` runs a client loop with live progress. Ported it.

## What
- **`lib/sync-loop.ts`** — a pure, exhaustively-tested reducer. `stepLoop(state, {httpStatus, result})` feeds one `/api/sync-one` result and returns the next state + a continue flag. Terminates on nothing-left (`status:"none"`), unauthorized (401), a busy claim (`dedupDecision:"claim_lost"`), any error, or a caught failure. `classifyError` maps the error string to the same branches the Python loop handles (Garmin upload-consent, expired Hevy key, expired Garmin auth).
- **`components/sync-loop.tsx`** — drives the reducer: Start (inline-confirmed, since each iteration is a real Garmin upload) → loops `/api/sync-one?live=1` with a live progress bar, **On Garmin / Pending / Synced** counts, the current workout, and a **Stop** button; shows an actionable hint on each error branch. Wired into the dashboard between Preview/Sync-now and the batch dispatcher.

## Verification
- **165 web tests pass** (9 new reducer tests: clean 3-workout run → 100% + "All caught up", busy/error/401/none termination, mid-run error keeps the count, error classification), tsc clean.
- **Fetch-mock validated** (standalone Chromium): mocking a 3-workout `/api/sync-one` sequence, the loop drove the bar to 100% with counts On Garmin 3 / Pending 0 / Synced 3 and "All caught up." — **zero real `/api/sync-one` calls against staging's real tokens** (the hard constraint).

Part of the 1:1 parity effort. Closes #415
