### PR TITLE
Web parity: mappings — full searchable table (all built-in + custom) + expandable rows

### DIFF
--- a/web/app/mappings/page.tsx
+++ b/web/app/mappings/page.tsx
@@ -5,6 +5,7 @@ import {
   categoryName,
 } from "@/lib/garmin-categories";
 import { DeleteMappingButton, MappingForm } from "@/components/mapping-form";
+import { MappingsTable } from "@/components/mappings-table";
 
 // Queries the live hevy2garmin Postgres per request — never at build time.
 export const dynamic = "force-dynamic";
@@ -18,14 +19,12 @@ interface CustomMapping {
 interface MappingsData {
   dbConfigured: boolean;
   custom: CustomMapping[];
-  builtinCount: number;
-  builtinSample: Array<{ name: string; category: number; subcategory: number }>;
+  builtin: Array<{ name: string; category: number; subcategory: number }>;
 }
 
 async function loadMappings(): Promise<MappingsData> {
   // The built-in map ships with the package — available regardless of DB state.
-  const builtinEntries = Object.entries(HEVY_TO_GARMIN);
-  const builtinSample = builtinEntries.slice(0, 12).map(([name, pair]) => ({
+  const builtin = Object.entries(HEVY_TO_GARMIN).map(([name, pair]) => ({
     name,
     category: pair[0],
     subcategory: pair[1],
@@ -35,12 +34,7 @@ async function loadMappings(): Promise<MappingsData> {
   try {
     sql = getDb();
   } catch {
-    return {
-      dbConfigured: false,
-      custom: [],
-      builtinCount: builtinEntries.length,
-      builtinSample,
-    };
+    return { dbConfigured: false, custom: [], builtin };
   }
 
   const rows = await sql`
@@ -56,8 +50,7 @@ async function loadMappings(): Promise<MappingsData> {
       category: Number(r.category),
       subcategory: Number(r.subcategory),
     })),
-    builtinCount: builtinEntries.length,
-    builtinSample,
+    builtin,
   };
 }
 
@@ -69,7 +62,9 @@ export default async function MappingsPage() {
       <header className="mb-6">
         <h1 className="text-2xl font-bold text-text">Exercise mappings</h1>
         <p className="mt-1 text-sm text-text-secondary">
-          How Hevy exercises map to Garmin FIT exercise categories.
+          {data.builtin.length} Hevy exercises mapped to Garmin FIT categories.
+          When you upload a workout, each exercise is translated so it displays
+          correctly in Garmin Connect.
         </p>
       </header>
 
@@ -126,42 +121,17 @@ export default async function MappingsPage() {
         )}
       </section>
 
-      {/* Built-in map */}
+      {/* Full mapping table (built-in + custom, searchable) */}
       <section>
-        <h2 className="mb-1 text-lg font-semibold text-text">
-          Built-in map
-        </h2>
-        <p className="mb-3 text-sm text-text-secondary">
-          {data.builtinCount} exercises are mapped out of the box. Sample:
-        </p>
-        <div className="overflow-x-auto rounded-xl border border-border bg-surface-elevated">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-text-muted">
-                <th className="px-4 py-2 font-medium">Hevy exercise</th>
-                <th className="px-4 py-2 font-medium">Garmin category</th>
-                <th className="px-4 py-2 text-right font-medium">Cat</th>
-                <th className="px-4 py-2 text-right font-medium">Sub</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-border">
-              {data.builtinSample.map((b) => (
-                <tr key={b.name}>
-                  <td className="px-4 py-2 font-medium text-text">{b.name}</td>
-                  <td className="px-4 py-2 text-text-secondary">
-                    {categoryName(b.category)}
-                  </td>
-                  <td className="px-4 py-2 text-right tabular-nums text-text-muted">
-                    {b.category}
-                  </td>
-                  <td className="px-4 py-2 text-right tabular-nums text-text-muted">
-                    {b.subcategory}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+        <h2 className="mb-3 text-lg font-semibold text-text">All mappings</h2>
+        <MappingsTable
+          builtin={data.builtin}
+          custom={data.custom.map((m) => ({
+            name: m.hevy_name,
+            category: m.category,
+            subcategory: m.subcategory,
+          }))}
+        />
       </section>
     </main>
   );

--- a/web/components/mappings-table.tsx
+++ b/web/components/mappings-table.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { Fragment, useMemo, useState } from "react";
+import { categoryName } from "@/lib/garmin-categories";
+
+interface Entry {
+  name: string;
+  category: number;
+  subcategory: number;
+  source: "custom" | "built-in";
+}
+
+/**
+ * The full exercise-mapping table — ports the Python mappings table: every
+ * built-in AND custom mapping (a custom entry overrides the built-in for the
+ * same Hevy name and is marked "custom"), a live search filter, and rows that
+ * expand to a detail panel. Replaces the previous 12-row built-in sample.
+ */
+export function MappingsTable({
+  builtin,
+  custom,
+}: {
+  builtin: Array<{ name: string; category: number; subcategory: number }>;
+  custom: Array<{ name: string; category: number; subcategory: number }>;
+}) {
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState<string | null>(null);
+
+  const entries = useMemo<Entry[]>(() => {
+    const byName = new Map<string, Entry>();
+    for (const b of builtin) byName.set(b.name, { ...b, source: "built-in" });
+    for (const c of custom) byName.set(c.name, { ...c, source: "custom" }); // custom overrides
+    return Array.from(byName.values()).sort((a, b) => a.name.localeCompare(b.name));
+  }, [builtin, custom]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return entries;
+    return entries.filter(
+      (e) => e.name.toLowerCase().includes(q) || categoryName(e.category).toLowerCase().includes(q),
+    );
+  }, [entries, query]);
+
+  return (
+    <div>
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <input
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search exercises…"
+          aria-label="Search exercises"
+          className="w-full max-w-xs rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text focus:border-teal focus:outline-none"
+        />
+        <span className="text-xs text-text-muted tabular-nums">
+          {filtered.length} of {entries.length}
+        </span>
+      </div>
+      <div className="overflow-x-auto rounded-xl border border-border bg-surface-elevated">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-border text-left text-xs uppercase tracking-wide text-text-muted">
+              <th className="px-4 py-2 font-medium">Hevy exercise</th>
+              <th className="px-4 py-2 font-medium">Garmin category</th>
+              <th className="px-4 py-2 text-right font-medium">Cat</th>
+              <th className="px-4 py-2 text-right font-medium">Sub</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {filtered.length === 0 ? (
+              <tr>
+                <td colSpan={4} className="px-4 py-6 text-center text-sm text-text-muted">
+                  No exercises match “{query}”.
+                </td>
+              </tr>
+            ) : (
+              filtered.map((e) => {
+                const isOpen = open === e.name;
+                return (
+                  <Fragment key={e.name}>
+                    <tr
+                      onClick={() => setOpen(isOpen ? null : e.name)}
+                      className="cursor-pointer hover:bg-surface-active/40"
+                    >
+                      <td className="px-4 py-2 font-medium text-text">
+                        {e.name}
+                        {e.source === "custom" && (
+                          <span className="ml-2 rounded-full bg-teal/15 px-1.5 py-0.5 text-[10px] font-medium text-teal">
+                            custom
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-4 py-2 text-text-secondary">{categoryName(e.category)}</td>
+                      <td className="px-4 py-2 text-right tabular-nums text-text-muted">{e.category}</td>
+                      <td className="px-4 py-2 text-right tabular-nums text-text-muted">{e.subcategory}</td>
+                    </tr>
+                    {isOpen && (
+                      <tr className="bg-surface/60">
+                        <td colSpan={4} className="px-4 py-3">
+                          <dl className="grid grid-cols-2 gap-x-6 gap-y-1 text-xs sm:grid-cols-4">
+                            <div>
+                              <dt className="text-text-muted">Hevy name</dt>
+                              <dd className="text-text">{e.name}</dd>
+                            </div>
+                            <div>
+                              <dt className="text-text-muted">FIT category</dt>
+                              <dd className="text-text">{categoryName(e.category)} ({e.category})</dd>
+                            </div>
+                            <div>
+                              <dt className="text-text-muted">FIT sub-category</dt>
+                              <dd className="text-text">{e.subcategory}</dd>
+                            </div>
+                            <div>
+                              <dt className="text-text-muted">Source</dt>
+                              <dd className="text-text">{e.source === "custom" ? "Custom" : "Built-in"}</dd>
+                            </div>
+                          </dl>
+                          <p className="mt-2 text-xs text-text-muted">
+                            {e.source === "custom"
+                              ? "This custom mapping overrides the built-in map for this exact Hevy exercise name."
+                              : "Built-in mapping. Add a custom mapping above to override it."}
+                          </p>
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Parity pass — the mappings page's biggest divergence. The Next.js page rendered only a 12-row built-in **sample** (`slice(0,12)`) and custom mappings weren't in the table at all.

## What
- New `MappingsTable` client component renders the **full** map: every built-in AND custom entry (a custom mapping overrides the built-in for the same Hevy name and is tagged `custom`), sorted by name.
- **Live search** filter (by exercise name or Garmin category), with an "N of M" count.
- **Clickable rows** that expand to a detail panel (Hevy name / FIT category+id / FIT sub-category / Source + an explanatory line).
- Header now shows the real total count and the Python description copy.
- The custom-mappings management list (add / delete) is unchanged.

## Verification
- **169 web tests pass**, tsc clean, React Fragment keys correct.
- **Screenshot validated** (standalone Chromium): the table holds **450 entries** (not 12), the search box filters live ("bench" → 40 of 450), custom rows show the `custom` badge, and the custom-mappings list renders above it.

Follow-up (separate PR): the unmapped-exercises card, which needs a Hevy recent-workout data source (`_get_unmapped_exercises()`).

Part of the 1:1 parity effort. Closes #417
