### PR TITLE
feat(web): GitHub token in-app + Actions setup on the fork; self-heal old Garmin token rows

### DIFF
--- a/src/hevy2garmin/db_postgres.py
+++ b/src/hevy2garmin/db_postgres.py
@@ -107,6 +107,23 @@ class PostgresDatabase(Database):
                         status VARCHAR(20) DEFAULT 'disconnected'
                     )
                 """)
+                # #459: self-heal a Garmin token row written by garmin-auth < 0.3 (flat DI payload).
+                # 0.3+ on both stacks nests it under 'garmin_tokens', the only shape the stores read;
+                # without this a fork whose row predates the change is told to reconnect Garmin.
+                # Legacy oauth1/oauth2 rows are dead anyway (rejected on load) — drop them.
+                cur.execute("""
+                    UPDATE platform_credentials
+                       SET credentials = jsonb_build_object('garmin_tokens', credentials),
+                           auth_type = 'oauth', status = 'active'
+                     WHERE platform = 'garmin_tokens'
+                       AND credentials ? 'di_token'
+                       AND NOT (credentials ? 'garmin_tokens')
+                """)
+                cur.execute("""
+                    DELETE FROM platform_credentials
+                     WHERE platform = 'garmin_tokens'
+                       AND (credentials ? 'oauth1_token.json' OR credentials ? 'oauth2_token.json')
+                """)
                 cur.execute("""
                     CREATE TABLE IF NOT EXISTS custom_mappings (
                         hevy_name TEXT PRIMARY KEY,

--- a/tests/fixtures/sync_workflow_120.yml
+++ b/tests/fixtures/sync_workflow_120.yml
@@ -1,0 +1,28 @@
+name: Sync Workouts
+
+on:
+  schedule:
+    - cron: '0 */2 * * *'
+  workflow_dispatch: {}
+  repository_dispatch:
+    types: [sync-trigger]
+
+concurrency:
+  group: sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Install
+        run: pip install ".[cloud]"
+      - name: Sync
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: hevy2garmin sync

--- a/tests/test_workflow_yaml_parity.py
+++ b/tests/test_workflow_yaml_parity.py
@@ -1,0 +1,51 @@
+"""The web dashboard builds the fork's sync workflow too (web/lib/github.ts). Both stacks must
+write the same file: this golden fixture is generated from the Python builder and the web test
+(web/lib/github.test.ts) asserts against the same file (#458)."""
+import os
+from pathlib import Path
+
+import pytest
+
+from hevy2garmin.server import _build_sync_workflow_yaml, _minutes_to_cron
+
+FIXTURE = Path(__file__).parent / "fixtures" / "sync_workflow_120.yml"
+
+
+def test_workflow_yaml_matches_golden():
+    assert _build_sync_workflow_yaml(120) == FIXTURE.read_text()
+
+
+def test_cron_table():
+    assert _minutes_to_cron(30) == "*/30 * * * *"
+    assert _minutes_to_cron(60) == "0 * * * *"
+    assert _minutes_to_cron(240) == "0 */4 * * *"
+    assert _minutes_to_cron(1440) == "0 0 * * *"
+    assert _minutes_to_cron(45) == "0 */2 * * *"
+
+
+@pytest.mark.skipif(not os.environ.get("DATABASE_URL"), reason="DATABASE_URL not set")
+def test_flat_garmin_token_row_is_nested_on_schema_init():
+    """#459: a row written by garmin-auth < 0.3 (flat DI payload) self-heals into the nested shape."""
+    import json
+
+    from hevy2garmin.db_postgres import PostgresDatabase
+
+    db = PostgresDatabase(os.environ["DATABASE_URL"])
+    with db._get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM platform_credentials WHERE platform = 'garmin_tokens'")
+            cur.execute(
+                "INSERT INTO platform_credentials (platform, auth_type, credentials, status) VALUES ('garmin_tokens', 'oauth', %s, 'active')",
+                (json.dumps({"di_token": "t", "di_refresh_token": "r", "di_client_id": "c"}),),
+            )
+        conn.commit()
+    db._ensure_tables()
+    db._ensure_tables()  # idempotent
+    with db._get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT credentials FROM platform_credentials WHERE platform = 'garmin_tokens'")
+            creds = cur.fetchone()[0]
+            creds = json.loads(creds) if isinstance(creds, str) else creds
+            cur.execute("DELETE FROM platform_credentials WHERE platform = 'garmin_tokens'")
+        conn.commit()
+    assert creds == {"garmin_tokens": {"di_token": "t", "di_refresh_token": "r", "di_client_id": "c"}}

--- a/tests/test_workflow_yaml_parity.py
+++ b/tests/test_workflow_yaml_parity.py
@@ -44,7 +44,8 @@ def test_flat_garmin_token_row_is_nested_on_schema_init():
     with db._get_conn() as conn:
         with conn.cursor() as cur:
             cur.execute("SELECT credentials FROM platform_credentials WHERE platform = 'garmin_tokens'")
-            creds = cur.fetchone()[0]
+            row = cur.fetchone()  # RealDictCursor: a dict, not a tuple
+            creds = row["credentials"] if isinstance(row, dict) else row[0]
             creds = json.loads(creds) if isinstance(creds, str) else creds
             cur.execute("DELETE FROM platform_credentials WHERE platform = 'garmin_tokens'")
         conn.commit()

--- a/web/app/api/cron/sync/route.ts
+++ b/web/app/api/cron/sync/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { syncOneWorkout, type SyncOneResult } from "@/lib/sync-one";
 import { getDb } from "@/lib/db";
+import { getGithubPat, getGithubRepo, triggerViaActions } from "@/lib/github";
 
 // Runs the sync at request time — never at build.
 export const dynamic = "force-dynamic";
@@ -17,18 +18,6 @@ export const runtime = "nodejs";
 
 const CAP = 50;
 
-async function triggerViaActions(pat: string, repo: string): Promise<boolean> {
-  const res = await fetch(`https://api.github.com/repos/${repo}/dispatches`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${pat}`,
-      Accept: "application/vnd.github+json",
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ event_type: "sync-trigger" }),
-  });
-  return res.ok;
-}
 
 export async function GET(request: Request) {
   const secret = process.env.CRON_SECRET;
@@ -40,8 +29,11 @@ export async function GET(request: Request) {
 
   // Deployed path: hand off to the Action so the long browser-auth sync runs off
   // the request.
-  const pat = process.env.GITHUB_PAT;
-  const repo = process.env.GITHUB_REPO;
+  // Settings row first, GITHUB_PAT fallback (#458). The DB handle may be unavailable here; env still works.
+  let sqlForPat: ReturnType<typeof getDb> | null = null;
+  try { sqlForPat = getDb(); } catch { sqlForPat = null; }
+  const pat = await getGithubPat(sqlForPat);
+  const repo = getGithubRepo();
   if (pat && repo) {
     try {
       const ok = await triggerViaActions(pat, repo);

--- a/web/app/api/cron/webhook/route.ts
+++ b/web/app/api/cron/webhook/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { syncOneWorkout } from "@/lib/sync-one";
 import { getDb } from "@/lib/db";
+import { getGithubPat, getGithubRepo, triggerViaActions } from "@/lib/github";
 
 // Runs a sync at request time — never at build.
 export const dynamic = "force-dynamic";
@@ -16,18 +17,6 @@ export const runtime = "nodejs";
  * Action when GITHUB_PAT + GITHUB_REPO are set, else running the tested
  * single-workout engine inline.
  */
-async function triggerViaActions(pat: string, repo: string): Promise<boolean> {
-  const res = await fetch(`https://api.github.com/repos/${repo}/dispatches`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${pat}`,
-      Accept: "application/vnd.github+json",
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ event_type: "sync-trigger" }),
-  });
-  return res.ok;
-}
 
 export async function POST(request: Request) {
   const secret = process.env.CRON_SECRET;
@@ -43,8 +32,11 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
   }
 
