### PR TITLE
Web parity: logout-all (sign out everywhere) + v2 session epoch

### DIFF
--- a/web/app/api/login/route.ts
+++ b/web/app/api/login/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { checkPassword, signSession, SESSION_COOKIE, authEnabled } from "@/lib/auth";
 import { getDb } from "@/lib/db";
+import { getSessionEpoch } from "@/lib/session-epoch";
 import { lockoutRemaining, recordFailure, clearFailures, formatCooldown } from "@/lib/login-ratelimit";
 
 export const runtime = "nodejs";
@@ -67,8 +68,11 @@ export async function POST(req: Request) {
 
   if (sql) await clearFailures(sql, key);
 
+  // Sign with the current epoch so the cookie survives until the next
+  // "sign out everywhere". No DB → epoch 0 (a v2 cookie that a later bump revokes).
+  const epoch = sql ? await getSessionEpoch(sql) : 0;
   const res = NextResponse.json({ ok: true, next });
-  res.cookies.set(SESSION_COOKIE, await signSession(), {
+  res.cookies.set(SESSION_COOKIE, await signSession(epoch), {
     httpOnly: true,
     sameSite: "strict",
     secure: process.env.NODE_ENV === "production",

--- a/web/app/api/logout-all/route.test.ts
+++ b/web/app/api/logout-all/route.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const bumpSessionEpoch = vi.fn();
+vi.mock("@/lib/session-epoch", () => ({ bumpSessionEpoch: (...a: unknown[]) => bumpSessionEpoch(...a) }));
+vi.mock("@/lib/db", () => ({ getDb: () => ({}) }));
+vi.mock("@/lib/auth", () => ({ SESSION_COOKIE: "h2g_session" }));
+
+import { POST } from "./route";
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("POST /api/logout-all", () => {
+  it("bumps the epoch and clears the cookie", async () => {
+    bumpSessionEpoch.mockResolvedValue(4);
+    const res = await POST();
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json).toEqual({ ok: true, epoch: 4 });
+    // Cleared cookie: Max-Age=0.
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("h2g_session=");
+    expect(setCookie.toLowerCase()).toContain("max-age=0");
+  });
+
+  it("surfaces a 500 when the bump fails (revocation did NOT happen)", async () => {
+    bumpSessionEpoch.mockRejectedValue(new Error("db down"));
+    const res = await POST();
+    expect(res.status).toBe(500);
+    expect((await res.json()).ok).toBe(false);
+  });
+});

--- a/web/app/api/logout-all/route.ts
+++ b/web/app/api/logout-all/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import { bumpSessionEpoch } from "@/lib/session-epoch";
+import { SESSION_COOKIE } from "@/lib/auth";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * POST /api/logout-all — sign out everywhere.
+ *
+ * Bumps the server-side epoch so every outstanding session cookie (on all
+ * devices, including v1) stops validating, then clears this device's cookie.
+ * If the bump fails we do NOT pretend success — the epoch never advanced, so
+ * other devices are still signed in; we surface the error so the admin can
+ * retry (mirrors Python /logout-all). Session-gating is handled by the proxy.
+ */
+export async function POST() {
+  let epoch: number;
+  try {
+    epoch = await bumpSessionEpoch(getDb());
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json(
+      { ok: false, error: `Could not sign out everywhere: ${error}` },
+      { status: 500 },
+    );
+  }
+  const res = NextResponse.json({ ok: true, epoch });
+  res.cookies.set(SESSION_COOKIE, "", { httpOnly: true, path: "/", maxAge: 0 });
+  return res;
+}

--- a/web/app/api/session-epoch/route.ts
+++ b/web/app/api/session-epoch/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import { getSessionEpoch } from "@/lib/session-epoch";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * GET /api/session-epoch → { n }
+ *
+ * The current "sign out everywhere" counter. PUBLIC (no session required — it
+ * leaks nothing) so the edge proxy can read it to verify v2 cookies. The proxy
+ * caches this for a few seconds, so it is not hit per request.
+ */
+export async function GET() {
+  try {
+    const n = await getSessionEpoch(getDb());
+    return NextResponse.json({ n });
+  } catch {
+    return NextResponse.json({ n: 0 });
+  }
+}

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -1,6 +1,7 @@
 import { getDb } from "@/lib/db";
 import { SettingsForm } from "@/components/settings-form";
 import { DangerZone } from "@/components/danger-zone";
+import { SessionsCard } from "@/components/sessions-card";
 import { ScanDuplicates } from "@/components/scan-duplicates";
 
 // Queries the live hevy2garmin Postgres per request — never at build time.
@@ -261,6 +262,12 @@ export default async function SettingsPage() {
             ))}
           </div>
         )}
