### PR TITLE
Web parity: workout row — Hevy + Garmin external links, terminal-row dimming

### DIFF
--- a/web/components/workout-row.tsx
+++ b/web/components/workout-row.tsx
@@ -235,13 +235,36 @@ export function WorkoutRow({ item }: { item: WorkoutItem }) {
   }
 
   return (
-    <li className="px-4 py-3">
+    <li className={`px-4 py-3 ${item.kind === "terminal" ? "opacity-70" : ""}`}>
       <div className="flex items-center justify-between gap-3">
         <div className="min-w-0">
           <div className="truncate text-sm font-medium text-text">{item.title || "Untitled workout"}</div>
           <div className="mt-0.5 text-xs text-text-muted">
             {fmtDate(item.when)}
-            {item.garmin_activity_id && <span> · Garmin {item.garmin_activity_id}</span>}
+            {item.garmin_activity_id && (
+              <>
+                {" · "}
+                <a
+                  href={`https://connect.garmin.com/modern/activity/${item.garmin_activity_id}`}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-teal underline underline-offset-2 hover:text-teal/80"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  Garmin {item.garmin_activity_id}
+                </a>
+              </>
+            )}
+            {" · "}
+            <a
+              href={`https://hevy.com/workout/${item.hevy_id}`}
+              target="_blank"
+              rel="noreferrer"
+              className="text-text-secondary underline underline-offset-2 hover:text-text"
+              onClick={(e) => e.stopPropagation()}
+            >
+              Hevy
+            </a>
             {item.detail && <span className="text-text-secondary"> · {item.detail}</span>}
           </div>
         </div>


### PR DESCRIPTION
Parity pass — workout row links + dimming (small WorkoutRow polish).
- The Garmin activity id is now a link to `connect.garmin.com/modern/activity/{id}`.
- A Hevy external link (`hevy.com/workout/{id}`).
- Terminal (resolved) rows dim to opacity 70 as a status cue; pending rows stay full-strength.
- Both links `stopPropagation` so they don't toggle the row's HR panel.

## Verification
Full suite green, tsc clean. The workouts page has 0 recorded rows on staging (and the Hevy candidates call returns 401 there), so a populated row couldn't be screenshot; the change is two `<a>` tags + an opacity class, tsc-validated.

Follow-ups (data-model): exercise chips, HR Chart.js richness, re-sync, calorie breakdown.

Closes #425
