### PR TITLE
ci: fresh-fork check — install and boot exactly what a forker's Vercel deploy gets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,3 +116,51 @@ jobs:
 
       - name: Test
         run: npm test
+
+  check-fresh-fork:
+    # What a forker's Vercel deploy actually installs: the base [project.dependencies]
+    # only — no [dev]/[cloud] extras, no requirements.txt, non-editable (#357/#358 shape).
+    name: Fresh fork (Vercel-style base install)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install base dependencies only (no extras, non-editable)
+        run: pip install .
+
+      - name: Dependency consistency
+        run: pip check
+
+      - name: requirements.txt matches the base dependencies
+        run: |
+          python - <<'PYCHK'
+          import tomllib, re
+          norm = lambda s: re.sub(r"\s+", "", s)
+          base = {norm(d) for d in tomllib.load(open("pyproject.toml", "rb"))["project"]["dependencies"]}
+          req = {norm(l.split("#")[0]) for l in open("requirements.txt") if l.split("#")[0].strip()}
+          missing, extra = base - req, req - base
+          assert not missing and not extra, f"requirements.txt out of sync: missing={sorted(missing)} extra={sorted(extra)}"
+          print(f"requirements.txt matches {len(base)} base dependencies")
+          PYCHK
+
+      - name: Import the Vercel entry from outside the repo
+        # api/index.py falls back to src/ when the package is not installed; running it
+        # from another directory makes sure only the INSTALLED package and its deps are used.
+        run: |
+          mkdir -p /tmp/outside && cp api/index.py /tmp/outside/index.py
+          cd /tmp/outside && env -i PATH="$PATH" HOME=/tmp/outside python -c "import index; print('import ok:', index.app.title)"
+
+      - name: Boot the dashboard with no environment and answer over HTTP
+        run: |
+          cd /tmp/outside
+          env -i PATH="$PATH" HOME=/tmp/outside python -m uvicorn index:app --host 127.0.0.1 --port 8129 > uvicorn.log 2>&1 &
+          for i in $(seq 1 30); do
+            sleep 1
+            code=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8129/login || true)
+            case "$code" in 2*|3*) echo "GET /login -> $code"; exit 0;; esac
+          done
+          echo "dashboard did not answer on /login"; cat uvicorn.log; exit 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,14 @@
+# Kept identical to [project.dependencies] in pyproject.toml (CI asserts it).
+# Vercel installs from pyproject; this file exists for platforms that read requirements.txt.
+garmin-auth>=0.3.0,<0.4.0
+garminconnect>=0.3.0,<0.4.0
+curl_cffi>=0.6
+ua-generator>=1.0
+requests>=2.31
+fit-tool>=0.9.15
 fastapi>=0.110
 uvicorn>=0.29
 jinja2>=3.1
 python-multipart>=0.0.9
-garmin-auth>=0.2.0
-garminconnect>=0.2.38,<0.3.0
-requests>=2.31
-fit-tool>=0.9.15
-psycopg2-binary>=2.9
 pynacl>=1.5
+psycopg2-binary>=2.9


### PR DESCRIPTION
## The sentence
For `repo://hevy2garmin/main`, we know `fork_deployable := true|false` (observed by CI on every PR and push to main), and can do `check_fresh_fork` (tier none; executor script; reversible; shared; batch) when an intent is minted by a pull request, producing event `hevy2garmin.fresh_fork.checked` (observed; success|failure), so that derived state `safe_for_forkers` = "the last fresh-fork check on main succeeded", rendered at the CI status on the PR, governed by policy red-blocks-merge-and-cutover.

## What
- `check-fresh-fork` job: Python 3.12, `pip install .` (base deps only, non-editable, like `@vercel/python`), `pip check`, import `api/index.py` from **outside** the repo so its `src/` fallback cannot mask a missing installed dependency, boot uvicorn with `env -i` and require `/login` to answer 2xx/3xx.
- `requirements.txt` regenerated from `[project.dependencies]` (it had drifted: `garminconnect>=0.2.38,<0.3.0` and `garmin-auth>=0.2.0` against pyproject's `>=0.3.0,<0.4.0`), with a CI assertion that keeps the two identical.

## Done is an observation
- Local rehearsal of the same steps against `main` (clean `git archive`, fresh venv, python 3.12): install ok, `pip check` clean, `import ok: FastAPI hevy2garmin` from outside the repo, `GET /login -> 307` with no environment.
- This PR's own **Fresh fork** check is the verify_cmd; red blocks merge and, later, the Python→web cutover.

## Forkers
No runtime code touched. A fork that syncs `main` gets the same package, a consistent `requirements.txt`, and a CI that fails before a fresh Vercel deploy can.

Closes #452
Closes #453
Closes #454
