### PR TITLE
Web parity: routines list — search filter + count

### DIFF
--- a/web/components/hevy-routines-list.tsx
+++ b/web/components/hevy-routines-list.tsx
@@ -132,6 +132,7 @@ export function HevyRoutinesList() {
   const [phase, setPhase] = useState<"loading" | "ready">("loading");
   const [routines, setRoutines] = useState<Routine[]>([]);
   const [note, setNote] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
 
   useEffect(() => {
     let alive = true;
@@ -153,9 +154,25 @@ export function HevyRoutinesList() {
     };
   }, []);
 
+  const filtered = query.trim()
+    ? routines.filter((r) => r.title.toLowerCase().includes(query.trim().toLowerCase()))
+    : routines;
+
   return (
     <section className="mb-8">
-      <h2 className="mb-3 text-lg font-semibold text-text">Your Hevy routines</h2>
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <h2 className="text-lg font-semibold text-text">Your Hevy routines</h2>
+        {routines.length > 0 && (
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search routines…"
+            aria-label="Search routines"
+            className="w-full max-w-xs rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text focus:border-teal focus:outline-none"
+          />
+        )}
+      </div>
       {phase === "loading" ? (
         <div className="rounded-lg border border-border bg-surface p-6 text-center text-sm text-text-muted">
           Loading routines from Hevy…
@@ -164,12 +181,21 @@ export function HevyRoutinesList() {
         <div className="rounded-lg border border-border bg-surface p-6 text-center text-sm text-text-muted">
           {note ? `Couldn't load routines: ${note}` : "No routines found in Hevy."}
         </div>
+      ) : filtered.length === 0 ? (
+        <div className="rounded-lg border border-border bg-surface p-6 text-center text-sm text-text-muted">
+          No routines match “{query}”.
+        </div>
       ) : (
-        <ul className="divide-y divide-border overflow-hidden rounded-xl border border-border bg-surface-elevated">
-          {routines.map((r) => (
-            <RoutineRow key={r.id} r={r} />
-          ))}
-        </ul>
+        <>
+          <ul className="divide-y divide-border overflow-hidden rounded-xl border border-border bg-surface-elevated">
+            {filtered.map((r) => (
+              <RoutineRow key={r.id} r={r} />
+            ))}
+          </ul>
+          <p className="mt-2 text-xs text-text-muted tabular-nums">
+            {filtered.length} of {routines.length} routine{routines.length === 1 ? "" : "s"}
+          </p>
+        </>
       )}
     </section>
   );


### PR DESCRIPTION
Parity pass — routines list search. The Python routines page has a Search input; the Next.js list had none.

## What
Adds a live search input (filters the Hevy routines by title) and an "N of M routines" count to `HevyRoutinesList`, with a "no match" empty state.

## Verification
Full suite green, tsc clean. Screenshot validated (standalone Chromium, fetch-mocked `/api/hevy-routines` since staging's Hevy key returns 401): typing "push" filters 3 routines to the one match with "1 of 3 routines".

Follow-up (separate PR): bulk "Sync all" + segmented On-Garmin/Pending filter + recurring schedule — bulk sync fires real Garmin writes, so it needs the same fetch-mock validation.

Closes #421
