### PR TITLE
Web: modern pipeline diagram driven by soma-style tokens

### DIFF
--- a/web/components/pipeline-diagram.tsx
+++ b/web/components/pipeline-diagram.tsx
@@ -1,14 +1,14 @@
 /**
- * The sync pipeline "how it works" diagram — the same truth as the Python
- * dashboard's SVG, presented more richly in TS/React: brand-coloured gradient
- * stages, an animated pulse flowing through the arrows (CSS-only, no JS), and
- * the HR-enrichment loop rendered properly. Server component; theme-agnostic
- * (the brand accents read on both light and dark grounds).
+ * The sync pipeline "how it works" diagram on the dashboard — a modern data-flow
+ * visualization (glowing nodes, light particles streaming along the connectors,
+ * the HR-enrichment loop) whose colours all come from the shared soma-style
+ * tokens (var(--color-*) / currentColor), so restyling soma-style centrally
+ * restyles this too. No hardcoded brand hex, no external fonts.
  *
  * Content is faithful to the real pipeline and MUST stay accurate:
- *   Hevy API (fetch workouts) → Map exercises (N built-in mappings)
- *   → Generate FIT (+ HR + calories) → Garmin (upload activity)
- *   HR loop: Garmin daily HR → matched to the workout → calories → into the FIT.
+ *   Hevy (fetch) → Map exercises (N built-in mappings) → Generate FIT
+ *   (+ HR + calories) → Garmin (upload). HR loop: Garmin's daily heart-rate is
+ *   matched to the workout, its calories computed, and fed back into the FIT.
  */
 
 interface Stage {
@@ -18,22 +18,19 @@ interface Stage {
   title: string;
   sub: string;
   dynamic?: boolean;
-  a: string;
-  b: string;
+  cls: string; // sets `color` (currentColor) to a soma-style token
+  titleVar: string; // fill for the title text
 }
 
 const STAGES: Stage[] = [
-  { key: "hevy", x: 8, w: 184, title: "Hevy API", sub: "Fetch workouts", a: "#6366f1", b: "#818cf8" },
-  { key: "map", x: 224, w: 184, title: "Map exercises", sub: "", dynamic: true, a: "#a855f7", b: "#c084fc" },
-  { key: "fit", x: 440, w: 184, title: "Generate FIT", sub: "+ HR + calories", a: "#f59e0b", b: "#fbbf24" },
-  { key: "garmin", x: 656, w: 184, title: "Garmin", sub: "Upload activity", a: "#00875a", b: "#34d399" },
+  { key: "hevy", x: 8, w: 188, title: "Hevy", sub: "Fetch your workout", cls: "pl-teal", titleVar: "var(--color-teal-light)" },
+  { key: "map", x: 224, w: 188, title: "Map exercises", sub: "", dynamic: true, cls: "pl-warm", titleVar: "var(--color-warm-light)" },
+  { key: "fit", x: 440, w: 188, title: "Generate FIT", sub: "sets · reps · HR · calories", cls: "pl-success", titleVar: "var(--color-success)" },
+  { key: "garmin", x: 656, w: 188, title: "Garmin", sub: "Upload activity", cls: "pl-tealL", titleVar: "var(--color-teal-light)" },
 ];
 
-const ROSE = "#f43f5e";
-const ROSE_LIGHT = "#fb7185";
-
 export function PipelineDiagram({ mappingCount }: { mappingCount?: number }) {
-  const mapSub = `${(mappingCount ?? 433).toLocaleString()} exercises mapped`;
+  const mapSub = `${(mappingCount ?? 433).toLocaleString()} mappings`;
 
   return (
     <section className="mb-8 rounded-xl border border-border bg-surface-elevated p-4">
@@ -47,80 +44,115 @@ export function PipelineDiagram({ mappingCount }: { mappingCount?: number }) {
 
       <div className="overflow-x-auto">
         <svg
-          viewBox="0 0 848 214"
+          viewBox="0 0 852 214"
           role="img"
-          aria-label="Hevy workout, map exercises, generate FIT with heart-rate and calories, upload to Garmin; Garmin's daily heart-rate is matched back into the FIT."
-          className="h-auto w-full min-w-[560px]"
+          aria-label="Hevy fetches the workout, exercises are mapped to Garmin FIT categories, a FIT file is generated with heart-rate and calories, and it is uploaded to Garmin. In a loop, Garmin's daily heart-rate is matched to the workout and its calories are computed, feeding back into the FIT."
+          className="block h-auto w-full min-w-[600px]"
+          style={{ fontFamily: "inherit" }}
         >
           <defs>
-            {STAGES.map((s) => (
-              <linearGradient key={s.key} id={`pg-${s.key}`} x1="0" y1="0" x2="0" y2="1">
-                <stop offset="0" stopColor={s.a} stopOpacity="0.22" />
-                <stop offset="1" stopColor={s.a} stopOpacity="0.06" />
-              </linearGradient>
-            ))}
             <style>{`
-              .pg-flow { stroke-dasharray: 5 6; animation: pgflow 0.9s linear infinite; }
-              .pg-flow-rose { stroke-dasharray: 4 6; animation: pgflow 1.1s linear infinite; }
-              @keyframes pgflow { to { stroke-dashoffset: -22; } }
-              @media (prefers-reduced-motion: reduce) { .pg-flow, .pg-flow-rose { animation: none; } }
+              .pl-teal { color: var(--color-teal); }
+              .pl-tealL { color: var(--color-teal-light); }
+              .pl-warm { color: var(--color-warm); }
+              .pl-success { color: var(--color-success); }
+              .pl-danger { color: var(--color-danger); }
+              .pl-base { fill: var(--color-base); }
+              .pl-sub { fill: var(--color-text-muted); }
+              .pl-cbase { stroke: var(--color-border); }
+              .pl-amb { stroke: var(--color-border-subtle); }
+              .pl-flow { stroke-dasharray: 2 12; animation: plflow 0.75s linear infinite; }
+              @keyframes plflow { to { stroke-dashoffset: -14; } }
+              @media (prefers-reduced-motion: reduce) { .pl-flow, .pl-particle { display: none; } }
             `}</style>
-            <marker id="pg-arrow" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
-              <path d="M0,0 L6,3 L0,6 Z" fill="#94a3b8" />
-            </marker>
-            <marker id="pg-arrow-rose" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
-              <path d="M0,0 L6,3 L0,6 Z" fill={ROSE} />
-            </marker>
+            <filter id="pl-glow" x="-60%" y="-60%" width="220%" height="220%">
+              <feGaussianBlur stdDeviation="3.2" result="b" />
+              <feMerge><feMergeNode in="b" /><feMergeNode in="SourceGraphic" /></feMerge>
+            </filter>
+            <filter id="pl-soft" x="-80%" y="-80%" width="260%" height="260%">
+              <feGaussianBlur stdDeviation="8" />
+            </filter>
           </defs>
 
-          {/* Top-row flow arrows (animated dashes = data moving) */}
-          {[0, 1, 2].map((i) => {
-            const x1 = STAGES[i].x + STAGES[i].w;
-            const x2 = STAGES[i + 1].x;
-            return (
-              <g key={`arr-${i}`}>
-                <line x1={x1 + 2} y1="46" x2={x2 - 6} y2="46" stroke="#334155" strokeWidth="6" strokeLinecap="round" opacity="0.35" />
-                <line x1={x1 + 2} y1="46" x2={x2 - 6} y2="46" stroke="#94a3b8" strokeWidth="2" className="pg-flow" markerEnd="url(#pg-arrow)" />
-              </g>
-            );
-          })}
+          {/* ambient guide lines */}
+          <g className="pl-amb" strokeWidth="1">
+            <line x1="0" y1="118" x2="852" y2="118" /><line x1="0" y1="330" x2="852" y2="330" />
+          </g>
 
-          {/* Stage cards */}
+          {/* connector paths */}
+          <path id="pl-c1" d="M196,120 L224,120" fill="none" />
+          <path id="pl-c2" d="M412,120 L440,120" fill="none" />
+          <path id="pl-c3" d="M628,120 L656,120" fill="none" />
+          <path id="pl-h1" d="M750,168 C750,208 750,220 750,262" fill="none" />
+          <path id="pl-h2" d="M656,300 C628,300 620,300 592,300" fill="none" />
+          <path id="pl-h3" d="M534,262 C534,222 534,208 534,168" fill="none" />
+
+          {/* base strokes + animated flow overlay */}
+          <g fill="none" strokeLinecap="round">
+            <use href="#pl-c1" className="pl-cbase" strokeWidth="2.5" /><use href="#pl-c2" className="pl-cbase" strokeWidth="2.5" /><use href="#pl-c3" className="pl-cbase" strokeWidth="2.5" />
+            <g className="pl-teal"><use href="#pl-c1" className="pl-flow" stroke="currentColor" strokeWidth="2.5" strokeOpacity="0.8" /></g>
+            <g className="pl-warm"><use href="#pl-c2" className="pl-flow" stroke="currentColor" strokeWidth="2.5" strokeOpacity="0.8" /></g>
+            <g className="pl-success"><use href="#pl-c3" className="pl-flow" stroke="currentColor" strokeWidth="2.5" strokeOpacity="0.8" /></g>
+            <use href="#pl-h1" className="pl-cbase" strokeWidth="2.5" /><use href="#pl-h2" className="pl-cbase" strokeWidth="2.5" /><use href="#pl-h3" className="pl-cbase" strokeWidth="2.5" />
+            <g className="pl-danger">
+              <use href="#pl-h1" className="pl-flow" stroke="currentColor" strokeWidth="2.5" strokeOpacity="0.8" style={{ animationDuration: "0.95s" }} />
+              <use href="#pl-h2" className="pl-flow" stroke="currentColor" strokeWidth="2.5" strokeOpacity="0.8" style={{ animationDuration: "0.95s" }} />
+              <use href="#pl-h3" className="pl-flow" stroke="currentColor" strokeWidth="2.5" strokeOpacity="0.8" style={{ animationDuration: "0.95s" }} />
+            </g>
+          </g>
+
+          {/* streaming light particles */}
+          <g filter="url(#pl-glow)" className="pl-particle">
+            <circle r="3" className="pl-teal" fill="currentColor"><animateMotion dur="1.6s" repeatCount="indefinite"><mpath href="#pl-c1" /></animateMotion></circle>
+            <circle r="3" className="pl-warm" fill="currentColor"><animateMotion dur="1.6s" begin="0.5s" repeatCount="indefinite"><mpath href="#pl-c2" /></animateMotion></circle>
+            <circle r="3" className="pl-success" fill="currentColor"><animateMotion dur="1.6s" begin="0.9s" repeatCount="indefinite"><mpath href="#pl-c3" /></animateMotion></circle>
+            <circle r="2.7" className="pl-danger" fill="currentColor"><animateMotion dur="2.6s" repeatCount="indefinite"><mpath href="#pl-h1" /></animateMotion></circle>
+            <circle r="2.7" className="pl-danger" fill="currentColor"><animateMotion dur="2.6s" begin="0.9s" repeatCount="indefinite"><mpath href="#pl-h2" /></animateMotion></circle>
+            <circle r="2.7" className="pl-danger" fill="currentColor"><animateMotion dur="3.2s" begin="1.4s" repeatCount="indefinite"><mpath href="#pl-h3" /></animateMotion></circle>
+          </g>
+
+          {/* top-row stage cards */}
           {STAGES.map((s) => (
-            <g key={s.key}>
-              <rect x={s.x} y="14" width={s.w} height="64" rx="10" fill={`url(#pg-${s.key})`} stroke={s.a} strokeOpacity="0.4" />
-              <rect x={s.x} y="14" width={s.w} height="4" rx="2" fill={s.a} />
-              <text x={s.x + s.w / 2} y="45" textAnchor="middle" fontSize="14" fontWeight="700" fill={s.b}>{s.title}</text>
-              <text x={s.x + s.w / 2} y="63" textAnchor="middle" fontSize="11" fill="#94a3b8">
+            <g key={s.key} className={s.cls}>
+              <rect x={s.x} y="76" width={s.w} height="88" rx="16" fill="currentColor" opacity="0.13" filter="url(#pl-soft)" />
+              <rect x={s.x} y="76" width={s.w} height="88" rx="16" className="pl-base" stroke="currentColor" strokeOpacity="0.55" />
+              <rect x={s.x} y="76" width={s.w} height="88" rx="16" fill="currentColor" opacity="0.07" />
+              <rect x={s.x} y="76" width={s.w} height="3.5" rx="1.75" fill="currentColor" />
+              <text x={s.x + s.w / 2} y="118" textAnchor="middle" fontSize="17" fontWeight="700" fill={s.titleVar}>{s.title}</text>
+              <text x={s.x + s.w / 2} y="140" textAnchor="middle" fontSize="11.5" className="pl-sub">
                 {s.dynamic ? mapSub : s.sub}
               </text>
             </g>
           ))}
 
-          {/* ── HR enrichment loop ── */}
-          {/* Garmin ↓ to Fetch HR */}
-          <line x1="748" y1="80" x2="748" y2="120" stroke="#00875a" strokeWidth="2" className="pg-flow" markerEnd="url(#pg-arrow)" opacity="0.9" />
-          {/* Fetch HR Data (dashed, under Garmin) */}
-          <rect x="656" y="126" width="184" height="52" rx="10" fill="rgba(0,135,90,0.06)" stroke="#00875a" strokeOpacity="0.35" strokeDasharray="6 3" />
-          <text x="748" y="148" textAnchor="middle" fontSize="12" fontWeight="600" fill="#34d399">Fetch HR data</text>
-          <text x="748" y="164" textAnchor="middle" fontSize="10" fill="#94a3b8">Daily watch monitoring</text>
-          {/* Fetch HR ← Match HR (rose, data flows left) */}
-          <line x1="654" y1="152" x2="626" y2="152" stroke={ROSE} strokeWidth="2" className="pg-flow-rose" markerEnd="url(#pg-arrow-rose)" />
-          {/* Match HR & Calc Calories (rose, under Generate FIT) */}
-          <rect x="440" y="126" width="184" height="52" rx="10" fill="rgba(244,63,94,0.07)" stroke={ROSE} strokeOpacity="0.4" />
-          <text x="532" y="148" textAnchor="middle" fontSize="12" fontWeight="600" fill={ROSE_LIGHT}>Match HR & calc calories</text>
-          <text x="532" y="164" textAnchor="middle" fontSize="10" fill="#94a3b8">~90 bpm fallback if none</text>
-          {/* Match HR ↑ into Generate FIT (rose, feeds back up) */}
-          <line x1="532" y1="124" x2="532" y2="82" stroke={ROSE} strokeWidth="2" className="pg-flow-rose" markerEnd="url(#pg-arrow-rose)" />
+          {/* Fetch HR data (teal-light, dashed, under Garmin) */}
+          <g className="pl-tealL">
+            <rect x="656" y="262" width="188" height="76" rx="16" className="pl-base" stroke="currentColor" strokeOpacity="0.4" strokeDasharray="7 4" />
+            <text x="750" y="296" textAnchor="middle" fontSize="14.5" fontWeight="600" fill="var(--color-teal-light)">Fetch HR data</text>
+            <text x="750" y="316" textAnchor="middle" fontSize="11" className="pl-sub">Daily watch monitoring</text>
+          </g>
+
+          {/* Match HR & calories (danger, under Generate FIT) */}
+          <g className="pl-danger">
+            <rect x="440" y="262" width="188" height="76" rx="16" fill="currentColor" opacity="0.11" filter="url(#pl-soft)" />
+            <rect x="440" y="262" width="188" height="76" rx="16" className="pl-base" stroke="currentColor" strokeOpacity="0.5" />
+            <rect x="440" y="262" width="188" height="76" rx="16" fill="currentColor" opacity="0.06" />
+            <text x="534" y="296" textAnchor="middle" fontSize="14" fontWeight="600" fill="var(--color-danger)">Match HR &amp; calories</text>
+            <text x="534" y="316" textAnchor="middle" fontSize="10.5" className="pl-sub">~90 bpm fallback</text>
+          </g>
         </svg>
       </div>
 
-      {/* Legend */}
+      {/* legend */}
       <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px] text-text-muted">
-        <span className="inline-flex items-center gap-1.5"><span className="inline-block h-2 w-3 rounded-sm bg-[#94a3b8]" /> Workout data</span>
-        <span className="inline-flex items-center gap-1.5"><span className="inline-block h-2 w-3 rounded-sm" style={{ background: ROSE }} /> Heart-rate enrichment</span>
+        <span className="inline-flex items-center gap-1.5">
+          <span className="inline-block h-2.5 w-2.5 rounded-full bg-teal" style={{ boxShadow: "0 0 10px var(--color-teal)" }} /> Workout data
+        </span>
+        <span className="inline-flex items-center gap-1.5">
+          <span className="inline-block h-2.5 w-2.5 rounded-full bg-danger" style={{ boxShadow: "0 0 10px var(--color-danger)" }} /> Heart-rate enrichment
+        </span>
         <span>
-          Toggle HR fusion in{" "}
+          Runs when HR fusion is on — toggle it in{" "}
           <a href="/settings" className="text-teal underline">
             Settings
           </a>

--- a/web/components/pipeline-diagram.tsx
+++ b/web/components/pipeline-diagram.tsx
@@ -44,7 +44,7 @@ export function PipelineDiagram({ mappingCount }: { mappingCount?: number }) {
 
       <div className="overflow-x-auto">
         <svg
-          viewBox="0 0 852 214"
+          viewBox="0 0 852 352"
           role="img"
           aria-label="Hevy fetches the workout, exercises are mapped to Garmin FIT categories, a FIT file is generated with heart-rate and calories, and it is uploaded to Garmin. In a loop, Garmin's daily heart-rate is matched to the workout and its calories are computed, feeding back into the FIT."
           className="block h-auto w-full min-w-[600px]"


### PR DESCRIPTION
Ports the approved modern pipeline visualization into the real dashboard component, colored entirely through soma-style tokens so a central soma-style change restyles it (and everything else) — no hardcoded brand hex.

## What
- Glowing accent nodes, light particles streaming along the connectors, and the full HR-enrichment loop (Garmin → Fetch HR data → Match HR & calories → back into Generate FIT), same as the plainer #441 but far richer.
- Every colour is a soma-style variable: node accents via `currentColor` set from `var(--color-teal)` / `--color-warm` / `--color-success` / `--color-teal-light` / `--color-danger`; surfaces `var(--color-base)` / `--color-surface-elevated`; lines `var(--color-border)` / `--color-border-subtle`; text `--color-text-muted`. The legend and card use the Tailwind token classes (`text-teal`, `bg-danger`, `border-border`). Editing a soma-style token restyles the diagram.
- Uses the app font (no external fonts). Animation is CSS + SVG `animateMotion`, and respects `prefers-reduced-motion`.
- Content unchanged and accurate: Hevy fetch → map (live built-in count) → Generate FIT (+ HR + calories) → Garmin, with the HR loop and ~90 bpm fallback.

## Verification
Full suite green, tsc clean. Screenshot-validated on the live dashboard: the teal node resolves to `rgb(119,200,209)` (the `--color-teal` token via `currentColor`), particles measurably animate, the HR loop renders, no console errors. Caught and fixed a clipped `viewBox` height mid-review.

Closes #442