-  const pat = process.env.GITHUB_PAT;
-  const repo = process.env.GITHUB_REPO;
+  // Settings row first, GITHUB_PAT fallback (#458). The DB handle may be unavailable here; env still works.
+  let sqlForPat: ReturnType<typeof getDb> | null = null;
+  try { sqlForPat = getDb(); } catch { sqlForPat = null; }
+  const pat = await getGithubPat(sqlForPat);
+  const repo = getGithubRepo();
   if (pat && repo) {
     try {
       const ok = await triggerViaActions(pat, repo);

--- a/web/app/api/settings/route.ts
+++ b/web/app/api/settings/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { getDb } from "@/lib/db";
+import { saveGithubPat } from "@/lib/github";
 import { verifySession, SESSION_COOKIE, authEnabled } from "@/lib/auth";
 
 // Writes config to the live hevy2garmin Postgres (app_cache) at request time.
@@ -133,8 +134,11 @@ export async function POST(request: Request) {
       if (Object.keys(s).length > 0) changes[key] = s;
     }
   }
+  // GitHub token (#458): not app_cache config — the platform_credentials row the Python
+  // dashboard writes from its Settings page. Blank = keep the current one.
+  const githubPat = typeof body.github_pat === "string" ? body.github_pat.trim() : "";
   const keys = Object.keys(changes);
-  if (keys.length === 0) {
+  if (keys.length === 0 && !githubPat) {
     return NextResponse.json({ error: "No editable config provided." }, { status: 400 });
   }
 
@@ -146,6 +150,7 @@ export async function POST(request: Request) {
   }
 
   try {
+    if (githubPat) await saveGithubPat(sql, githubPat);
     const existing = (await sql`SELECT key, value FROM app_cache WHERE key = ANY(${keys})`) as {
       key: string;
       value: unknown;
@@ -160,7 +165,7 @@ export async function POST(request: Request) {
         ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()
       `;
     }
-    return NextResponse.json({ ok: true, saved: keys });
+    return NextResponse.json({ ok: true, saved: githubPat ? [...keys, "github_pat"] : keys });
   } catch (err) {
     console.error("settings write failed:", err);
     return NextResponse.json({ error: "Failed to save settings." }, { status: 500 });

--- a/web/app/api/setup-actions/route.test.ts
+++ b/web/app/api/setup-actions/route.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/auth", () => ({ authEnabled: () => false, verifySession: async () => true, SESSION_COOKIE: "h2g_session" }));
+const state: { pat: string | null } = { pat: null };
+vi.mock("@/lib/db", () => {
+  const tag = (async (strings: TemplateStringsArray) => {
+    const q = strings.join("?");
+    if (q.includes("FROM platform_credentials WHERE platform = 'github'")) return state.pat ? [{ credentials: { pat: state.pat } }] : [];
+    throw new Error("unexpected query: " + q);
+  }) as unknown as { (): unknown; json: <T>(v: T) => T };
+  tag.json = (v) => v;
+  return { getDb: () => tag };
+});
+const { setup } = vi.hoisted(() => ({ setup: vi.fn(async () => ({ ok: true, message: "Auto-sync enabled! Workouts will sync every 2 hours." })) }));
+vi.mock("@/lib/github", async (importOriginal) => ({ ...(await importOriginal<typeof import("@/lib/github")>()), setupGithubActions: setup }));
+
+import { POST } from "./route";
+const req = (body: unknown) => new Request("http://h/api/setup-actions", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+
+describe("POST /api/setup-actions", () => {
+  beforeEach(() => { state.pat = null; delete process.env.GITHUB_PAT; delete process.env.GITHUB_REPO; delete process.env.VERCEL_GIT_REPO_OWNER; delete process.env.VERCEL_GIT_REPO_SLUG; process.env.DATABASE_URL = "postgres://x"; setup.mockClear(); });
+  it("refuses without a token (same message as the Python route)", async () => {
+    const res = await POST(req({ interval: 120 })); expect(res.status).toBe(400); expect(await res.json()).toEqual({ ok: false, message: "GitHub token not set" });
+  });
+  it("refuses without a repo", async () => {
+    state.pat = "ghp_x"; const res = await POST(req({})); expect(res.status).toBe(400); expect((await res.json()).message).toBe("Not deployed via Vercel (missing repo info)");
+  });
+  it("uses the Settings token + Vercel repo metadata and a valid interval", async () => {
+    state.pat = "ghp_x"; process.env.VERCEL_GIT_REPO_OWNER = "o"; process.env.VERCEL_GIT_REPO_SLUG = "r";
+    const res = await POST(req({ interval: 240 })); expect(res.status).toBe(200);
+    expect(setup).toHaveBeenCalledWith({ pat: "ghp_x", repo: "o/r", databaseUrl: "postgres://x", intervalMinutes: 240 });
+  });
+});

--- a/web/app/api/setup-actions/route.ts
+++ b/web/app/api/setup-actions/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { getDb } from "@/lib/db";
+import { authEnabled, verifySession, SESSION_COOKIE } from "@/lib/auth";
+import { getGithubPat, getGithubRepo, setupGithubActions } from "@/lib/github";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/setup-actions  { interval?: 30|60|120|240|360|720|1440 }
+ * Configures GitHub Actions auto-sync on the fork (port of the Python route, #458).
+ * Needs the GitHub token (Settings, or GITHUB_PAT), the repo (GITHUB_REPO or Vercel's git
+ * metadata) and DATABASE_URL, which becomes the fork's Actions secret.
+ */
+export async function POST(request: Request) {
+  if (authEnabled()) {
+    const store = await cookies();
+    if (!(await verifySession(store.get(SESSION_COOKIE)?.value ?? null))) return NextResponse.json({ ok: false, message: "Unauthorized" }, { status: 401 });
+  }
+  let body: { interval?: unknown } = {};
+  try { const t = await request.text(); if (t) body = JSON.parse(t); } catch { return NextResponse.json({ ok: false, message: "Invalid JSON body." }, { status: 400 }); }
+  const allowed = [30, 60, 120, 240, 360, 720, 1440];
+  const interval = allowed.includes(Number(body.interval)) ? Number(body.interval) : 120;
+
+  let sql: ReturnType<typeof getDb> | null = null;
+  try { sql = getDb(); } catch { sql = null; }
+  const pat = await getGithubPat(sql);
+  const repo = getGithubRepo();
+  const databaseUrl = process.env.DATABASE_URL?.trim();
+  if (!pat) return NextResponse.json({ ok: false, message: "GitHub token not set" }, { status: 400 });
+  if (!repo) return NextResponse.json({ ok: false, message: "Not deployed via Vercel (missing repo info)" }, { status: 400 });
+  if (!databaseUrl) return NextResponse.json({ ok: false, message: "DATABASE_URL not set" }, { status: 400 });
+
+  const r = await setupGithubActions({ pat, repo, databaseUrl, intervalMinutes: interval });
+  return NextResponse.json(r, { status: r.ok ? 200 : 502 });
+}

--- a/web/app/api/sync/route.ts
+++ b/web/app/api/sync/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { syncOneWorkout, type SyncOneResult } from "@/lib/sync-one";
 import { getDb } from "@/lib/db";
+import { getGithubPat, getGithubRepo, triggerViaActions } from "@/lib/github";
 import { verifySession, SESSION_COOKIE, authEnabled } from "@/lib/auth";
 
 // Reads live Hevy + Postgres (and, on the live path, Garmin) at request time.
@@ -47,18 +48,6 @@ function wantsLive(request: Request, body: Record<string, unknown>): boolean {
   return b === 1 || b === true || b === "1" || b === "true";
 }
 
-async function triggerViaActions(pat: string, repo: string): Promise<boolean> {
-  const res = await fetch(`https://api.github.com/repos/${repo}/dispatches`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${pat}`,
-      Accept: "application/vnd.github+json",
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({ event_type: "sync-trigger" }),
-  });
-  return res.ok;
-}
 
 export async function POST(request: Request) {
   let body: Record<string, unknown> = {};
@@ -106,8 +95,8 @@ export async function POST(request: Request) {
 
   // Live, deployed: hand off to the GitHub Action so the long browser-auth sync
   // runs off the request path.
-  const pat = process.env.GITHUB_PAT;
-  const repo = process.env.GITHUB_REPO;
+  const pat = await getGithubPat(sql);   // Settings row first, GITHUB_PAT fallback (#458)
+  const repo = getGithubRepo();
   if (pat && repo) {
     try {
       const ok = await triggerViaActions(pat, repo);

--- a/web/app/api/toggle-autosync/route.ts
+++ b/web/app/api/toggle-autosync/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { getGithubPat, getGithubRepo, setupGithubActions, disableGithubActions } from "@/lib/github";
 
 // Reads/writes the app_cache config at request time — never at build.
 export const dynamic = "force-dynamic";
@@ -41,12 +42,30 @@ export async function POST(request: Request) {
     const enabled =
       typeof body.enabled === "boolean" ? body.enabled : !Boolean(current.enabled);
     const next = { ...current, enabled };
+    // On Vercel auto-sync runs through GitHub Actions on the fork (#458, parity with the
+    // Python route): enabling needs a token and writes the workflow; disabling deletes it.
+    const onVercel = Boolean(process.env.VERCEL);
+    let actions: { ok: boolean; message: string } | null = null;
+    if (onVercel) {
+      const pat = await getGithubPat(sql);
+      const repo = getGithubRepo();
+      if (enabled) {
+        if (!pat) return NextResponse.json({ ok: false, error: "Auto-sync needs a GitHub token. Add one in Settings, then turn auto-sync on." }, { status: 400 });
+        if (repo && process.env.DATABASE_URL) {
+          const interval = Number(current.interval_minutes) || 120;
+          actions = await setupGithubActions({ pat, repo, databaseUrl: process.env.DATABASE_URL, intervalMinutes: interval });
+          if (!actions.ok) return NextResponse.json({ ok: false, error: actions.message }, { status: 502 });
+        }
+      } else if (pat && repo) {
+        await disableGithubActions({ pat, repo });
+      }
+    }
     await sql`
       INSERT INTO app_cache (key, value, updated_at)
       VALUES ('auto_sync', ${sql.json(next)}, NOW())
       ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()
     `;
-    return NextResponse.json({ ok: true, enabled });
+    return NextResponse.json({ ok: true, enabled, ...(actions ? { message: actions.message } : {}) });
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);
     return NextResponse.json({ ok: false, error }, { status: 500 });

--- a/web/app/settings/page.tsx
+++ b/web/app/settings/page.tsx
@@ -199,6 +199,7 @@ export default async function SettingsPage() {
       <section className="mb-8">
         <h2 className="mb-3 text-lg font-semibold text-text">Configuration</h2>
         <SettingsForm
+          githubTokenSet={data.platforms.some((r) => r.platform === "github" && r.status === "active")}
           autoSyncEnabled={Boolean(autoSync.enabled)}
           autoSyncInterval={Number(autoSync.interval_minutes) || 120}
           hrFusionEnabled={hrFusion.enabled == null ? true : Boolean(hrFusion.enabled)}

--- a/web/components/settings-form.tsx
+++ b/web/components/settings-form.tsx
@@ -4,6 +4,8 @@ import { useRouter } from "next/navigation";
 import { useState } from "react";
 
 interface Props {
+  /** A GitHub token is saved (platform_credentials 'github'); the value itself is never sent to the browser. */
+  githubTokenSet?: boolean;
   autoSyncEnabled: boolean;
   autoSyncInterval: number;
   hrFusionEnabled: boolean;
@@ -67,6 +69,7 @@ function Toggle({ label, checked, onChange, hint }: { label: string; checked: bo
 export function SettingsForm(p: Props) {
   const router = useRouter();
   const [autoSync, setAutoSync] = useState(p.autoSyncEnabled);
+  const [githubPat, setGithubPat] = useState("");
   const [interval, setIntervalMin] = useState(p.autoSyncInterval);
   const [hrFusion, setHrFusion] = useState(p.hrFusionEnabled);
   const [strategy, setStrategy] = useState(p.mergeWatchStrategy);
@@ -133,6 +136,7 @@ export function SettingsForm(p: Props) {
           rest_between_exercises_seconds: numOrUndef(restEx) ?? 120,
         },
       };
+      if (githubPat.trim()) (body as Record<string, unknown>).github_pat = githubPat.trim();
       const res = await fetch("/api/settings", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -154,6 +158,12 @@ export function SettingsForm(p: Props) {
 
   return (
     <form onSubmit={submit} className="space-y-6">
+      <div className={cardCls}>
+        <label className={labelCls} htmlFor="github_pat">GitHub token (auto-sync on your fork)</label>
+        <input id="github_pat" type="password" autoComplete="off" value={githubPat} onChange={(e) => setGithubPat(e.target.value)}
+          placeholder={p.githubTokenSet ? "•••• saved — enter a new one to replace it" : "ghp_… (repo + workflow scope)"} className={controlCls} />
+        <p className="mt-0.5 text-xs text-text-muted">Stored in your database, same row the Python dashboard uses. Needed to enable auto-sync on Vercel.</p>
+      </div>
       {/* Sync */}
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         <div className={cardCls}>

--- a/web/lib/garmin-token-heal.test.ts
+++ b/web/lib/garmin-token-heal.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect, vi } from "vitest";
+const queries: string[] = [];
+vi.mock("./db", () => { const tag = (async (strings: TemplateStringsArray) => { queries.push(strings.join("?").replace(/\s+/g, " ").trim()); return []; }) as unknown as { (): unknown; json: <T>(v: T) => T }; tag.json = (v) => v; return { getDb: () => tag }; });
+import { normalizeGarminTokenRow, GARMIN_TOKEN_PLATFORM } from "./garmin-upload";
+import { getDb } from "./db";
+
+describe("normalizeGarminTokenRow (#459)", () => {
+  it("nests a flat DI payload under garmin_tokens, idempotently, and only once per process", async () => {
+    await normalizeGarminTokenRow(getDb()); await normalizeGarminTokenRow(getDb());
+    expect(queries.length).toBe(1);
+    expect(queries[0]).toContain("UPDATE platform_credentials SET credentials = jsonb_build_object('garmin_tokens', credentials)");
+    expect(queries[0]).toContain("credentials ? 'di_token'"); expect(queries[0]).toContain("NOT (credentials ? 'garmin_tokens')");
+    expect(GARMIN_TOKEN_PLATFORM).toBe("garmin_tokens");
+  });
+});

--- a/web/lib/garmin-upload.ts
+++ b/web/lib/garmin-upload.ts
@@ -15,6 +15,7 @@
  * (dryRun === false). `findExistingActivity` is a READ (the 409-prevention
  * lookup) and is always safe to call.
  */
+import { getDb } from "./db";
 import { GarminAuth, DBTokenStore, type GarminClient } from "garmin-auth";
 import {
   uploadFit,
@@ -28,6 +29,26 @@ import {
 export const GARMIN_TOKEN_PLATFORM = "garmin_tokens";
 
 let cachedClient: GarminClient | null = null;
+let normalized = false;
+
+/**
+ * Self-heal the token row (#459). garmin-auth < 0.3 (Python 0.2.x) wrote the DI payload FLAT
+ * ({di_token, …}); 0.3+ on both stacks writes it NESTED under `garmin_tokens`, which is the only
+ * shape DBTokenStore reads. A fork whose row was written by an older deploy would be told to
+ * "reconnect Garmin" for no reason. Idempotent; runs once per process; never throws.
+ */
+export async function normalizeGarminTokenRow(sql: ReturnType<typeof getDb>): Promise<void> {
+  if (normalized) return;
+  try {
+    await sql`
+      UPDATE platform_credentials
+         SET credentials = jsonb_build_object('garmin_tokens', credentials), auth_type = 'oauth', status = 'active'
+       WHERE platform = ${GARMIN_TOKEN_PLATFORM}
+         AND credentials ? 'di_token'
+         AND NOT (credentials ? 'garmin_tokens')`;
+    normalized = true;
+  } catch { /* best effort: DBTokenStore reports the real problem if any */ }
+}
 
 /**
  * Build (and cache) an authenticated GarminClient from the DI tokens stored in
@@ -42,6 +63,7 @@ export async function getGarminClient(databaseUrl?: string): Promise<GarminClien
   if (cachedClient) return cachedClient;
   const url = databaseUrl ?? process.env.DATABASE_URL;
   if (!url) throw new Error("DATABASE_URL not set (cannot load Garmin tokens)");
+  try { await normalizeGarminTokenRow(getDb()); } catch { /* no DB handle: DBTokenStore reports it */ }
   const store = new DBTokenStore(url, GARMIN_TOKEN_PLATFORM);
   const auth = new GarminAuth({ store });
   cachedClient = await auth.client();

--- a/web/lib/github.test.ts
+++ b/web/lib/github.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import sodium from "libsodium-wrappers";
+import { minutesToCron, formatIntervalLabel, buildSyncWorkflowYaml, sealSecret, setupGithubActions, disableGithubActions } from "./github";
+
+describe("cron + labels (parity with the Python dashboard)", () => {
+  it("maps the dashboard's intervals", () => {
+    expect(minutesToCron(30)).toBe("*/30 * * * *");
+    expect(minutesToCron(60)).toBe("0 * * * *");
+    expect(minutesToCron(120)).toBe("0 */2 * * *");
+    expect(minutesToCron(240)).toBe("0 */4 * * *");
+    expect(minutesToCron(1440)).toBe("0 0 * * *");
+    expect(minutesToCron(45)).toBe("0 */2 * * *"); // unexpected → default
+  });
+  it("labels", () => {
+    expect(formatIntervalLabel(30)).toBe("30 minutes");
+    expect(formatIntervalLabel(60)).toBe("1 hour");
+    expect(formatIntervalLabel(120)).toBe("2 hours");
+    expect(formatIntervalLabel(1440)).toBe("24 hours");
+  });
+});
+
+describe("sync workflow YAML", () => {
+  it("is byte-for-byte what the Python dashboard writes (tests/fixtures/sync_workflow_120.yml)", () => {
+    const golden = readFileSync(new URL("../../tests/fixtures/sync_workflow_120.yml", import.meta.url), "utf8");
+    expect(buildSyncWorkflowYaml(120)).toBe(golden);
+  });
+});
+
+describe("sealSecret", () => {
+  it("produces a sealed box the repo's private key can open", async () => {
+    await sodium.ready;
+    const kp = sodium.crypto_box_keypair();
+    const pkB64 = sodium.to_base64(kp.publicKey, sodium.base64_variants.ORIGINAL);
+    const sealed = await sealSecret(pkB64, "postgres://u:p@h/db");
+    const opened = sodium.crypto_box_seal_open(sodium.from_base64(sealed, sodium.base64_variants.ORIGINAL), kp.publicKey, kp.privateKey);
+    expect(sodium.to_string(opened)).toBe("postgres://u:p@h/db");
+  });
+});
+
+function fakeGithub(overrides: Partial<Record<string, (init?: RequestInit) => Response>> = {}) {
+  const calls: { method: string; path: string; body?: unknown }[] = [];
+  const kp = { pub: "" };
+  const fetchImpl = (async (url: string | URL, init?: RequestInit) => {
+    const u = String(url); const path = u.replace("https://api.github.com/repos/", ""); const method = (init?.method ?? "GET").toUpperCase();
+    calls.push({ method, path, body: init?.body ? JSON.parse(String(init.body)) : undefined });
+    const key = `${method} ${path}`;
+    if (overrides[key]) return overrides[key]!(init);
+    if (key === "PATCH o/r") return new Response("{}", { status: 200 });
+    if (key === "PUT o/r/actions/permissions") return new Response(null, { status: 204 });
+    if (key === "GET o/r/actions/secrets/public-key") return new Response(JSON.stringify({ key: kp.pub, key_id: "k1" }), { status: 200 });
+    if (key === "GET o/r/contents/.github/workflows/sync.yml") return new Response(JSON.stringify({ sha: "abc" }), { status: 200 });
+    if (key === "PUT o/r/actions/secrets/DATABASE_URL") return new Response(null, { status: 201 });
+    if (key === "PUT o/r/contents/.github/workflows/sync.yml") return new Response("{}", { status: 200 });
+    if (key === "POST o/r/dispatches") return new Response(null, { status: 204 });
+    if (key === "DELETE o/r/contents/.github/workflows/sync.yml") return new Response("{}", { status: 200 });
+    return new Response("nope", { status: 404 });
+  }) as unknown as typeof fetch;
+  return { calls, fetchImpl, kp };
+}
+
+describe("setupGithubActions", () => {
+  it("runs the Python sequence: public + permissions + key + workflow, then secret + workflow (with sha), then dispatch", async () => {
+    await sodium.ready; const { calls, fetchImpl, kp } = fakeGithub(); kp.pub = sodium.to_base64(sodium.crypto_box_keypair().publicKey, sodium.base64_variants.ORIGINAL);
+    const r = await setupGithubActions({ pat: "t", repo: "o/r", databaseUrl: "postgres://x", intervalMinutes: 240, fetchImpl });
+    expect(r).toEqual({ ok: true, message: "Auto-sync enabled! Workouts will sync every 4 hours." });
+    await new Promise((res) => setTimeout(res, 10));
+    const seq = calls.map((c) => `${c.method} ${c.path}`);
+    expect(seq.slice(0, 4).sort()).toEqual(["GET o/r/actions/secrets/public-key", "GET o/r/contents/.github/workflows/sync.yml", "PATCH o/r", "PUT o/r/actions/permissions"].sort());
+    expect(seq.slice(4, 6).sort()).toEqual(["PUT o/r/actions/secrets/DATABASE_URL", "PUT o/r/contents/.github/workflows/sync.yml"].sort());
+    expect(seq[6]).toBe("POST o/r/dispatches");
+    const wf = calls.find((c) => c.method === "PUT" && c.path.endsWith("sync.yml"))!.body as { sha: string; content: string; message: string };
+    expect(wf.sha).toBe("abc"); expect(wf.message).toBe("feat: auto-sync every 4 hours");
+    expect(Buffer.from(wf.content, "base64").toString("utf8")).toBe(buildSyncWorkflowYaml(240));
+    const secret = calls.find((c) => c.path.endsWith("secrets/DATABASE_URL"))!.body as { key_id: string; encrypted_value: string };
+    expect(secret.key_id).toBe("k1"); expect(secret.encrypted_value.length).toBeGreaterThan(20);
+  });
+  it("reports a failed permissions call the way Python does", async () => {
+    await sodium.ready; const { fetchImpl, kp } = fakeGithub({ "PUT o/r/actions/permissions": () => new Response("x", { status: 500 }) }); kp.pub = sodium.to_base64(sodium.crypto_box_keypair().publicKey, sodium.base64_variants.ORIGINAL);
+    expect(await setupGithubActions({ pat: "t", repo: "o/r", databaseUrl: "postgres://x", fetchImpl })).toEqual({ ok: false, message: "Failed to enable Actions: HTTP 500" });
+  });
+  it("disable deletes the workflow with its sha", async () => {
+    const { calls, fetchImpl } = fakeGithub();
+    expect(await disableGithubActions({ pat: "t", repo: "o/r", fetchImpl })).toBe(true);
+    const del = calls.find((c) => c.method === "DELETE")!; expect((del.body as { sha: string }).sha).toBe("abc");
+  });
+});

--- a/web/lib/github.ts
+++ b/web/lib/github.ts
@@ -1,0 +1,174 @@
+/**
+ * GitHub integration for auto-sync on a fork (port of the Python dashboard's
+ * get_github_pat / _setup_github_actions / _build_sync_workflow_yaml, #458).
+ *
+ * The token lives in `platform_credentials` (platform 'github', credentials.pat) — the
+ * row the Python dashboard writes from its Settings page — with GITHUB_PAT as the env
+ * fallback. Never log or return the token.
+ */
+import sodium from "libsodium-wrappers";
+import type { getDb } from "./db";
+
+type Sql = ReturnType<typeof getDb>;
+
+/** The token: DB row first (set in-app), then the GITHUB_PAT environment variable. */
+export async function getGithubPat(sql: Sql | null): Promise<string | null> {
+  if (sql) {
+    try {
+      const rows = (await sql`SELECT credentials FROM platform_credentials WHERE platform = 'github' LIMIT 1`) as { credentials: unknown }[];
+      const c = rows[0]?.credentials;
+      const creds = typeof c === "string" ? (JSON.parse(c) as Record<string, unknown>) : (c as Record<string, unknown> | undefined);
+      const pat = creds?.pat;
+      if (typeof pat === "string" && pat.trim()) return pat.trim();
+    } catch { /* fall through to env */ }
+  }
+  const env = process.env.GITHUB_PAT?.trim();
+  return env || null;
+}
+
+/** Store the token the way the Python dashboard does (same row, same keys). */
+export async function saveGithubPat(sql: Sql, pat: string): Promise<void> {
+  await sql`
+    INSERT INTO platform_credentials (platform, auth_type, credentials, status)
+    VALUES ('github', 'pat', ${sql.json({ pat })}, 'active')
+    ON CONFLICT (platform) DO UPDATE SET credentials = EXCLUDED.credentials, status = 'active'`;
+}
+
+/** "owner/repo": GITHUB_REPO, else Vercel's git metadata (a fork deployed from GitHub). */
+export function getGithubRepo(): string | null {
+  const explicit = process.env.GITHUB_REPO?.trim();
+  if (explicit) return explicit;
+  const owner = process.env.VERCEL_GIT_REPO_OWNER?.trim();
+  const slug = process.env.VERCEL_GIT_REPO_SLUG?.trim();
+  return owner && slug ? `${owner}/${slug}` : null;
+}
+
+function gh(pat: string, path: string, init: RequestInit = {}): Promise<Response> {
+  return fetch(`https://api.github.com/repos/${path}`, {
+    ...init,
+    headers: { Authorization: `Bearer ${pat}`, Accept: "application/vnd.github+json", "Content-Type": "application/json", ...(init.headers ?? {}) },
+    signal: init.signal ?? AbortSignal.timeout(10_000),
+  });
+}
+
+/** repository_dispatch 'sync-trigger' → the fork's sync workflow runs the long sync off the request path. */
+export async function triggerViaActions(pat: string, repo: string): Promise<boolean> {
+  const res = await gh(pat, `${repo}/dispatches`, { method: "POST", body: JSON.stringify({ event_type: "sync-trigger" }) });
+  return res.ok;
+}
+
+/** Interval (minutes) → cron. Same table as the Python dashboard's select: 30, 60, 120, 240, 360, 720, 1440. */
+export function minutesToCron(minutes: number): string {
+  if (minutes === 30) return "*/30 * * * *";
+  if (minutes === 60) return "0 * * * *";
+  if (minutes === 1440) return "0 0 * * *";
+  if (minutes >= 60 && minutes % 60 === 0) return `0 */${Math.floor(minutes / 60)} * * *`;
+  return "0 */2 * * *";
+}
+
+export function formatIntervalLabel(minutes: number): string {
+  if (minutes < 60) return `${minutes} minutes`;
+  if (minutes === 60) return "1 hour";
+  if (minutes === 1440) return "24 hours";
+  if (minutes % 60 === 0) return `${Math.floor(minutes / 60)} hours`;
+  return `${minutes} minutes`;
+}
+
+/** The workflow the Python dashboard writes into the fork, byte-for-byte. */
+export function buildSyncWorkflowYaml(intervalMinutes: number): string {
+  const cron = minutesToCron(intervalMinutes);
+  return (
+    "name: Sync Workouts\n\n" +
+    "on:\n" +
+    "  schedule:\n" +
+    `    - cron: '${cron}'\n` +
+    "  workflow_dispatch: {}\n" +
+    "  repository_dispatch:\n" +
+    "    types: [sync-trigger]\n\n" +
+    "concurrency:\n" +
+    "  group: sync\n" +
+    "  cancel-in-progress: false\n\n" +
+    "jobs:\n" +
+    "  sync:\n" +
+    "    runs-on: ubuntu-latest\n" +
+    "    timeout-minutes: 30\n" +
+    "    steps:\n" +
+    "      - uses: actions/checkout@v5\n" +
+    "      - uses: actions/setup-python@v6\n" +
+    "        with:\n" +
+    "          python-version: '3.12'\n" +
+    "      - name: Install\n" +
+    "        run: pip install \".[cloud]\"\n" +
+    "      - name: Sync\n" +
+    "        env:\n" +
+    "          DATABASE_URL: ${{ secrets.DATABASE_URL }}\n" +
+    "        run: hevy2garmin sync\n"
+  );
+}
+
+const WF_PATH = "contents/.github/workflows/sync.yml";
+
+/** GitHub's secret encryption: a libsodium sealed box over the repo's public key. */
+export async function sealSecret(publicKeyB64: string, value: string): Promise<string> {
+  await sodium.ready;
+  const pk = sodium.from_base64(publicKeyB64, sodium.base64_variants.ORIGINAL);
+  const sealed = sodium.crypto_box_seal(sodium.from_string(value), pk);
+  return sodium.to_base64(sealed, sodium.base64_variants.ORIGINAL);
+}
+
+export interface SetupResult { ok: boolean; message: string }
+
+/**
+ * Configure auto-sync on the fork: make the repo public, enable Actions, store DATABASE_URL
+ * as a repo secret, write .github/workflows/sync.yml, then fire the first sync-trigger.
+ * Same calls and order as the Python `_setup_github_actions`.
+ */
+export async function setupGithubActions(opts: { pat: string; repo: string; databaseUrl: string; intervalMinutes?: number; fetchImpl?: typeof fetch }): Promise<SetupResult> {
+  const interval = opts.intervalMinutes ?? 120;
+  const { pat, repo, databaseUrl } = opts;
+  const f = opts.fetchImpl ?? fetch;
+  const call = (path: string, init: RequestInit = {}) => f(`https://api.github.com/repos/${repo}${path ? `/${path}` : ""}`, {
+    ...init, headers: { Authorization: `Bearer ${pat}`, Accept: "application/vnd.github+json", "Content-Type": "application/json" }, signal: AbortSignal.timeout(10_000),
+  });
+  try {
+    const [, actions, pk, wf] = await Promise.all([
+      call("", { method: "PATCH", body: JSON.stringify({ private: false }) }),
+      call("actions/permissions", { method: "PUT", body: JSON.stringify({ enabled: true }) }),
+      call("actions/secrets/public-key"),
+      call(WF_PATH),
+    ]);
+    if (![200, 204].includes(actions.status)) return { ok: false, message: `Failed to enable Actions: HTTP ${actions.status}` };
+    if (!pk.ok) return { ok: false, message: `Failed to get repo public key: HTTP ${pk.status}` };
+    const pkData = (await pk.json()) as { key: string; key_id: string };
+    const encrypted = await sealSecret(pkData.key, databaseUrl);
+    const payload: Record<string, string> = {
+      message: `feat: auto-sync every ${formatIntervalLabel(interval)}`,
+      content: Buffer.from(buildSyncWorkflowYaml(interval), "utf8").toString("base64"),
+    };
+    if (wf.status === 200) { const j = (await wf.json()) as { sha?: string }; if (j.sha) payload.sha = j.sha; }
+    const [secret] = await Promise.all([
+      call("actions/secrets/DATABASE_URL", { method: "PUT", body: JSON.stringify({ encrypted_value: encrypted, key_id: pkData.key_id }) }),
+      call(WF_PATH, { method: "PUT", body: JSON.stringify(payload) }),
+    ]);
+    if (![200, 201, 204].includes(secret.status)) return { ok: false, message: `Failed to set DATABASE_URL secret: HTTP ${secret.status}` };
+    void call("dispatches", { method: "POST", body: JSON.stringify({ event_type: "sync-trigger" }) }).catch(() => undefined);
+    return { ok: true, message: `Auto-sync enabled! Workouts will sync every ${formatIntervalLabel(interval)}.` };
+  } catch (e) {
+    return { ok: false, message: `Failed to set up auto-sync: ${(e as Error).message}` };
+  }
+}
+
+/** Disable: delete the workflow file from the fork (best effort, like the Python side). */
+export async function disableGithubActions(opts: { pat: string; repo: string; fetchImpl?: typeof fetch }): Promise<boolean> {
+  const f = opts.fetchImpl ?? fetch;
+  const call = (path: string, init: RequestInit = {}) => f(`https://api.github.com/repos/${opts.repo}${path ? `/${path}` : ""}`, {
+    ...init, headers: { Authorization: `Bearer ${opts.pat}`, Accept: "application/vnd.github+json", "Content-Type": "application/json" }, signal: AbortSignal.timeout(10_000),
+  });
+  try {
+    const wf = await call(WF_PATH);
+    if (wf.status !== 200) return false;
+    const { sha } = (await wf.json()) as { sha?: string };
+    const del = await call(WF_PATH, { method: "DELETE", body: JSON.stringify({ message: "disable auto-sync", sha }) });
+    return del.ok;
+  } catch { return false; }
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.1.0",
       "dependencies": {
         "@garmin/fitsdk": "^21.212.0",
+        "@types/libsodium-wrappers": "^0.7.14",
         "garmin-auth": "^0.4.1",
         "hevy2garmin": "^0.1.4",
+        "libsodium-wrappers": "^0.8.4",
         "next": "^16.1.0",
         "postgres": "^3.4.9",
         "react": "^19.1.0",
@@ -2890,6 +2892,12 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/libsodium-wrappers": {
+      "version": "0.7.14",
+      "resolved": "https://registry.npmjs.org/@types/libsodium-wrappers/-/libsodium-wrappers-0.7.14.tgz",
+      "integrity": "sha512-5Kv68fXuXK0iDuUir1WPGw2R9fOZUlYlSAa0ztMcL0s0BfIDTqg9GXz8K30VJpPP3sxWhbolnQma2x+/TfkzDQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.20.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
@@ -4472,6 +4480,21 @@
       "peer": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/libsodium": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.8.4.tgz",
+      "integrity": "sha512-lMcYaRi0zcs7tarATsQUYC7rstliIXZuoq0c6zXSgNtSNtdvBgkSegjWhpMJAXzKX3SUSwIp7+zEsob+j3LuRw==",
+      "license": "ISC"
+    },
+    "node_modules/libsodium-wrappers": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.8.4.tgz",
+      "integrity": "sha512-mu8aAWucZjTB5O/BtGXtW4e1agy7uHxNYG7zPthmmD1jU43LCDmSWZLN4JhflbdPXj3yDO4lxM1O9hLDgIOXDw==",
+      "license": "ISC",
+      "dependencies": {
+        "libsodium": "^0.8.0"
       }
     },
     "node_modules/lighthouse-logger": {

--- a/web/package.json
+++ b/web/package.json
@@ -18,8 +18,10 @@
   },
   "dependencies": {
     "@garmin/fitsdk": "^21.212.0",
+    "@types/libsodium-wrappers": "^0.7.14",
     "garmin-auth": "^0.4.1",
     "hevy2garmin": "^0.1.4",
+    "libsodium-wrappers": "^0.8.4",
     "next": "^16.1.0",
     "postgres": "^3.4.9",
     "react": "^19.1.0",


### PR DESCRIPTION
## The sentence
For `repo://<fork>` deployed on Vercel, the web dashboard knows `github_token := set|unset` (observed from the platform_credentials row the Python dashboard also writes; env as fallback) and can do `setup_actions` (tier confirm — it writes a workflow and a secret into the owner's fork; executor script; compensable by disable; exclusive; batch) when the owner turns auto-sync on, producing `fork.actions_configured` (commanded), so that `auto_sync_runs` = "the fork's sync.yml exists and DATABASE_URL is a repo secret", rendered at Settings, governed by policy the-same-file-the-Python-dashboard-writes. For `platform_credentials/garmin_tokens`, the row is normalised to the nested shape on both stacks so a fork never re-authenticates because of a version it once ran.

## Done is an observation
- External writes (GitHub API) are mocked per the owner's policy: the call sequence, the sealed secret (opened with the keypair in the test), the workflow content (byte-equal to the Python builder via a shared golden fixture) and the disable path are asserted in `web/lib/github.test.ts`; route guards in `web/app/api/setup-actions/route.test.ts`; the self-heal SQL in `web/lib/garmin-token-heal.test.ts` and `tests/test_workflow_yaml_parity.py` (Postgres job).
- Local rehearsals of both fresh-fork checks pass; this PR's own CI is the verify_cmd.

## Forkers
A fork that syncs main keeps working: env-only setups still resolve GITHUB_PAT; the new dependency is in the lockfile (strict `npm ci` in CI); the token self-heal is idempotent and touches only the `garmin_tokens` row.

Closes #458
Closes #459
