### PR TITLE
Web parity: mappings unmapped-exercises card (detect + quick-map)

### DIFF
--- a/web/app/api/unmapped-exercises/route.ts
+++ b/web/app/api/unmapped-exercises/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { getDb } from "@/lib/db";
+import { getHevyClient } from "@/lib/hevy-sync";
+import { computeUnmapped, type WorkoutLike } from "@/lib/unmapped-exercises";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * GET /api/unmapped-exercises → { unmapped: [{name, count}], total }
+ *
+ * READ-ONLY: fetches recent Hevy workouts and the custom_mappings table, then
+ * reports exercises that don't map to a Garmin FIT category (Unknown/65534) and
+ * have no custom mapping. No Garmin calls and no writes. Mirrors the Python
+ * _get_unmapped_exercises() feeding the "Unmapped Exercises" card.
+ */
+export async function GET() {
+  // Custom-mapped names are excluded (best-effort: no DB → no exclusions).
+  let customNames = new Set<string>();
+  try {
+    const sql = getDb();
+    const rows = (await sql`SELECT hevy_name FROM custom_mappings`) as Array<{ hevy_name: string }>;
+    customNames = new Set(rows.map((r) => String(r.hevy_name).trim().toLowerCase()));
+  } catch {
+    /* no DB / table → treat everything as potentially unmapped */
+  }
+
+  let workouts: WorkoutLike[];
+  try {
+    const client = await getHevyClient();
+    workouts = (await client.getAllWorkouts()) as WorkoutLike[];
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ unmapped: [], total: 0, error }, { status: 502 });
+  }
+
+  const unmapped = computeUnmapped(workouts, customNames);
+  return NextResponse.json({ unmapped, total: unmapped.length });
+}

--- a/web/app/mappings/page.tsx
+++ b/web/app/mappings/page.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/lib/garmin-categories";
 import { DeleteMappingButton, MappingForm } from "@/components/mapping-form";
 import { MappingsTable } from "@/components/mappings-table";
+import { UnmappedCard } from "@/components/unmapped-card";
 
 // Queries the live hevy2garmin Postgres per request — never at build time.
 export const dynamic = "force-dynamic";
@@ -74,6 +75,9 @@ export default async function MappingsPage() {
           unavailable; the built-in map below still works.
         </div>
       )}
+
+      {/* Unmapped exercises (from recent Hevy workouts) */}
+      <UnmappedCard categories={CATEGORY_OPTIONS} />
 
       {/* Add a custom mapping */}
       <section className="mb-8" id="mapping-form">

