### PR TITLE
Web parity: routines recurring (weekly) schedule

### DIFF
--- a/web/app/api/routines/[hevyId]/schedule/route.ts
+++ b/web/app/api/routines/[hevyId]/schedule/route.ts
@@ -3,6 +3,7 @@ import { cookies } from "next/headers";
 import { scheduleRoutine } from "@/lib/garmin-routine-sync";
 import { getDb } from "@/lib/db";
 import { verifySession, SESSION_COOKIE, authEnabled } from "@/lib/auth";
+import { recurringDates } from "@/lib/recurring-dates";
 
 // Writes a Garmin calendar entry at request time.
 export const dynamic = "force-dynamic";
@@ -37,16 +38,37 @@ export async function POST(
     return NextResponse.json({ error: "hevyId is required." }, { status: 400 });
   }
 
-  let body: { date?: unknown } = {};
+  let body: { date?: unknown; mode?: unknown; weekday?: unknown; start_date?: unknown; weeks?: unknown } = {};
   try {
     const text = await request.text();
     if (text) body = JSON.parse(text);
   } catch {
     return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
   }
-  const date = typeof body.date === "string" ? body.date.trim() : "";
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
-    return NextResponse.json({ error: "A date (YYYY-MM-DD) is required." }, { status: 400 });
+
+  // Resolve the list of dates to schedule: one for a single date, or several
+  // for a weekly recurring schedule.
+  let dates: string[];
+  if (body.mode === "recurring") {
+    const startDate = typeof body.start_date === "string" ? body.start_date.trim() : "";
+    const weekday = Number(body.weekday);
+    const weeks = Number(body.weeks);
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(startDate) || !Number.isFinite(weekday) || !Number.isFinite(weeks)) {
+      return NextResponse.json(
+        { error: "Recurring needs start_date (YYYY-MM-DD), weekday (0-6), and weeks." },
+        { status: 400 },
+      );
+    }
+    dates = recurringDates(startDate, weekday, weeks);
+  } else {
+    const date = typeof body.date === "string" ? body.date.trim() : "";
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+      return NextResponse.json({ error: "A date (YYYY-MM-DD) is required." }, { status: 400 });
+    }
+    dates = [date];
+  }
+  if (dates.length === 0) {
+    return NextResponse.json({ error: "No valid dates to schedule." }, { status: 400 });
   }
 
   if (!(await isAuthorized(request))) {
@@ -75,9 +97,25 @@ export async function POST(
         { status: 409 },
       );
     }
-    const result = await scheduleRoutine(hevyId, garminWorkoutId, date, sql);
-    const code = result.status === "error" ? 502 : 200;
-    return NextResponse.json({ ok: result.status === "scheduled", ...result }, { status: code });
+    // Schedule each date; report how many succeeded.
+    const results = [];
+    let scheduled = 0;
+    for (const d of dates) {
+      const r = await scheduleRoutine(hevyId, garminWorkoutId, d, sql);
+      if (r.status === "scheduled") scheduled += 1;
+      results.push({ date: d, status: r.status, error: r.error });
+    }
+    if (dates.length === 1) {
+      const r = results[0];
+      return NextResponse.json(
+        { ok: r.status === "scheduled", status: r.status, error: r.error, scheduleId: null },
+        { status: r.status === "error" ? 502 : 200 },
+      );
+    }
+    return NextResponse.json(
+      { ok: scheduled > 0, scheduled, total: dates.length, dates: results },
+      { status: scheduled > 0 ? 200 : 502 },
+    );
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);
     return NextResponse.json({ error }, { status: 502 });

--- a/web/components/hevy-routines-list.tsx
+++ b/web/components/hevy-routines-list.tsx
@@ -20,6 +20,9 @@ function RoutineRow({ r }: { r: Routine }) {
   const [synced, setSynced] = useState(false);
   const [showSchedule, setShowSchedule] = useState(false);
   const [date, setDate] = useState("");
+  const [recurring, setRecurring] = useState(false);
+  const [weekday, setWeekday] = useState(1); // Mon
+  const [weeks, setWeeks] = useState("4");
 
   async function sync() {
     setBusy("sync");
@@ -44,25 +47,28 @@ function RoutineRow({ r }: { r: Routine }) {
 
   async function schedule() {
     if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
-      setError("Pick a date first.");
+      setError(recurring ? "Pick a start date first." : "Pick a date first.");
       return;
     }
     setBusy("schedule");
     setError(null);
     setMsg(null);
     try {
+      const payload = recurring
+        ? { mode: "recurring", weekday, start_date: date, weeks: Number.parseInt(weeks || "1", 10) }
+        : { date };
       const res = await fetch(`/api/routines/${encodeURIComponent(r.id)}/schedule`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ date }),
+        body: JSON.stringify(payload),
       });
-      const d = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string };
+      const d = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string; scheduled?: number; total?: number };
       if (!res.ok || !d.ok) {
         setError(d.error ?? `Request failed (${res.status}).`);
         return;
       }
       setShowSchedule(false);
