### PR TITLE
feat(web): accept H2G_SECRET and H2G_PASSWORD_HASH (argon2) like the Python dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ A Next.js rebuild of the dashboard lives in `web/`. It uses the same database an
 
 ```bash
 cd web
-cp .env.example .env.local   # fill in DATABASE_URL, H2G_PASSWORD, HEVY2GARMIN_SECRET, CRON_SECRET
+cp .env.example .env.local   # fill in DATABASE_URL, H2G_PASSWORD (or H2G_PASSWORD_HASH), HEVY2GARMIN_SECRET (or H2G_SECRET), CRON_SECRET
 npm ci && npm run dev        # http://localhost:8096
 ```
 

--- a/web/.env.example
+++ b/web/.env.example
@@ -4,7 +4,8 @@
 # Required
 DATABASE_URL=postgres://user:password@host/dbname          # Neon or any Postgres; shared with the Python dashboard and the CLI
 H2G_PASSWORD=change-me                                       # dashboard login password (plain); or set H2G_PASSWORD_HASH (argon2) instead
-HEVY2GARMIN_SECRET=change-me-32-random-chars                 # signs the login session cookie (also accepted as H2G_SECRET)
+HEVY2GARMIN_SECRET=change-me-32-random-chars                 # signs the login session cookie; H2G_SECRET is accepted too (Python-compatible derivation)
+# H2G_PASSWORD_HASH=$argon2id$...                            # instead of H2G_PASSWORD: output of `hevy2garmin hash-password` (argon2)
 CRON_SECRET=change-me-32-random-chars                        # Vercel Cron / GitHub Actions call /api/cron/sync with this bearer
 
 # Optional

--- a/web/app/api/login/route.test.ts
+++ b/web/app/api/login/route.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("@/lib/auth", () => ({
   authEnabled: () => true,
   checkPassword: (p: string) => p === "correct-horse",
+  verifyPassword: async (p: string) => p === "correct-horse",
   signSession: async () => "v1.123.deadbeefdeadbeefdeadbeefdeadbeef",
   SESSION_COOKIE: "h2g_session",
 }));

--- a/web/app/api/login/route.ts
+++ b/web/app/api/login/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { checkPassword, signSession, SESSION_COOKIE, authEnabled } from "@/lib/auth";
+import { verifyPassword, signSession, SESSION_COOKIE, authEnabled } from "@/lib/auth";
 import { getDb } from "@/lib/db";
 import { getSessionEpoch } from "@/lib/session-epoch";
 import { lockoutRemaining, recordFailure, clearFailures, formatCooldown } from "@/lib/login-ratelimit";
@@ -52,7 +52,7 @@ export async function POST(req: Request) {
     }
   }
 