--- a/web/components/unmapped-card.tsx
+++ b/web/components/unmapped-card.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+interface CategoryOption {
+  id: number;
+  name: string;
+}
+interface Unmapped {
+  name: string;
+  count: number;
+}
+
+/**
+ * The "Unmapped exercises" card — exercises in recent Hevy workouts that don't
+ * map to a Garmin FIT category (they show as "Unknown" on Garmin). Fetches
+ * /api/unmapped-exercises (read-only) on mount and offers a per-exercise
+ * quick-map form (category + sub ID → POST /api/mapping). Hidden when there are
+ * none. Mirrors the Python unmapped-exercises card.
+ */
+export function UnmappedCard({ categories }: { categories: CategoryOption[] }) {
+  const router = useRouter();
+  const [phase, setPhase] = useState<"loading" | "ready">("loading");
+  const [items, setItems] = useState<Unmapped[]>([]);
+
+  useEffect(() => {
+    let alive = true;
+    fetch("/api/unmapped-exercises")
+      .then((r) => r.json())
+      .then((d: { unmapped?: Unmapped[] }) => {
+        if (!alive) return;
+        setItems(Array.isArray(d.unmapped) ? d.unmapped : []);
+        setPhase("ready");
+      })
+      .catch(() => alive && setPhase("ready"));
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  if (phase === "loading" || items.length === 0) return null;
+
+  return (
+    <section className="mb-8 rounded-xl border border-warm/40 bg-warm/10 p-4">
+      <div className="mb-2 flex items-center gap-2">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-warm" aria-hidden="true">
+          <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+          <line x1="12" y1="9" x2="12" y2="13" />
+          <line x1="12" y1="17" x2="12.01" y2="17" />
+        </svg>
+        <h2 className="text-sm font-semibold text-warm">{items.length} unmapped exercise{items.length === 1 ? "" : "s"}</h2>
+      </div>
+      <p className="mb-3 text-xs text-text-muted">
+        These show as &ldquo;Unknown&rdquo; on Garmin. Pick a category to map them.
+      </p>
+      <ul className="space-y-2">
+        {items.map((it) => (
+          <UnmappedRow key={it.name} item={it} categories={categories} onMapped={() => router.refresh()} />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+function UnmappedRow({
+  item,
+  categories,
+  onMapped,
+}: {
+  item: Unmapped;
+  categories: CategoryOption[];
+  onMapped: () => void;
+}) {
+  const [category, setCategory] = useState(categories[0]?.id ?? 0);
+  const [sub, setSub] = useState("0");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  async function map() {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/mapping", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ hevy_name: item.name, category, subcategory: Number.parseInt(sub || "0", 10) }),
+      });
+      const d = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      if (!res.ok || !d.ok) {
+        setError(d.error ?? `Request failed (${res.status}).`);
+        return;
+      }
+      setDone(true);
+      onMapped();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (done) return null;
+
+  return (
+    <li className="rounded-lg border border-border bg-surface p-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-medium text-text">{item.name}</div>
+          <div className="text-xs text-text-muted">{item.count}× in recent workouts</div>
+        </div>
+        <select
+          value={category}
+          onChange={(e) => setCategory(Number.parseInt(e.target.value, 10))}
+          aria-label={`Category for ${item.name}`}
+          className="rounded-lg border border-border bg-surface px-2 py-1.5 text-xs text-text focus:border-teal focus:outline-none"
+        >
+          {categories.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name} ({c.id})
+            </option>
+          ))}
+        </select>
+        <input
+          type="number"
+          min={0}
+          value={sub}
+          onChange={(e) => setSub(e.target.value)}
+          aria-label={`Sub ID for ${item.name}`}
+          className="w-16 rounded-lg border border-border bg-surface px-2 py-1.5 text-xs text-text focus:border-teal focus:outline-none"
+        />
+        <button
+          type="button"
+          onClick={map}
+          disabled={busy}
+          className="rounded-lg bg-teal/20 px-3 py-1.5 text-xs font-medium text-teal transition-colors hover:bg-teal/30 disabled:opacity-50"
+        >
+          {busy ? "…" : "Map"}
+        </button>
+      </div>
+      {error && (
+        <p className="mt-1.5 text-xs text-danger" role="alert">
+          {error}
+        </p>
+      )}
+    </li>
+  );
+}

--- a/web/lib/unmapped-exercises.test.ts
+++ b/web/lib/unmapped-exercises.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Deterministic lookup: names containing "UNK" are Unknown (65534), else mapped.
+vi.mock("hevy2garmin", () => ({
+  lookupExercise: (title: string) => ({
+    category: title.includes("UNK") ? 65534 : 5,
+    subcategory: 0,
+  }),
+}));
+
+import { computeUnmapped, type WorkoutLike } from "./unmapped-exercises";
+
+const wk = (exercises: Array<{ title?: string; name?: string }>): WorkoutLike => ({ exercises });
+
+describe("computeUnmapped", () => {
+  it("counts only Unknown-category exercises, most-frequent first", () => {
+    const workouts = [
+      wk([{ title: "Bench Press" }, { title: "UNK Machine A" }]),
+      wk([{ title: "UNK Machine A" }, { title: "UNK Machine B" }]),
+      wk([{ title: "Squat" }]),
+    ];
+    const res = computeUnmapped(workouts, new Set());
+    expect(res).toEqual([
+      { name: "UNK Machine A", count: 2 },
+      { name: "UNK Machine B", count: 1 },
+    ]);
+  });
+
+  it("excludes exercises that already have a custom mapping", () => {
+    const workouts = [wk([{ title: "UNK Already Mapped" }, { title: "UNK New" }])];
+    const custom = new Set(["unk already mapped"]); // lowercased
+    const res = computeUnmapped(workouts, custom);
+    expect(res).toEqual([{ name: "UNK New", count: 1 }]);
+  });
+
+  it("uses name when title is absent, skips blanks", () => {
+    const workouts = [wk([{ name: "UNK ByName" }, { title: "" }, {}])];
+    expect(computeUnmapped(workouts, new Set())).toEqual([{ name: "UNK ByName", count: 1 }]);
+  });
+
+  it("returns [] when everything maps", () => {
+    expect(computeUnmapped([wk([{ title: "Bench Press" }])], new Set())).toEqual([]);
+  });
+
+  it("tolerates workouts with no exercises array", () => {
+    expect(computeUnmapped([{ exercises: undefined }, {}], new Set())).toEqual([]);
+  });
+});

--- a/web/lib/unmapped-exercises.ts
+++ b/web/lib/unmapped-exercises.ts
@@ -1,0 +1,49 @@
+/**
+ * Detect Hevy exercises that don't map to a Garmin FIT category — ports the
+ * Python _get_unmapped_exercises(). An exercise is "unmapped" when
+ * lookupExercise() returns the Unknown category (65534) AND there is no custom
+ * mapping for its exact name. Pure + testable; the route feeds it real workouts.
+ */
+import { lookupExercise } from "hevy2garmin";
+
+const UNKNOWN_CATEGORY = 65534;
+
+export interface UnmappedExercise {
+  name: string;
+  count: number;
+}
+
+/** A minimal view of a Hevy workout's exercises (payloads carry more fields). */
+export interface WorkoutLike {
+  exercises?: Array<{ title?: string | null; name?: string | null; exercise_template_id?: string | null }> | unknown;
+  [key: string]: unknown;
+}
+
+/**
+ * Count occurrences of unmapped exercises across the given workouts.
+ * `customNames` is the set of lowercased Hevy names that already have a custom
+ * mapping (those are excluded even if the built-in map doesn't know them).
+ */
+export function computeUnmapped(workouts: WorkoutLike[], customNames: Set<string>): UnmappedExercise[] {
+  const counts = new Map<string, number>();
+  for (const w of workouts) {
+    const exs = Array.isArray(w.exercises) ? (w.exercises as Array<Record<string, unknown>>) : [];
+    for (const e of exs) {
+      const title = String((e.title as string) || (e.name as string) || "").trim();
+      if (!title) continue;
+      if (customNames.has(title.toLowerCase())) continue; // already custom-mapped
+      let category: number;
+      try {
+        category = lookupExercise(title, (e.exercise_template_id as string) ?? null).category;
+      } catch {
+        continue;
+      }
+      if (category === UNKNOWN_CATEGORY) {
+        counts.set(title, (counts.get(title) ?? 0) + 1);
+      }
+    }
+  }
+  return Array.from(counts.entries())
+    .map(([name, count]) => ({ name, count }))
+    .sort((a, b) => b.count - a.count || a.name.localeCompare(b.name));
+}


### PR DESCRIPTION
Parity pass — the mappings "Unmapped exercises" card, the biggest remaining mappings gap. The Python page detects exercises in recent Hevy workouts that don't map to a Garmin FIT category and offers to map them; the Next.js app had no data source for this.

## What
- **`lib/unmapped-exercises`**: `computeUnmapped(workouts, customNames)` — pure + testable — counts exercises whose `lookupExercise()` is Unknown (65534) and that have no custom mapping, most-frequent-first.
- **`GET /api/unmapped-exercises`**: READ-ONLY — fetches Hevy workouts + the `custom_mappings` table and runs the detector. No Garmin calls, no writes.
- **`UnmappedCard`**: an amber card (warning icon + "N unmapped exercises") with a per-exercise quick-map form (category select + sub ID → POST /api/mapping); hidden when there are none. Ports the Python `_get_unmapped_exercises()` card.

## Verification
- **5 detection tests** (191 total), tsc clean: Unknown-only counting most-frequent-first, custom-mapped exclusion, name-fallback, empty-when-all-mapped, missing-exercises tolerance.
- **Live read-only detection with the prod Hevy key**: fetched **332 real workouts**, found **0 unmapped** (every exercise already maps) — validates the detector on real data; the card correctly hides at zero. No writes, no Garmin.
- **Screenshot** (fetch-mocked with 3 unmapped): the amber card + quick-map rows render correctly. Map wasn't clicked (it writes a custom_mapping).

Closes #433