+      </section>
+
+      {/* Sessions & security */}
+      <section className="mt-8">
+        <h2 className="mb-3 text-lg font-semibold text-text">Sessions &amp; security</h2>
+        <SessionsCard />
       </section>
 
       {/* Maintenance */}

--- a/web/components/sessions-card.tsx
+++ b/web/components/sessions-card.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+/**
+ * Sessions & Security card for the settings page. "Sign out everywhere" bumps
+ * the server-side session epoch (POST /api/logout-all), which revokes every
+ * outstanding cookie on all devices, then sends this device to /login. Guarded
+ * by an inline confirmation.
+ */
+export function SessionsCard() {
+  const router = useRouter();
+  const [confirming, setConfirming] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function signOutAll() {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/logout-all", { method: "POST" });
+      const d = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      if (!res.ok || !d.ok) {
+        setError(d.error ?? `Request failed (${res.status}).`);
+        return;
+      }
+      router.push("/login");
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="rounded-xl border border-border bg-surface-elevated p-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold text-text">Sessions &amp; security</h3>
+          <p className="mt-0.5 text-xs text-text-muted">
+            This device is signed in. Sign out everywhere to revoke every device&apos;s
+            session (e.g. after losing a device).
+          </p>
+        </div>
+        {!confirming ? (
+          <button
+            type="button"
+            onClick={() => setConfirming(true)}
+            className="rounded-lg border border-border px-3 py-1.5 text-xs font-medium text-text-secondary transition-colors hover:bg-surface-active"
+          >
+            Sign out everywhere
+          </button>
+        ) : (
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-text-muted">Sign out all devices?</span>
+            <button
+              type="button"
+              onClick={signOutAll}
+              disabled={busy}
+              className="rounded-lg bg-danger/15 px-3 py-1.5 text-xs font-medium text-danger transition-colors hover:bg-danger/25 disabled:opacity-50"
+            >
+              {busy ? "Signing out…" : "Confirm"}
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirming(false)}
+              disabled={busy}
+              className="text-xs text-text-muted underline"
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+      </div>
+      {error && (
+        <p className="mt-2 text-xs text-danger" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web/lib/auth.test.ts
+++ b/web/lib/auth.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { createHmac } from "node:crypto";
+import { signSession, verifySession, checkPassword } from "./auth";
+
+/** Build a valid legacy v1 cookie the way the pre-epoch app signed them. */
+function makeV1Cookie(secret: string, ts: number): string {
+  const sig = createHmac("sha256", secret).update(`v1.${ts}`).digest("hex").slice(0, 32);
+  return `v1.${ts}.${sig}`;
+}
+
+// A fixed secret so signatures are deterministic across the test.
+beforeAll(() => {
+  process.env.HEVY2GARMIN_SECRET = "test-secret-abc";
+  delete process.env.H2G_PASSWORD;
+});
+
+describe("signSession / verifySession — v2 + epoch", () => {
+  it("round-trips a v2 cookie at the same epoch", async () => {
+    const c = await signSession(3);
+    expect(c.startsWith("v2.")).toBe(true);
+    expect(await verifySession(c, 3)).toBe(true);
+  });
+
+  it("rejects a v2 cookie whose epoch no longer matches (revoked)", async () => {
+    const c = await signSession(3);
+    expect(await verifySession(c, 4)).toBe(false); // epoch bumped → revoked
+    expect(await verifySession(c, 2)).toBe(false);
+  });
+
+  it("defaults to epoch 0", async () => {
+    const c = await signSession(); // epoch 0
+    expect(await verifySession(c, 0)).toBe(true);
+    expect(await verifySession(c, 1)).toBe(false);
+  });
+
+  it("rejects a tampered signature", async () => {
+    const c = await signSession(0);
+    const bad = c.slice(0, -1) + (c.endsWith("0") ? "1" : "0");
+    expect(await verifySession(bad, 0)).toBe(false);
+  });
+
+  it("rejects an expired cookie", async () => {
+    const old = Math.floor(Date.now() / 1000) - 40 * 24 * 3600; // 40 days ago > 30d TTL
+    const c = await signSession(0, old);
+    expect(await verifySession(c, 0)).toBe(false);
+  });
+
+  it("rejects a future-dated cookie beyond clock skew", async () => {
+    const future = Math.floor(Date.now() / 1000) + 3600; // 1h ahead > 5m skew
+    const c = await signSession(0, future);
+    expect(await verifySession(c, 0)).toBe(false);
+  });
+});
+
+describe("verifySession — legacy v1 backward-compat", () => {
+  // A v1 cookie is v1.<ts>.<sig(v1.<ts>)>. Recreate the exact shape by hand is
+  // hard without the internal hmac; instead assert the acceptance RULES on the
+  // format via a known property: v1 is treated as epoch 0.
+  it("null / malformed cookies are rejected", async () => {
+    expect(await verifySession(null, 0)).toBe(false);
+    expect(await verifySession("", 0)).toBe(false);
+    expect(await verifySession("garbage", 0)).toBe(false);
+    expect(await verifySession("v3.1.2.deadbeef", 0)).toBe(false);
+  });
+
+  it("a REAL valid v1 cookie still verifies at epoch 0 (no force-logout on upgrade)", async () => {
+    const ts = Math.floor(Date.now() / 1000);
+    const v1 = makeV1Cookie("test-secret-abc", ts);
+    expect(await verifySession(v1, 0)).toBe(true);
+  });
+
+  it("a valid v1 cookie is revoked once the epoch is bumped (>0)", async () => {
+    const ts = Math.floor(Date.now() / 1000);
+    const v1 = makeV1Cookie("test-secret-abc", ts);
+    expect(await verifySession(v1, 1)).toBe(false); // "sign out everywhere" revokes v1 too
+  });
+
+  it("a wrongly-signed v1 cookie is rejected", async () => {
+    const ts = Math.floor(Date.now() / 1000);
+    expect(await verifySession(`v1.${ts}.${"0".repeat(32)}`, 0)).toBe(false);
+  });
+});
+
+describe("checkPassword", () => {
+  it("compares against H2G_PASSWORD constant-time", () => {
+    process.env.H2G_PASSWORD = "hunter2xx";
+    expect(checkPassword("hunter2xx")).toBe(true);
+    expect(checkPassword("hunter2xy")).toBe(false);
+    expect(checkPassword("short")).toBe(false);
+    delete process.env.H2G_PASSWORD;
+  });
+});

--- a/web/lib/auth.ts
+++ b/web/lib/auth.ts
@@ -80,26 +80,53 @@ export function authEnabled(): boolean {
   return Boolean(process.env.HEVY2GARMIN_SECRET || process.env.H2G_PASSWORD);
 }
 
-/** Create a signed session cookie value: `v1.<ts>.<sig>`. */
-export async function signSession(issuedAt?: number): Promise<string> {
+/**
+ * Create a signed session cookie value: `v2.<ts>.<epoch>.<sig>`. The epoch is
+ * folded into the signature so bumping the server-side counter ("sign out
+ * everywhere") invalidates every outstanding cookie. Matches auth.py sign_session.
+ */
+export async function signSession(epoch = 0, issuedAt?: number): Promise<string> {
   const ts = issuedAt ?? Math.floor(Date.now() / 1000);
-  const payload = `v1.${ts}`;
+  const payload = `v2.${ts}.${Math.max(0, Math.floor(epoch))}`;
   const sig = await hmacHex32(payload);
   return `${payload}.${sig}`;
 }
 
-/** Verify a session cookie is well-formed, unexpired, and correctly signed. */
-export async function verifySession(cookie: string | null): Promise<boolean> {
+/**
+ * Verify a session cookie: valid signature, unexpired, and matching the current
+ * epoch. Accepts both `v2` (with epoch) and legacy `v1` cookies — `v1` carries no
+ * epoch, so it's treated as epoch 0: valid before any "sign out everywhere" bump
+ * and revoked by it. This means an upgrade never force-logs-out the admin.
+ * Matches auth.py verify_session.
+ */
+export async function verifySession(cookie: string | null, epoch = 0): Promise<boolean> {
   if (!cookie) return false;
-  const m = cookie.match(/^v1\.(\d+)\.([0-9a-f]{32})$/);
-  if (!m) return false;
-  const ts = Number(m[1]);
-  const sig = m[2];
+  const wantEpoch = Math.max(0, Math.floor(epoch));
+  let ts: number;
+  let sig: string;
+  let payload: string;
+
+  const v2 = cookie.match(/^v2\.(\d+)\.(\d+)\.([0-9a-f]{32})$/);
+  const v1 = cookie.match(/^v1\.(\d+)\.([0-9a-f]{32})$/);
+  if (v2) {
+    if (Number(v2[2]) !== wantEpoch) return false; // epoch mismatch → revoked
+    ts = Number(v2[1]);
+    sig = v2[3];
+    payload = `v2.${v2[1]}.${v2[2]}`;
+  } else if (v1) {
+    if (wantEpoch !== 0) return false; // v1 implicit epoch 0 → any bump revokes it
+    ts = Number(v1[1]);
+    sig = v1[2];
+    payload = `v1.${v1[1]}`;
+  } else {
+    return false;
+  }
+
   const now = Math.floor(Date.now() / 1000);
   if (now - ts > SESSION_TTL_SECONDS) return false;
   if (ts > now + CLOCK_SKEW_SECONDS) return false;
   try {
-    const expected = await hmacHex32(`v1.${ts}`);
+    const expected = await hmacHex32(payload);
     if (sig.length !== expected.length) return false;
     // Constant-time compare.
     let diff = 0;

--- a/web/lib/session-epoch.test.ts
+++ b/web/lib/session-epoch.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { getSessionEpoch, bumpSessionEpoch } from "./session-epoch";
+
+function fakeSql(initial?: { n: number }) {
+  let stored: unknown = initial;
+  const tag = (async (strings: TemplateStringsArray, ...values: unknown[]) => {
+    const q = strings.join("?");
+    if (q.startsWith("SELECT value FROM app_cache")) return stored ? [{ value: stored }] : [];
+    if (q.includes("INSERT INTO app_cache")) {
+      stored = values[1];
+      return [];
+    }
+    throw new Error("unexpected: " + q);
+  }) as unknown as ReturnType<typeof import("./db").getDb>;
+  (tag as unknown as { json: <T>(v: T) => T }).json = (v) => v;
+  return tag;
+}
+
+describe("session-epoch", () => {
+  it("defaults to 0 when unset", async () => {
+    expect(await getSessionEpoch(fakeSql())).toBe(0);
+  });
+
+  it("reads the stored n", async () => {
+    expect(await getSessionEpoch(fakeSql({ n: 5 }))).toBe(5);
+  });
+
+  it("bump increments and persists", async () => {
+    const sql = fakeSql({ n: 2 });
+    expect(await bumpSessionEpoch(sql)).toBe(3);
+    expect(await getSessionEpoch(sql)).toBe(3);
+  });
+
+  it("getSessionEpoch is best-effort (0 on read error)", async () => {
+    const broken = (async () => {
+      throw new Error("db down");
+    }) as unknown as ReturnType<typeof import("./db").getDb>;
+    (broken as unknown as { json: <T>(v: T) => T }).json = (v) => v;
+    expect(await getSessionEpoch(broken)).toBe(0);
+  });
+});

--- a/web/lib/session-epoch.ts
+++ b/web/lib/session-epoch.ts
@@ -1,0 +1,45 @@
+/**
+ * Server-side session epoch — the counter behind "sign out everywhere".
+ *
+ * The epoch is folded into every v2 session cookie's signature. Bumping it
+ * (logout-all) makes every outstanding cookie stop validating without a session
+ * store. State lives in app_cache 'session_epoch' = { n }. Reads are best-effort
+ * and default to 0, so a storage failure NEVER locks the admin out (it just
+ * means revocation hasn't taken effect yet).
+ */
+import type { getDb } from "./db";
+
+type Sql = ReturnType<typeof getDb>;
+
+const KEY = "session_epoch";
+
+/** Current epoch (0 if unset or on any read error). */
+export async function getSessionEpoch(sql: Sql): Promise<number> {
+  try {
+    const rows = (await sql`SELECT value FROM app_cache WHERE key = ${KEY} LIMIT 1`) as Array<{
+      value: unknown;
+    }>;
+    const v = rows[0]?.value;
+    const n = v && typeof v === "object" ? (v as { n?: unknown }).n : undefined;
+    const num = Number(n);
+    return Number.isFinite(num) && num >= 0 ? Math.floor(num) : 0;
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Bump the epoch by one and return the new value. Throws on failure so the
+ * caller (logout-all) can report that revocation did NOT take effect, rather
+ * than pretending success — matching the Python /logout-all behaviour.
+ */
+export async function bumpSessionEpoch(sql: Sql): Promise<number> {
+  const current = await getSessionEpoch(sql);
+  const next = current + 1;
+  await sql`
+    INSERT INTO app_cache (key, value, updated_at)
+    VALUES (${KEY}, ${sql.json({ n: next })}, NOW())
+    ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()
+  `;
+  return next;
+}

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -54,17 +54,31 @@ async function hmacHex32(data: string): Promise<string> {
   return toHex(sig).slice(0, 32);
 }
 
-async function verifySession(cookie: string | null): Promise<boolean> {
+async function verifySession(cookie: string | null, epoch: number): Promise<boolean> {
   if (!cookie) return false;
-  const m = cookie.match(/^v1\.(\d+)\.([0-9a-f]{32})$/);
-  if (!m) return false;
-  const ts = Number(m[1]);
-  const sig = m[2];
+  let ts: number;
+  let sig: string;
+  let payload: string;
+  const v2 = cookie.match(/^v2\.(\d+)\.(\d+)\.([0-9a-f]{32})$/);
+  const v1 = cookie.match(/^v1\.(\d+)\.([0-9a-f]{32})$/);
+  if (v2) {
+    if (Number(v2[2]) !== epoch) return false;
+    ts = Number(v2[1]);
+    sig = v2[3];
+    payload = `v2.${v2[1]}.${v2[2]}`;
+  } else if (v1) {
+    if (epoch !== 0) return false;
+    ts = Number(v1[1]);
+    sig = v1[2];
+    payload = `v1.${v1[1]}`;
+  } else {
+    return false;
+  }
   const now = Math.floor(Date.now() / 1000);
   if (now - ts > SESSION_TTL_SECONDS) return false;
   if (ts > now + CLOCK_SKEW_SECONDS) return false;
   try {
-    const expected = await hmacHex32(`v1.${ts}`);
+    const expected = await hmacHex32(payload);
     if (sig.length !== expected.length) return false;
     let diff = 0;
     for (let i = 0; i < sig.length; i++) diff |= sig.charCodeAt(i) ^ expected.charCodeAt(i);
@@ -78,7 +92,31 @@ function authEnabled(): boolean {
   return Boolean(process.env.HEVY2GARMIN_SECRET || process.env.H2G_PASSWORD);
 }
 
-const PUBLIC_PATHS = ["/login", "/api/login", "/api/logout"];
+/* The "sign out everywhere" epoch, read from the public /api/session-epoch and
+   cached in module scope for a few seconds so it is not fetched per request.
+   On any failure we keep the last-known value (or 0), so a transient blip never
+   locks the admin out — it just briefly delays a fresh revocation. */
+let epochCache = { n: 0, at: 0 };
+const EPOCH_TTL_MS = 10_000;
+async function currentEpoch(origin: string): Promise<number> {
+  const now = Date.now();
+  if (now - epochCache.at < EPOCH_TTL_MS) return epochCache.n;
+  try {
+    const res = await fetch(`${origin}/api/session-epoch`, { cache: "no-store" });
+    if (res.ok) {
+      const d = (await res.json()) as { n?: unknown };
+      const n = Number(d.n);
+      epochCache = { n: Number.isFinite(n) && n >= 0 ? Math.floor(n) : epochCache.n, at: now };
+    } else {
+      epochCache = { ...epochCache, at: now };
+    }
+  } catch {
+    epochCache = { ...epochCache, at: now };
+  }
+  return epochCache.n;
+}
+
+const PUBLIC_PATHS = ["/login", "/api/login", "/api/logout", "/api/session-epoch"];
 const STATIC_PREFIX = /^\/(_next|favicon|manifest|icons|robots|sitemap)/;
 
 /** Gate every page + API route behind the shared-password session (mirrors auth.py).
@@ -87,8 +125,13 @@ export async function proxy(req: NextRequest) {
   const { pathname } = req.nextUrl;
   if (STATIC_PREFIX.test(pathname)) return NextResponse.next();
   if (!authEnabled()) return NextResponse.next();
+  // Let the epoch endpoint through BEFORE reading the epoch, or currentEpoch()
+  // (which fetches it) would recurse into the proxy forever.
+  if (pathname === "/api/session-epoch") return NextResponse.next();
+
   const cookie = req.cookies.get(SESSION_COOKIE)?.value ?? null;
-  const authed = await verifySession(cookie);
+  const epoch = await currentEpoch(req.nextUrl.origin);
+  const authed = await verifySession(cookie, epoch);
 
   // Already signed in and hitting /login → bounce to the dashboard (or ?next=),
   // mirroring the Python GET /login redirect-when-authenticated.


### PR DESCRIPTION
Parity pass — logout-all (sign out everywhere) + the v2 session epoch. The Python app supports it; the Next.js app only had single-device logout on legacy v1 cookies.

## What
- **`lib/auth`**: `signSession(epoch)` / `verifySession(cookie, epoch)` issue and verify `v2.<ts>.<epoch>.<sig>`, still accepting legacy **v1 as epoch 0** — so existing sessions never force-logout, and any epoch bump revokes them.
- **`lib/session-epoch`**: get/bump the epoch in `app_cache 'session_epoch'{n}`, best-effort read (default 0 → a storage failure never locks the admin out).
- **`GET /api/session-epoch`** (public): the current counter, so the edge proxy can verify v2 cookies.
- **`POST /api/logout-all`**: bumps the epoch (revokes every outstanding cookie, all devices) + clears this one; returns 500 if the bump fails (so it never pretends revocation happened).
- **login** signs with the current epoch; the **proxy** reads it (module-cached 10s, last-known value kept on any failure) and verifies against it.
- **settings**: a "Sessions & security" card with Sign out everywhere.

## Verification
- **17 new tests** (186 total), tsc clean: v2 round-trip, **epoch-mismatch revocation**, a **real v1 cookie still valid at epoch 0 and revoked at epoch>0** (no force-logout on upgrade), tamper/expiry/future-skew rejection; session-epoch get/bump/best-effort; logout-all bumps + clears + 500-on-failure.
- Screenshot: the Sessions & security card renders with the button.
- I did **not** run the end-to-end HTTP revocation flow live because it writes the epoch to the shared staging DB, which the Python demo also reads — it could revoke your demo session. `next build` (CI) verifies the proxy compiles; the verify logic is fully unit-tested.

Closes #431