-  if (!body.password || !checkPassword(body.password)) {
+  if (!body.password || !(await verifyPassword(body.password))) {
     if (sql) {
       await recordFailure(sql, key);
       const remaining = await lockoutRemaining(sql, key);

--- a/web/lib/auth.test.ts
+++ b/web/lib/auth.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
 import { createHmac } from "node:crypto";
-import { signSession, verifySession, checkPassword } from "./auth";
+import { signSession, verifySession, checkPassword, authEnabled, verifyPassword } from "./auth";
 
 /** Build a valid legacy v1 cookie the way the pre-epoch app signed them. */
 function makeV1Cookie(secret: string, ts: number): string {
@@ -88,5 +88,31 @@ describe("checkPassword", () => {
     expect(checkPassword("hunter2xy")).toBe(false);
     expect(checkPassword("short")).toBe(false);
     delete process.env.H2G_PASSWORD;
+  });
+});
+
+describe("auth env parity with the Python dashboard (#460)", () => {
+  const saved = { ...process.env };
+  const reset = () => { for (const k of ["HEVY2GARMIN_SECRET", "H2G_SECRET", "H2G_PASSWORD", "H2G_PASSWORD_HASH"]) delete process.env[k]; };
+  afterEach(() => { reset(); Object.assign(process.env, saved); });
+
+  it("H2G_SECRET alone enables auth and signs/verifies a session", async () => {
+    reset(); process.env.H2G_SECRET = "seed-from-python-side";
+    expect(authEnabled()).toBe(true);
+    const c = await signSession(0); expect(await verifySession(c, 0)).toBe(true);
+  });
+  it("H2G_PASSWORD_HASH alone enables auth and verifies an argon2 candidate", async () => {
+    reset();
+    const { argon2id } = await import("hash-wasm");
+    const hash = await argon2id({ password: "hunter2", salt: new Uint8Array(16).fill(7), parallelism: 1, iterations: 2, memorySize: 8192, hashLength: 32, outputType: "encoded" });
+    process.env.H2G_PASSWORD_HASH = hash;
+    expect(authEnabled()).toBe(true);
+    expect(await verifyPassword("hunter2")).toBe(true);
+    expect(await verifyPassword("hunter3")).toBe(false);
+    const c = await signSession(0); expect(await verifySession(c, 0)).toBe(true);
+  });
+  it("falls back to the plaintext password when no hash is set", async () => {
+    reset(); process.env.H2G_PASSWORD = "plain";
+    expect(await verifyPassword("plain")).toBe(true); expect(await verifyPassword("wrong")).toBe(false);
   });
 });

--- a/web/lib/auth.ts
+++ b/web/lib/auth.ts
@@ -36,7 +36,10 @@ let cachedKey: { material: string; key: CryptoKey } | null = null;
  */
 async function getKey(): Promise<CryptoKey> {
   const secret = process.env.HEVY2GARMIN_SECRET;
-  const password = process.env.H2G_PASSWORD;
+  // Python's auth.py `_secret()`: H2G_SECRET, else the password, else the password hash —
+  // all run through SHA-256("h2g-session-" + seed). HEVY2GARMIN_SECRET keeps its raw-bytes
+  // behaviour for existing deployments. (#460 parity)
+  const seed = process.env.H2G_SECRET || process.env.H2G_PASSWORD || process.env.H2G_PASSWORD_HASH;
 
   let material: string;
   let rawKey: Uint8Array;
@@ -45,12 +48,12 @@ async function getKey(): Promise<CryptoKey> {
     material = `secret:${secret}`;
     rawKey = new TextEncoder().encode(secret);
   } else {
-    if (!password) throw new Error("H2G_PASSWORD not set (and no HEVY2GARMIN_SECRET)");
-    material = `password:${password}`;
-    // SHA-256("h2g-session-" + password) — matches auth.py `_secret()`.
+    if (!seed) throw new Error("no signing seed: set H2G_PASSWORD, H2G_PASSWORD_HASH, H2G_SECRET or HEVY2GARMIN_SECRET");
+    material = `seed:${seed}`;
+    // SHA-256("h2g-session-" + seed) — matches auth.py `_secret()`.
     const digest = await crypto.subtle.digest(
       "SHA-256",
-      new TextEncoder().encode(`h2g-session-${password}`),
+      new TextEncoder().encode(`h2g-session-${seed}`),
     );
     rawKey = new Uint8Array(digest);
   }
@@ -77,7 +80,7 @@ async function hmacHex32(data: string): Promise<string> {
 
 /** True when auth is configured (either a secret or a password is present). */
 export function authEnabled(): boolean {
-  return Boolean(process.env.HEVY2GARMIN_SECRET || process.env.H2G_PASSWORD);
+  return Boolean(process.env.HEVY2GARMIN_SECRET || process.env.H2G_SECRET || process.env.H2G_PASSWORD || process.env.H2G_PASSWORD_HASH);
 }
 
 /**
@@ -145,4 +148,22 @@ export function checkPassword(candidate: string): boolean {
   let diff = 0;
   for (let i = 0; i < pw.length; i++) diff |= candidate.charCodeAt(i) ^ pw.charCodeAt(i);
   return diff === 0;
+}
+
+/**
+ * Verify a login candidate the way auth.py `check_password` does: against the argon2
+ * H2G_PASSWORD_HASH when set (`hevy2garmin hash-password` output, an encoded
+ * `$argon2id$…` string), else the plaintext H2G_PASSWORD. (#460 parity)
+ */
+export async function verifyPassword(candidate: string): Promise<boolean> {
+  const hash = process.env.H2G_PASSWORD_HASH?.trim();
+  if (hash) {
+    try {
+      const { argon2Verify } = await import("hash-wasm");
+      return await argon2Verify({ password: candidate, hash });
+    } catch {
+      return false;
+    }
+  }
+  return checkPassword(candidate);
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -11,6 +11,7 @@
         "@garmin/fitsdk": "^21.212.0",
         "@types/libsodium-wrappers": "^0.7.14",
         "garmin-auth": "^0.4.1",
+        "hash-wasm": "^4.12.0",
         "hevy2garmin": "^0.1.4",
         "libsodium-wrappers": "^0.8.4",
         "next": "^16.1.0",
@@ -4119,6 +4120,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/hash-wasm": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/hash-wasm/-/hash-wasm-4.12.0.tgz",
+      "integrity": "sha512-+/2B2rYLb48I/evdOIhP+K/DD2ca2fgBjp6O+GBEnCDk2e4rpeXIK8GvIyRPjTezgmWn9gmKwkQjjx6BtqDHVQ==",
+      "license": "MIT"
     },
     "node_modules/hasown": {
       "version": "2.0.4",

--- a/web/package.json
+++ b/web/package.json
@@ -20,6 +20,7 @@
     "@garmin/fitsdk": "^21.212.0",
     "@types/libsodium-wrappers": "^0.7.14",
     "garmin-auth": "^0.4.1",
+    "hash-wasm": "^4.12.0",
     "hevy2garmin": "^0.1.4",
     "libsodium-wrappers": "^0.8.4",
     "next": "^16.1.0",

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -21,18 +21,19 @@ let cachedKey: { material: string; key: CryptoKey } | null = null;
 
 async function getKey(): Promise<CryptoKey> {
   const secret = process.env.HEVY2GARMIN_SECRET;
-  const password = process.env.H2G_PASSWORD;
+  // Same seed order as lib/auth.ts and Python auth.py `_secret()` (#460).
+  const seed = process.env.H2G_SECRET || process.env.H2G_PASSWORD || process.env.H2G_PASSWORD_HASH;
   let material: string;
   let rawKey: Uint8Array;
   if (secret) {
     material = `secret:${secret}`;
     rawKey = new TextEncoder().encode(secret);
   } else {
-    if (!password) throw new Error("no auth secret");
-    material = `password:${password}`;
+    if (!seed) throw new Error("no auth secret");
+    material = `seed:${seed}`;
     const digest = await crypto.subtle.digest(
       "SHA-256",
-      new TextEncoder().encode(`h2g-session-${password}`),
+      new TextEncoder().encode(`h2g-session-${seed}`),
     );
     rawKey = new Uint8Array(digest);
   }
@@ -89,7 +90,7 @@ async function verifySession(cookie: string | null, epoch: number): Promise<bool
 }
 
 function authEnabled(): boolean {
-  return Boolean(process.env.HEVY2GARMIN_SECRET || process.env.H2G_PASSWORD);
+  return Boolean(process.env.HEVY2GARMIN_SECRET || process.env.H2G_SECRET || process.env.H2G_PASSWORD || process.env.H2G_PASSWORD_HASH);
 }
 
 /* The "sign out everywhere" epoch, read from the public /api/session-epoch and


### PR DESCRIPTION
## The sentence
For `deploy://<fork>` of the web dashboard, we know `auth_env := {HEVY2GARMIN_SECRET | H2G_SECRET} × {H2G_PASSWORD | H2G_PASSWORD_HASH}` (declared by the forker, the same names the Python dashboard and the README use), and can do `login` (tier none; executor script; reversible; shared; interactive) producing `session.signed`, so that `cutover_keeps_sessions` = "a deployment secured per the README logs in on both stacks with the same env", rendered at /login, governed by policy the-web-accepts-every-name-the-python-side-does.

## Done is an observation
- `web/lib/auth.test.ts`: an argon2id hash generated in the test verifies the right password and rejects the wrong one; H2G_SECRET alone enables auth and round-trips a session; plaintext fallback unchanged. Full suite green; both fresh-fork checks are this PR's own CI.

## Forkers
Additive: existing HEVY2GARMIN_SECRET / H2G_PASSWORD setups behave exactly as before; hash-wasm is pure WASM (no native binary), pinned in the lockfile.

Closes #460
