### PR TITLE
feat(setup): enter GitHub token in-app instead of a Vercel env var

### DIFF
--- a/src/hevy2garmin/config.py
+++ b/src/hevy2garmin/config.py
@@ -199,6 +199,40 @@ def is_configured() -> bool:
     return True
 
 
+def get_github_pat() -> str | None:
+    """Return the GitHub personal access token, DB value taking precedence.
+
+    On cloud deployments the token is saved in ``platform_credentials`` (platform
+    ``github``) from the Settings page, so a fresh Vercel deploy no longer needs
+    it as an environment variable. Falls back to the ``GITHUB_PAT`` env var for
+    local, Docker, and CI use. Returns ``None`` when neither is set.
+    """
+    import os
+
+    from hevy2garmin.db import get_database_url, get_db
+
+    if get_database_url():
+        try:
+            _db = get_db()
+            if hasattr(_db, "_get_conn"):
+                with _db._get_conn() as conn:
+                    with conn.cursor() as cur:
+                        cur.execute(
+                            "SELECT credentials FROM platform_credentials WHERE platform = 'github'"
+                        )
+                        row = cur.fetchone()
+                if row is not None:
+                    creds = row["credentials"] if isinstance(row["credentials"], dict) else json.loads(row["credentials"])
+                    pat = (creds or {}).get("pat")
+                    if pat and pat.strip():
+                        return pat.strip()
+        except Exception:
+            pass
+
+    env_pat = os.environ.get("GITHUB_PAT")
+    return env_pat.strip() if env_pat and env_pat.strip() else None
+
+
 def _deep_merge(base: dict, override: dict) -> None:
     """Merge override into base recursively (mutates base)."""
     for key, value in override.items():

--- a/src/hevy2garmin/server.py
+++ b/src/hevy2garmin/server.py
@@ -26,7 +26,7 @@ from hevy2garmin.db_interface import NoWritableDatabaseError
 from hevy2garmin.auth import (
     auth_enabled, verify_session, sign_session, check_password, SESSION_COOKIE, session_ttl,
 )
