### PR TITLE
ci: fresh-fork check for the web path, web/.env.example, README note on the rebuild

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,3 +164,38 @@ jobs:
             case "$code" in 2*|3*) echo "GET /login -> $code"; exit 0;; esac
           done
           echo "dashboard did not answer on /login"; cat uvicorn.log; exit 1
+
+  check-fresh-fork-web:
+    # What a forker's Vercel deploy of the Next.js dashboard gets: a strict `npm ci` (a stale
+    # lockfile must FAIL here, not on their first deploy), a build, and a boot with nothing but
+    # a database URL in the environment. Mirror of check-fresh-fork for the web path (#457).
+    name: Fresh fork (web, Vercel-style install)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install exactly from the lockfile (no fallback)
+        run: npm ci
+
+      - name: Build
+        # Routes are force-dynamic; the build must not need a real database.
+        env:
+          DATABASE_URL: postgres://ci:ci@localhost:5432/ci
+        run: npm run build
+
+      - name: Boot with a bare environment and answer on /login
+        run: |
+          env -i PATH="$PATH" HOME="$HOME" DATABASE_URL=postgres://ci:ci@localhost:5432/ci npx next start --port 8097 > start.log 2>&1 &
+          for i in $(seq 1 30); do
+            sleep 1
+            code=$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8097/login || true)
+            case "$code" in 2*|3*) echo "GET /login -> $code"; exit 0;; esac
+          done
+          echo "dashboard did not answer on /login"; cat start.log; exit 1

--- a/README.md
+++ b/README.md
@@ -112,6 +112,18 @@ To keep future workouts syncing automatically, toggle **Auto-sync** on the dashb
 
 **That's it.** Check [Garmin Connect](https://connect.garmin.com/modern/activities) to see your workouts with proper exercise names, sets, reps, and weights.
 
+### Web dashboard rebuild (Next.js, preview)
+
+A Next.js rebuild of the dashboard lives in `web/`. It uses the same database and the same `platform_credentials` rows as the Python dashboard, so both can run against one Neon project. Vercel still serves the Python dashboard from `api/index.py` until the cutover is announced here and in the changelog. To try the rebuild now:
+
+```bash
+cd web
+cp .env.example .env.local   # fill in DATABASE_URL, H2G_PASSWORD, HEVY2GARMIN_SECRET, CRON_SECRET
+npm ci && npm run dev        # http://localhost:8096
+```
+
+CI runs a fresh-fork check for both paths on every change: the Python package must install and boot from its base dependencies, and the web app must install from its lockfile, build, and answer with a bare environment. A red check blocks the merge, so `main` stays deployable for a fresh fork.
+
 ### Web Dashboard (local install)
 
 ```bash

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,15 @@
+# hevy2garmin web dashboard (Next.js). Copy to .env.local for a local run; on Vercel set these as
+# project environment variables. Names must match exactly; values are examples.
+
+# Required
+DATABASE_URL=postgres://user:password@host/dbname          # Neon or any Postgres; shared with the Python dashboard and the CLI
+H2G_PASSWORD=change-me                                       # dashboard login password (plain); or set H2G_PASSWORD_HASH (argon2) instead
+HEVY2GARMIN_SECRET=change-me-32-random-chars                 # signs the login session cookie (also accepted as H2G_SECRET)
+CRON_SECRET=change-me-32-random-chars                        # Vercel Cron / GitHub Actions call /api/cron/sync with this bearer
+
+# Optional
+HEVY_API_KEY=                                                # normally saved in-app at /setup; env is the fallback
+GITHUB_PAT=                                                  # for auto-sync via GitHub Actions on your fork; normally saved in-app
+GITHUB_REPO=you/hevy2garmin                                  # your fork, for the auto-sync workflow dispatch
+GARMIN_LOGIN_WORKER_URL=                                     # override the Garmin login Worker used by /setup (leave empty for the default)
+DEMO_MODE=false                                              # true = read-only demo (every mutating /api call is refused)


### PR DESCRIPTION
## The sentence
For `repo://hevy2garmin/main` (web path), we know `fork_deployable_web := true|false` (observed by CI on every PR: strict `npm ci`, `next build`, boot with a bare environment, `/login` answers), and can do `check_fresh_fork_web` (tier none; executor script; reversible; shared; batch) when a pull request mints the intent, producing `hevy2garmin.fresh_fork_web.checked` (observed), so that `safe_for_forkers` covers both the Python and the web path, rendered at the CI status and the README, governed by policy red-blocks-merge-and-cutover.

## Done is an observation
- Rehearsed locally with the exact steps: `npm ci` ok, build ok, `GET /login -> 200` with `env -i`.
- This PR's own **Fresh fork (web, Vercel-style install)** check is the verify_cmd.

## Forkers
No runtime code touched. A fork syncing main gets `web/.env.example` and a README that says what the web/ directory is and that Vercel still serves the Python app.

Closes #457