-      setMsg(`Scheduled for ${date}.`);
+      setMsg(recurring ? `Scheduled ${d.scheduled ?? d.total} weekly sessions.` : `Scheduled for ${date}.`);
       router.refresh();
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
@@ -95,22 +101,57 @@ function RoutineRow({ r }: { r: Routine }) {
         </div>
       </div>
       {showSchedule && (
-        <div className="mt-2 flex flex-wrap items-center gap-2">
-          <input
-            type="date"
-            value={date}
-            onChange={(e) => setDate(e.target.value)}
-            className="rounded-lg border border-border bg-surface px-3 py-1.5 text-xs text-text focus:border-teal focus:outline-none"
-          />
-          <button
-            type="button"
-            onClick={schedule}
-            disabled={busy !== null}
-            className="rounded-lg bg-teal/20 px-3 py-1.5 text-xs font-medium text-teal transition-colors hover:bg-teal/30 disabled:opacity-50"
-          >
-            {busy === "schedule" ? "Scheduling…" : "Add to calendar"}
-          </button>
-          <span className="text-xs text-text-muted">Sync the routine first if you haven&apos;t.</span>
+        <div className="mt-2 space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <label className="text-xs text-text-muted">{recurring ? "Start date" : "Date"}</label>
+            <input
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              className="rounded-lg border border-border bg-surface px-3 py-1.5 text-xs text-text focus:border-teal focus:outline-none"
+            />
+            <label className="flex items-center gap-1.5 text-xs text-text-secondary">
+              <input type="checkbox" checked={recurring} onChange={(e) => setRecurring(e.target.checked)} className="h-3.5 w-3.5 accent-teal" />
+              Repeat weekly
+            </label>
+          </div>
+          {recurring && (
+            <div className="flex flex-wrap items-center gap-2">
+              <label className="text-xs text-text-muted">on</label>
+              <select
+                value={weekday}
+                onChange={(e) => setWeekday(Number.parseInt(e.target.value, 10))}
+                aria-label="Weekday"
+                className="rounded-lg border border-border bg-surface px-2 py-1.5 text-xs text-text focus:border-teal focus:outline-none"
+              >
+                {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((d, i) => (
+                  <option key={d} value={i}>{d}</option>
+                ))}
+              </select>
+              <label className="text-xs text-text-muted">for</label>
+              <input
+                type="number"
+                min={1}
+                max={52}
+                value={weeks}
+                onChange={(e) => setWeeks(e.target.value)}
+                aria-label="Weeks"
+                className="w-16 rounded-lg border border-border bg-surface px-2 py-1.5 text-xs text-text focus:border-teal focus:outline-none"
+              />
+              <span className="text-xs text-text-muted">weeks</span>
+            </div>
+          )}
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={schedule}
+              disabled={busy !== null}
+              className="rounded-lg bg-teal/20 px-3 py-1.5 text-xs font-medium text-teal transition-colors hover:bg-teal/30 disabled:opacity-50"
+            >
+              {busy === "schedule" ? "Scheduling…" : recurring ? "Add weekly" : "Add to calendar"}
+            </button>
+            <span className="text-xs text-text-muted">Sync the routine first if you haven&apos;t.</span>
+          </div>
         </div>
       )}
       {msg && !error && <div className="mt-1.5 text-xs text-success">{msg}</div>}

--- a/web/lib/recurring-dates.ts
+++ b/web/lib/recurring-dates.ts
@@ -1,0 +1,24 @@
+/**
+ * Generate weekly recurring calendar dates for a routine schedule — ports the
+ * Python recurring mode (weekday + start_date + weeks). Returns YYYY-MM-DD
+ * strings: the first occurrence of `weekday` on/after `startDate`, then every 7
+ * days, `weeks` times. All in UTC so a date never shifts by timezone.
+ */
+export function recurringDates(startDate: string, weekday: number, weeks: number): string[] {
+  const start = new Date(`${startDate}T00:00:00Z`);
+  if (Number.isNaN(start.getTime())) return [];
+  const w = (((Math.floor(weekday) % 7) + 7) % 7); // 0=Sun..6=Sat
+  const n = Math.max(1, Math.min(52, Math.floor(weeks) || 1));
+
+  const first = new Date(start);
+  const shift = (w - first.getUTCDay() + 7) % 7; // days to the first matching weekday
+  first.setUTCDate(first.getUTCDate() + shift);
+
+  const out: string[] = [];
+  for (let i = 0; i < n; i++) {
+    const d = new Date(first);
+    d.setUTCDate(first.getUTCDate() + i * 7);
+    out.push(d.toISOString().slice(0, 10));
+  }
+  return out;
+}


### PR DESCRIPTION
Parity pass — recurring (weekly) routine schedules. The Python schedule supports a recurring mode; the Next.js schedule was single-date only.

## What
- **`lib/recurring-dates`**: `recurringDates(startDate, weekday, weeks)` — pure — generates the weekly dates (first matching weekday on/after start, then every 7 days, clamped 1–52), all in UTC.
- **`POST /api/routines/[hevyId]/schedule`** now accepts `{mode:"recurring", weekday, start_date, weeks}` alongside the single `{date}`, schedules each generated date, and returns a per-date summary.
- **RoutineRow**: a "Repeat weekly" checkbox reveals a weekday select + weeks input; "Add weekly" posts the recurring payload.

## Verification
- **5 recurring-dates tests** (191 total), tsc clean: weekly spacing + correct weekday, advance-to-first-weekday, weeks clamp [1,52], weekday normalization, invalid-start → [].
- Screenshot validated (standalone Chromium, fetch-mocked routines): the recurring controls (Start date · Repeat weekly · on <weekday> for <N> weeks · Add weekly) render. Not fired live (real Garmin schedule writes).

Closes #438
