### PR TITLE
docs: drop the env-var step from the Vercel deploy walkthrough

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,20 @@
 # hevy2garmin environment variables
+#
+# On the Vercel deploy you do not need to set the credentials below: the setup
+# wizard collects your Hevy key and Garmin login in the app and stores them in
+# the database, and the GitHub token is entered in Settings. They are still read
+# here for local, Docker, and CI runs.
 
-# Required: Hevy API key (requires Hevy Pro subscription)
-# Get yours at https://hevy.com/settings > Integrations & API > Generate API Key
+# Hevy API key (requires Hevy Pro subscription). Entered in the app on cloud.
+# Get yours at https://hevy.com/settings > Developer > Generate API Key
 HEVY_API_KEY=
 
-# Optional: GitHub PAT with repo+workflow scopes (enables auto-sync via GitHub Actions)
+# GitHub PAT with repo+workflow scopes (enables auto-sync via GitHub Actions).
+# On the Vercel deploy, paste this into Settings instead of setting it here.
 # Create one at: https://github.com/settings/tokens/new?scopes=repo,workflow&description=hevy2garmin
 GITHUB_PAT=
 
-# Required: Garmin Connect credentials (used for initial auth on all platforms)
+# Garmin Connect credentials (used for initial auth). Entered in the app on cloud.
 GARMIN_EMAIL=
 GARMIN_PASSWORD=
 

--- a/README.md
+++ b/README.md
@@ -69,39 +69,22 @@ Open [hevy.com/settings](https://hevy.com/settings), scroll to **Developer** (He
 
 Sign up at [github.com](https://github.com/signup). You'll use this to sign into Vercel too.
 
-**Step 3: Create a GitHub access token**
-
-This token lets hevy2garmin set up automatic syncing on your behalf. Open [this link](https://github.com/settings/tokens/new?scopes=repo,workflow&description=hevy2garmin) (sign in if prompted):
-
-1. Set **Expiration** to **No expiration** (otherwise auto-sync stops when it expires)
-2. Scroll to the bottom, click **Generate token**
-3. **Copy the token immediately** (starts with `ghp_`). GitHub only shows it once.
-
-**Step 4: Fork the repo**
+**Step 3: Fork the repo**
 
 [Fork hevy2garmin on GitHub](https://github.com/drkostas/hevy2garmin/fork) -- click the green **Create fork** button. This gives you your own copy that stays linked to the original, so you can pull updates later with one click.
 
-**Step 5: Deploy to Vercel**
+**Step 4: Deploy to Vercel**
 
 1. Go to [vercel.com/new](https://vercel.com/new) and sign in with GitHub
 2. Find **hevy2garmin** in your repo list and click **Import**. If your fork isn't listed even though GitHub shows it, click **Adjust GitHub App Permissions** (or **Configure GitHub App**) and grant Vercel access to the repo, then it will appear.
 3. **Add a database (required).** If you see an **Integrations** or **Storage** section during import, add **Neon Postgres** (it's free). This is where your sync history lives. If you don't see it during import, that's fine: deploy first, then open your project's **Storage** tab, add **Neon Postgres**, and redeploy. A serverless host has a read-only filesystem, so with no database the app can't save anything and shows an "internal server error".
-4. **Environment Variables.** Vercel does not pre-fill these. The form shows an empty field with a placeholder like `EXAMPLE_NAME`. Add each of the four below as its own variable: type the name in **Key**, the value in **Value**, then click **Add More** for the next one.
+4. Click **Deploy** and wait about a minute for it to build. You don't need to set any environment variables: you enter your Hevy key and Garmin login in the app on the next step. If the deployed page shows an "internal server error", it almost always means the database step was skipped: add **Neon Postgres** from the **Storage** tab, then redeploy.
 
-| Key | What to paste |
-|-------|--------------|
-| `HEVY_API_KEY` | The API key from step 1 |
-| `GARMIN_EMAIL` | Your Garmin Connect email |
-| `GARMIN_PASSWORD` | Your Garmin Connect password |
-| `GITHUB_PAT` | The token from step 3 |
-
-5. Click **Deploy** and wait about a minute for it to build. If the deployed page shows an "internal server error", it almost always means the database step was skipped: add **Neon Postgres** from the **Storage** tab, then redeploy.
-
-**Step 6: Connect Garmin**
+**Step 5: Connect Hevy and Garmin**
 
 Click **Continue to Dashboard**, then **Visit** to open your app. Bookmark this URL -- it's your dashboard.
 
-On the setup page, enter your Garmin email and password and click **Connect**.
+The setup page walks you through it: paste your Hevy API key from step 1, then enter your Garmin email and password and click **Connect**.
 
 - If your Garmin account **does not** have 2FA enabled, you're connected in a second. That's it.
 - If your Garmin account **has 2FA enabled**, Garmin emails you a 6-digit code. A code input appears on the page, paste the code, click **Verify**. Done.
@@ -112,13 +95,13 @@ Garmin blocks automated logins from cloud servers (AWS, Azure, Vercel), so hevy2
 
 > **Fallback for edge cases:** on the rare occasion Garmin doesn't accept the direct login (most often when the account has an unusual security configuration), the setup page automatically reveals the old "Sign into Garmin in a new tab and paste the URL back" flow as a safety net. You don't need to do anything differently -- just follow the instructions the page shows you.
 
-**Step 7: Sync your workouts**
+**Step 6: Sync your workouts**
 
 You're on the dashboard. Click **Sync All Workouts** to backfill your history. The app syncs one workout at a time (you can close the page and come back, it picks up where it left off).
 
 > **EU users:** If you see an upload consent error, go to [Garmin Connect Settings](https://connect.garmin.com/modern/settings) > scroll to **Data** > enable **Device Upload**. This is a one-time Garmin GDPR requirement.
 
-To keep future workouts syncing automatically, toggle **Auto-sync** on the dashboard. This creates a background job that syncs new workouts every 2 hours.
+To keep future workouts syncing automatically, toggle **Auto-sync** on the dashboard. The first time, it asks for a GitHub token so it can schedule the job on your fork: create one with `repo` and `workflow` scopes [here](https://github.com/settings/tokens/new?scopes=repo,workflow&description=hevy2garmin) (set **Expiration** to **No expiration** so it doesn't stop later), paste it into **Settings**, then turn **Auto-sync** on. It syncs new workouts every 2 hours.
 
 > **Sync timing:** hevy2garmin waits `sync.grace_period_minutes` (default 120)
 > after a workout ends before syncing it automatically, so your Garmin watch


### PR DESCRIPTION
## What

Simplifies the "Vercel Deploy (no coding required)" walkthrough now that the token can be entered in the app (#445).

- Removes the up-front "create a GitHub token" step and the four hand-typed env vars (`HEVY_API_KEY`, `GARMIN_EMAIL`, `GARMIN_PASSWORD`, `GITHUB_PAT`).
- Folds the Hevy key into the connect step, where the setup wizard already collects it.
- Moves the GitHub token to the auto-sync instructions, matching the in-app flow (toggle auto-sync, paste the token in Settings).
- Seven steps down to six.
- `.env.example`: marks the credential vars as entered in the app on cloud, kept for local, Docker, and CI.

## Why

Part of #444. This is the user-facing payoff: a fresh deploy is fork, import, add Neon, deploy, then configure in the app.

## Verified

Read the rewritten section end to end: steps renumber cleanly 1 through 6, no dangling "from step 3" references, no env-var table. Docs-only, no code change.

Closes #447