-from hevy2garmin.config import is_configured, load_config, save_config
+from hevy2garmin.config import get_github_pat, is_configured, load_config, save_config
 from hevy2garmin.demo import is_demo_mode
 from hevy2garmin.ratelimit import record_rate_limit, cooldown_remaining, clear_rate_limit, format_cooldown
 from hevy2garmin.sync import (
@@ -1199,6 +1199,35 @@ async def history_page(request: Request):
     return _render("history.html", total=db.get_synced_count(), history=db.get_recent_synced(50))
 
 
+def _save_github_pat(pat: str) -> None:
+    """Persist the GitHub PAT to the DB (platform 'github') on cloud deployments.
+
+    Mirrors how the setup form stores Hevy and Garmin credentials, so auto-sync
+    can read the token without a Vercel environment variable (#445). A no-op
+    locally, where the token comes from the environment.
+    """
+    pat = (pat or "").strip()
+    if not pat or not db.get_database_url():
+        return
+    try:
+        import json as _json
+        _db = db.get_db()
+        if hasattr(_db, "_get_conn"):
+            with _db._get_conn() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        INSERT INTO platform_credentials (platform, auth_type, credentials, status)
+                        VALUES ('github', 'pat', %s, 'active')
+                        ON CONFLICT (platform) DO UPDATE SET credentials = EXCLUDED.credentials, status = 'active'
+                        """,
+                        (_json.dumps({"pat": pat}),),
+                    )
+                conn.commit()
+    except Exception as e:
+        logger.warning("Failed to persist GitHub PAT to DB: %s", e)
+
+
 @app.get("/settings", response_class=HTMLResponse)
 async def settings_page(request: Request):
     config = load_config()
@@ -1212,12 +1241,13 @@ async def settings_page(request: Request):
     merge_extra_types = ", ".join(
         t for t in config.get("merge_activity_types", ["strength_training"]) if t != "strength_training"
     )
-    return _render("settings.html", config=config, unmapped=sorted(unmapped.items(), key=lambda x: -x[1]), merge_extra_types=merge_extra_types, err=request.query_params.get("err"))
+    return _render("settings.html", config=config, unmapped=sorted(unmapped.items(), key=lambda x: -x[1]), merge_extra_types=merge_extra_types, github_pat_set=bool(get_github_pat()), err=request.query_params.get("err"))
 
 
 @app.post("/settings")
 async def settings_save(
     hevy_api_key: str = Form(""), garmin_email: str = Form(""), garmin_password: str = Form(""),
+    github_pat: str = Form(""),
     weight_kg: float = Form(80.0), birth_year: int = Form(1990), sex: str = Form("male"), vo2max: float = Form(45.0),
     timezone: str = Form(""),
     working_set_seconds: int = Form(40), warmup_set_seconds: int = Form(25),
@@ -1282,6 +1312,11 @@ async def settings_save(
             })
         except Exception as e:
             logger.warning("Failed to persist settings to DB: %s", e)
+
+    # The GitHub token is only needed for auto-sync, and only stored on cloud
+    # (locally it comes from the environment). Blank means "keep current" (#445).
+    if github_pat.strip():
+        _save_github_pat(github_pat)
 
     return RedirectResponse("/settings", status_code=303)
 
@@ -1466,8 +1501,13 @@ async def api_sync(request: Request):
         return JSONResponse({"status": "demo", "message": "Sync disabled in demo mode"})
 
     # If GitHub PAT + repo are set (Vercel deploy), trigger sync via GitHub Actions
-    github_pat = os.environ.get("GITHUB_PAT")
+    github_pat = get_github_pat()
     github_repo = os.environ.get("GITHUB_REPO")
+    if not github_repo:
+        _owner = os.environ.get("VERCEL_GIT_REPO_OWNER")
+        _slug = os.environ.get("VERCEL_GIT_REPO_SLUG")
+        if _owner and _slug:
+            github_repo = f"{_owner}/{_slug}"
     if github_pat and github_repo:
         import requests as req
 
@@ -2060,6 +2100,16 @@ async def api_toggle_autosync(request: Request):
     if interval not in (30, 60, 120, 240, 360, 720, 1440):
         interval = 120
 
+    # On Vercel, auto-sync runs through GitHub Actions and needs a token. Refuse
+    # to enable it without one instead of silently doing nothing (#445). The
+    # token is entered on the Settings page (or as a GITHUB_PAT env var).
+    if enabled and os.environ.get("VERCEL") and not get_github_pat():
+        return _render(
+            "partials/autosync_status.html",
+            auto_sync=autosync.status(),
+            error="Auto-sync needs a GitHub token. Add one in Settings, then turn auto-sync on.",
+        )
+
     config = load_config()
     config.setdefault("auto_sync", {})
     config["auto_sync"]["enabled"] = enabled
@@ -2084,7 +2134,7 @@ async def api_toggle_autosync(request: Request):
             logger.warning("Failed to persist auto-sync state: %s", e)
 
     if enabled:
-        if os.environ.get("VERCEL") and os.environ.get("GITHUB_PAT"):
+        if os.environ.get("VERCEL"):
             ok, msg = await _setup_github_actions(interval_minutes=interval)
             if ok:
                 logger.info("GitHub Actions auto-sync configured (interval=%dmin)", interval)
@@ -2096,10 +2146,10 @@ async def api_toggle_autosync(request: Request):
     else:
         autosync.stop()
         # On Vercel: delete the sync workflow to stop the cron
-        if os.environ.get("VERCEL") and os.environ.get("GITHUB_PAT"):
+        pat = get_github_pat()
+        if os.environ.get("VERCEL") and pat:
             try:
                 import requests as req
-                pat = os.environ.get("GITHUB_PAT")
                 owner = os.environ.get("VERCEL_GIT_REPO_OWNER")
                 repo_name = os.environ.get("VERCEL_GIT_REPO_SLUG")
                 gh_headers = {"Authorization": f"Bearer {pat}", "Accept": "application/vnd.github+json"}
@@ -2193,13 +2243,13 @@ async def _setup_github_actions(interval_minutes: int = 120) -> tuple[bool, str]
     import asyncio
     from base64 import b64encode
 
-    pat = os.environ.get("GITHUB_PAT")
+    pat = get_github_pat()
     owner = os.environ.get("VERCEL_GIT_REPO_OWNER")
     repo = os.environ.get("VERCEL_GIT_REPO_SLUG")
     database_url = db.get_database_url()
 
     if not pat:
-        return False, "GITHUB_PAT not set"
+        return False, "GitHub token not set"
     if not owner or not repo:
         return False, "Not deployed via Vercel (missing repo info)"
     if not database_url:

--- a/src/hevy2garmin/templates/partials/autosync_status.html
+++ b/src/hevy2garmin/templates/partials/autosync_status.html
@@ -1,3 +1,9 @@
+{% if error %}
+<div class="sync-status-row" style="color: var(--red, #d73a4a);">
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+    <span>{{ error }}</span>
+</div>
+{% endif %}
 {% if auto_sync.enabled %}
 <div class="sync-status-row">
     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--accent)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>

--- a/src/hevy2garmin/templates/settings.html
+++ b/src/hevy2garmin/templates/settings.html
@@ -66,6 +66,15 @@
                 <input class="form-input" type="password" id="garmin_password" name="garmin_password" placeholder="Leave blank to keep current">
             </div>
         </div>
+        <div class="form-group" style="margin-top: 12px;">
+            <label class="form-label" for="github_pat">GitHub Token <span style="color: var(--text-muted); font-weight: normal;">(only for auto-sync)</span></label>
+            <input class="form-input" type="password" id="github_pat" name="github_pat" placeholder="{% if github_pat_set %}Saved. Leave blank to keep current{% else %}Paste a token to enable auto-sync{% endif %}">
+            <div style="font-size: 12px; color: var(--text-muted); margin-top: 6px;">
+                Lets hevy2garmin set up scheduled syncing on your fork. Create one with <code>repo</code> and <code>workflow</code> scopes at
+                <a href="https://github.com/settings/tokens/new?scopes=repo,workflow&amp;description=hevy2garmin" target="_blank" rel="noopener">github.com/settings/tokens</a>.
+                Not needed for manual syncing.
+            </div>
+        </div>
     </div>
 
     <!-- Profile Section -->

--- a/tests/test_github_pat.py
+++ b/tests/test_github_pat.py
@@ -1,0 +1,168 @@
+"""Tests for the in-app GitHub PAT (issue #445).
+
+The GitHub token used to be a required Vercel environment variable. It can now
+be entered on the Settings page and stored in the DB (platform 'github'), so a
+fresh cloud deploy needs no hand-typed env vars. These tests cover the read
+helper (DB-over-env precedence), the persistence helper, and the auto-sync
+guard that refuses to enable without a token instead of failing silently.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hevy2garmin import server as srv
+from hevy2garmin.config import get_github_pat
+from hevy2garmin.server import _save_github_pat
+
+
+class _FakeCursor:
+    def __init__(self, fetchone_row=None):
+        self._row = fetchone_row
+        self.executed: list = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+
+    def fetchone(self):
+        return self._row
+
+
+class _FakeConn:
+    def __init__(self, cursor):
+        self._cursor = cursor
+        self.committed = False
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def cursor(self):
+        return self._cursor
+
+    def commit(self):
+        self.committed = True
+
+
+class _FakeDB:
+    def __init__(self, cursor):
+        self._conn = _FakeConn(cursor)
+
+    def _get_conn(self):
+        return self._conn
+
+
+class TestGetGithubPat:
+    def test_env_only_when_no_db(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_PAT", "ghp_env")
+        with patch("hevy2garmin.db.get_database_url", return_value=None):
+            assert get_github_pat() == "ghp_env"
+
+    def test_none_when_neither(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_PAT", raising=False)
+        with patch("hevy2garmin.db.get_database_url", return_value=None):
+            assert get_github_pat() is None
+
+    def test_strips_whitespace_from_env(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_PAT", "  ghp_env\n")
+        with patch("hevy2garmin.db.get_database_url", return_value=None):
+            assert get_github_pat() == "ghp_env"
+
+    def test_db_takes_precedence_over_env(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_PAT", "ghp_env")
+        cur = _FakeCursor(fetchone_row={"credentials": {"pat": "ghp_db"}})
+        with patch("hevy2garmin.db.get_database_url", return_value="postgresql://x"), \
+             patch("hevy2garmin.db.get_db", return_value=_FakeDB(cur)):
+            assert get_github_pat() == "ghp_db"
+
+    def test_falls_back_to_env_when_no_db_row(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_PAT", "ghp_env")
+        cur = _FakeCursor(fetchone_row=None)
+        with patch("hevy2garmin.db.get_database_url", return_value="postgresql://x"), \
+             patch("hevy2garmin.db.get_db", return_value=_FakeDB(cur)):
+            assert get_github_pat() == "ghp_env"
+
+    def test_db_read_failure_falls_back_to_env(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_PAT", "ghp_env")
+
+        class _Boom:
+            def _get_conn(self):
+                raise RuntimeError("db down")
+
+        with patch("hevy2garmin.db.get_database_url", return_value="postgresql://x"), \
+             patch("hevy2garmin.db.get_db", return_value=_Boom()):
+            assert get_github_pat() == "ghp_env"
+
+
+class TestSaveGithubPat:
+    def test_writes_github_row_on_cloud(self):
+        cur = _FakeCursor()
+        fake = _FakeDB(cur)
+        with patch("hevy2garmin.server.db.get_database_url", return_value="postgresql://x"), \
+             patch("hevy2garmin.server.db.get_db", return_value=fake):
+            _save_github_pat("  ghp_tok  ")
+        assert len(cur.executed) == 1
+        sql, params = cur.executed[0]
+        assert "platform_credentials" in sql and "'github'" in sql
+        assert params == ('{"pat": "ghp_tok"}',)
+        assert fake._conn.committed is True
+
+    def test_noop_when_local(self):
+        cur = _FakeCursor()
+        with patch("hevy2garmin.server.db.get_database_url", return_value=None), \
+             patch("hevy2garmin.server.db.get_db", return_value=_FakeDB(cur)):
+            _save_github_pat("ghp_tok")
+        assert cur.executed == []
+
+    def test_noop_on_blank(self):
+        cur = _FakeCursor()
+        with patch("hevy2garmin.server.db.get_database_url", return_value="postgresql://x"), \
+             patch("hevy2garmin.server.db.get_db", return_value=_FakeDB(cur)):
+            _save_github_pat("   ")
+        assert cur.executed == []
+
+
+class TestToggleAutosyncNeedsToken:
+    """On Vercel, enabling auto-sync without a token must refuse, not no-op."""
+
+    def _client(self):
+        srv._is_configured_cache = True
+        return TestClient(srv.app)
+
+    def test_enable_without_token_shows_message(self, monkeypatch):
+        monkeypatch.setenv("VERCEL", "1")
+        # The guard returns before any config load/save, so no disk or DB touch.
+        with patch("hevy2garmin.server.get_github_pat", return_value=None), \
+             patch("hevy2garmin.server._setup_github_actions") as setup:
+            r = self._client().post("/api/toggle-autosync", data={"enabled": "true", "interval": "120"})
+        assert r.status_code == 200
+        assert "needs a GitHub token" in r.text
+        setup.assert_not_called()
+
+    def test_enable_with_token_proceeds(self, monkeypatch):
+        monkeypatch.setenv("VERCEL", "1")
+
+        async def _ok(interval_minutes=120):
+            return True, "ok"
+
+        with patch("hevy2garmin.server.get_github_pat", return_value="ghp_tok"), \
+             patch("hevy2garmin.server.load_config", return_value={"auto_sync": {}}), \
+             patch("hevy2garmin.server.save_config"), \
+             patch("hevy2garmin.server.db.get_database_url", return_value=None), \
+             patch("hevy2garmin.server._setup_github_actions", side_effect=_ok) as setup:
+            r = self._client().post("/api/toggle-autosync", data={"enabled": "true", "interval": "120"})
+        assert r.status_code == 200
+        assert "needs a GitHub token" not in r.text
+        setup.assert_called_once()


### PR DESCRIPTION
## What

The GitHub personal access token was the only deploy-time value that could not be entered in the app, so the Vercel walkthrough required typing it as an env var up front. This moves it into the dashboard.

- New "GitHub Token (only for auto-sync)" field on the Settings page, persisted to `platform_credentials` (platform `github`) on cloud, mirroring how Hevy and Garmin creds are stored.
- New `get_github_pat()` helper reads the DB value first, then falls back to the `GITHUB_PAT` env var. Every sync and auto-sync call site now goes through it (`api_sync`, enable and disable auto-sync, `_setup_github_actions`).
- Enabling auto-sync on Vercel without a token now returns a clear "Auto-sync needs a GitHub token" message instead of silently scheduling nothing.
- The manual-sync dispatch path derives the repo from `VERCEL_GIT_REPO_OWNER` / `VERCEL_GIT_REPO_SLUG` when `GITHUB_REPO` is unset.

## Why

Part of #444 (cut the Vercel deploy env vars). The Hevy key and Garmin creds are already collected by the setup wizard and written to the DB, so the token was the last blocker to a zero-env deploy.

## Notes

- Env vars keep working for local, Docker, and CI use. This only removes the token from the required cloud path.
- The token is stored the same way the Garmin password already is (JSON in `platform_credentials` on the user's own Neon DB), so this is not a new class of secret exposure.

## Tests

New `tests/test_github_pat.py` (11 tests): DB-over-env precedence, env fallback, whitespace strip, DB-read failure fallback, persistence writes the `github` row on cloud and no-ops locally or on blank, and the auto-sync guard refuses without a token but proceeds with one. Full suite: 809 passed, 7 skipped.

## Verified

Settings page rendered on the local server and screenshotted: the token field shows in the Credentials card with the scoped-token link and help text, consistent with the other fields.

Closes #445
