### PR TITLE
Web parity: mappings — per-row Edit/Override (prefill the form)

### DIFF
--- a/web/app/mappings/page.tsx
+++ b/web/app/mappings/page.tsx
@@ -76,7 +76,7 @@ export default async function MappingsPage() {
       )}
 
       {/* Add a custom mapping */}
-      <section className="mb-8">
+      <section className="mb-8" id="mapping-form">
         <h2 className="mb-3 text-lg font-semibold text-text">
           Add a custom mapping
         </h2>

--- a/web/components/mapping-form.tsx
+++ b/web/components/mapping-form.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useEffect, useState } from "react";
 
 interface CategoryOption {
   id: number;
@@ -13,14 +13,38 @@ interface CategoryOption {
  * refreshes the server-rendered mappings list on success. The category dropdown
  * is seeded from the server (which reads /api/garmin-categories' source map), so
  * this component does no fetching of its own.
+ *
+ * When the mappings table's Edit/Override button sets ?edit=name&cat=c&sub=s,
+ * the form prefills those values so an existing (or built-in) mapping can be
+ * overridden in place. Wrapped in Suspense because useSearchParams requires it.
  */
 export function MappingForm({ categories }: { categories: CategoryOption[] }) {
+  return (
+    <Suspense fallback={<MappingFormInner categories={categories} />}>
+      <MappingFormInner categories={categories} />
+    </Suspense>
+  );
+}
+
+function MappingFormInner({ categories }: { categories: CategoryOption[] }) {
   const router = useRouter();
+  const params = useSearchParams();
   const [hevyName, setHevyName] = useState("");
   const [category, setCategory] = useState(categories[0]?.id ?? 0);
   const [subcategory, setSubcategory] = useState("0");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const editName = params.get("edit");
+
+  // Prefill from the table's Edit/Override link.
+  useEffect(() => {
+    if (!editName) return;
+    setHevyName(editName);
+    const cat = Number.parseInt(params.get("cat") ?? "", 10);
+    if (Number.isFinite(cat)) setCategory(cat);
+    const sub = params.get("sub");
+    if (sub != null) setSubcategory(sub);
+  }, [editName, params]);
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
@@ -51,6 +75,7 @@ export function MappingForm({ categories }: { categories: CategoryOption[] }) {
       }
       setHevyName("");
       setSubcategory("0");
+      if (editName) router.replace("/mappings"); // clear the edit param
       router.refresh();
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -60,7 +85,20 @@ export function MappingForm({ categories }: { categories: CategoryOption[] }) {
   }
 
   return (
-    <form onSubmit={submit} className="flex flex-col gap-3 sm:flex-row sm:items-end">
+    <>
+      {editName && (
+        <div className="mb-2 flex items-center gap-2 text-xs text-teal">
+          <span>Overriding <span className="font-medium">{editName}</span></span>
+          <button
+            type="button"
+            onClick={() => { setHevyName(""); setSubcategory("0"); setCategory(categories[0]?.id ?? 0); router.replace("/mappings"); }}
+            className="underline hover:text-teal/80"
+          >
+            Clear
+          </button>
+        </div>
+      )}
+      <form onSubmit={submit} className="flex flex-col gap-3 sm:flex-row sm:items-end">
       <div className="flex-1">
         <label className="mb-1 block text-xs text-text-muted" htmlFor="mf-name">
           Hevy exercise name (exact)
@@ -111,12 +149,13 @@ export function MappingForm({ categories }: { categories: CategoryOption[] }) {
       >
         {busy ? "Saving…" : "Save"}
       </button>
-      {error && (
-        <p className="text-xs text-danger sm:self-center" role="alert">
-          {error}
-        </p>
-      )}
-    </form>
+        {error && (
+          <p className="text-xs text-danger sm:self-center" role="alert">
+            {error}
+          </p>
+        )}
+      </form>
+    </>
   );
 }
 

--- a/web/components/mappings-table.tsx
+++ b/web/components/mappings-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Fragment, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
 import { categoryName } from "@/lib/garmin-categories";
 
 interface Entry {
@@ -23,8 +24,18 @@ export function MappingsTable({
   builtin: Array<{ name: string; category: number; subcategory: number }>;
   custom: Array<{ name: string; category: number; subcategory: number }>;
 }) {
+  const router = useRouter();
   const [query, setQuery] = useState("");
   const [open, setOpen] = useState<string | null>(null);
+
+  function override(e: Entry) {
+    router.replace(
+      `/mappings?edit=${encodeURIComponent(e.name)}&cat=${e.category}&sub=${e.subcategory}`,
+    );
+    if (typeof document !== "undefined") {
+      document.getElementById("mapping-form")?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  }
 
   const entries = useMemo<Entry[]>(() => {
     const byName = new Map<string, Entry>();
@@ -120,6 +131,13 @@ export function MappingsTable({
                               ? "This custom mapping overrides the built-in map for this exact Hevy exercise name."
                               : "Built-in mapping. Add a custom mapping above to override it."}
                           </p>
+                          <button
+                            type="button"
+                            onClick={() => override(e)}
+                            className="mt-2 rounded-lg border border-border px-2.5 py-1 text-xs font-medium text-teal transition-colors hover:bg-surface-active"
+                          >
+                            {e.source === "custom" ? "Edit" : "Override"}
+                          </button>
                         </td>
                       </tr>
                     )}


### PR DESCRIPTION
Parity pass — mappings per-row Edit/Override. The Python mappings table has an Edit/Override affordance that prefills the add-mapping form; the Next.js table had none.

## What
Each row's expandable detail now has an **Override** (built-in) / **Edit** (custom) button that sets `?edit=name&cat=c&sub=s`, scrolls to the add-mapping form, and prefills it (Suspense-wrapped `useSearchParams`), showing an "Overriding X" indicator with a **Clear** reset. Saving clears the param.

## Verification
Full suite green, tsc clean. Screenshot validated (standalone Chromium): clicking Override on the "21s Bicep Curl" row scrolled to the form and prefilled name="21s Bicep Curl", category="Curl (7)", Sub ID=3, with the "Overriding …" indicator.

Follow-up (minor): the sub-ID helper chips.

Closes #427
