### PR TITLE
Web parity: dashboard polish — auto-sync interval select + Recent 'All' link + Garmin CTA

### DIFF
--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -40,6 +40,7 @@ interface DashboardData {
   recent: RecentWorkout[];
   syncLog: SyncLogEntry[];
   autoSyncEnabled: boolean;
+  autoSyncInterval: number;
 }
 
 const EMPTY: DashboardData = {
@@ -56,6 +57,7 @@ const EMPTY: DashboardData = {
   recent: [],
   syncLog: [],
   autoSyncEnabled: false,
+  autoSyncInterval: 120,
 };
 
 async function loadDashboard(): Promise<DashboardData> {
@@ -152,6 +154,7 @@ async function loadDashboard(): Promise<DashboardData> {
       trigger: r.trigger ?? "manual",
     })),
     autoSyncEnabled: Boolean(autoSyncValue.enabled),
+    autoSyncInterval: Number(autoSyncValue.interval_minutes) || 120,
   };
 }
 
@@ -242,6 +245,24 @@ export default async function DashboardPage() {
         <ConnectionBadge label="Garmin Connect" connected={data.garminConnected} />
       </section>
 
+      {data.dbConfigured && (!data.hevyConnected || !data.garminConnected) && (
+        <div className="mb-6 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-warm/40 bg-warm/10 p-4">
+          <p className="text-sm text-warm">
+            {!data.hevyConnected && !data.garminConnected
+              ? "Connect Hevy and Garmin to start syncing."
+              : !data.garminConnected
+                ? "Garmin isn't connected — connect it to upload workouts."
+                : "Hevy isn't connected — connect it to pull workouts."}
+          </p>
+          <a
+            href="/setup"
+            className="rounded-lg bg-warm/20 px-3 py-1.5 text-xs font-medium text-warm transition-colors hover:bg-warm/30"
+          >
+            {!data.garminConnected ? "Connect Garmin" : "Connect Hevy"} →
+          </a>
+        </div>
+      )}
+
       {/* Stat cards */}
       <section className="mb-8 grid grid-cols-2 gap-3 sm:grid-cols-3">
         <StatCard label="On Garmin" value={data.totalSynced} accent="text-teal" />
@@ -278,12 +299,19 @@ export default async function DashboardPage() {
       </div>
 
       <div className="mb-8">
-        <AutoSyncToggle enabled={data.autoSyncEnabled} />
+        <AutoSyncToggle enabled={data.autoSyncEnabled} interval={data.autoSyncInterval} />
       </div>
 
       {/* Recent synced workouts */}
       <section className="mb-8">
-        <h2 className="mb-3 text-lg font-semibold text-text">Recent workouts</h2>
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-text">Recent workouts</h2>
+          {data.recent.length > 0 && (
+            <a href="/history" className="text-xs font-medium text-teal underline">
+              All →
+            </a>
+          )}
+        </div>
         {data.recent.length === 0 ? (
           <div className="rounded-lg border border-border bg-surface p-6 text-center text-sm text-text-muted">
             No synced workouts yet.

--- a/web/components/autosync-toggle.tsx
+++ b/web/components/autosync-toggle.tsx
@@ -3,12 +3,20 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
+const INTERVALS = [30, 60, 120, 240, 360, 720, 1440];
+function fmtInterval(m: number): string {
+  if (m < 60) return `${m} min`;
+  const h = m / 60;
+  return h === 1 ? "1 hour" : h < 24 ? `${h} hours` : "1 day";
+}
+
 /**
- * A compact on/off switch for scheduled auto-sync, for the dashboard. Posts to
- * /api/toggle-autosync (DB-only) and refreshes. The same value is editable in
- * Settings; this is the quick toggle.
+ * A compact on/off switch for scheduled auto-sync, for the dashboard, with an
+ * interval selector shown when it's on. The toggle posts to /api/toggle-autosync
+ * (DB-only) and the interval to /api/settings (auto_sync.interval_minutes) —
+ * both editable in Settings too; this is the quick control.
  */
-export function AutoSyncToggle({ enabled }: { enabled: boolean }) {
+export function AutoSyncToggle({ enabled, interval = 120 }: { enabled: boolean; interval?: number }) {
   const router = useRouter();
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -35,12 +43,36 @@ export function AutoSyncToggle({ enabled }: { enabled: boolean }) {
     }
   }
 
+  async function changeInterval(minutes: number) {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/settings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ auto_sync: { interval_minutes: minutes } }),
+      });
+      const d = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      if (!res.ok || !d.ok) {
+        setError(d.error ?? `Request failed (${res.status}).`);
+        return;
+      }
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
   return (
     <div className="flex items-center gap-3 rounded-lg border border-border bg-surface px-4 py-3">
       <div className="flex-1">
         <div className="text-sm font-medium text-text">Auto-sync</div>
         <div className="text-xs text-text-muted">
-          {enabled ? "On — new workouts sync on a schedule." : "Off — sync only when you run it."}
+          {enabled
+            ? `On — new workouts sync every ${fmtInterval(interval)}.`
+            : "Off — sync only when you run it."}
         </div>
         {error && (
           <div className="mt-1 text-xs text-danger" role="alert">
@@ -48,6 +80,21 @@ export function AutoSyncToggle({ enabled }: { enabled: boolean }) {
           </div>
         )}
       </div>
+      {enabled && (
+        <select
+          value={interval}
+          onChange={(e) => changeInterval(Number.parseInt(e.target.value, 10))}
+          disabled={busy}
+          aria-label="Auto-sync interval"
+          className="rounded-lg border border-border bg-surface px-2 py-1.5 text-xs text-text focus:border-teal focus:outline-none disabled:opacity-50"
+        >
+          {INTERVALS.map((m) => (
+            <option key={m} value={m}>
+              {fmtInterval(m)}
+            </option>
+          ))}
+        </select>
+      )}
       <button
         type="button"
         onClick={toggle}


### PR DESCRIPTION
Parity pass — dashboard polish (follow-up to #416/#420).

## What
- **Auto-sync interval `<select>`** (30 min–24 h) shown next to the toggle when auto-sync is on; posts to `/api/settings` (`auto_sync.interval_minutes`). The label now names the interval.
- **"All →" link** on Recent workouts → `/history`.
- **Not-connected banner** with a Connect Garmin / Connect Hevy CTA → `/setup`, shown when a platform isn't connected.

## Verification
Full suite green, tsc clean. The three additions are conditional renders; on staging their trigger conditions aren't met (auto-sync off, 0 recent workouts, both platforms connected), and curl confirms they're correctly hidden. I did not screenshot them enabled because forcing the conditions would flip staging state (enabling auto-sync could trip the demo cron). The dashboard structure itself was screenshot-validated in #420.

Follow-up (separate PR): the decorative SVG pipeline diagram.

Closes #423
