### PR TITLE
feat(web): last Python→web gaps + the first Playwright parity smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,14 @@ jobs:
       - name: Test
         run: npm test
 
+      - name: Playwright smoke (desktop)
+        # A production build started with only a password: no database, every page must still render.
+        run: |
+          npx playwright install --with-deps chromium
+          npx playwright test --project=desktop
+        env:
+          CI: "1"
+
   check-fresh-fork:
     # What a forker's Vercel deploy actually installs: the base [project.dependencies]
     # only — no [dev]/[cloud] extras, no requirements.txt, non-editable (#357/#358 shape).

--- a/web/app/api/pull-garmin-profile/route.test.ts
+++ b/web/app/api/pull-garmin-profile/route.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect, vi } from "vitest";
+vi.mock("@/lib/auth", () => ({ authEnabled: () => false, verifySession: async () => true, SESSION_COOKIE: "h2g_session" }));
+const writes: { key: string; value: Record<string, unknown> }[] = [];
+vi.mock("@/lib/db", () => { const tag = (async (strings: TemplateStringsArray, ...values: unknown[]) => { const q = strings.join("?"); if (q.startsWith("SELECT value FROM app_cache")) return [{ value: { timezone: "Europe/Athens", weight_kg: 70 } }]; if (q.includes("INSERT INTO app_cache")) { writes.push({ key: values[0] as string, value: values[1] as Record<string, unknown> }); return []; } throw new Error("unexpected: " + q); }) as unknown as { (): unknown; json: <T>(v: T) => T }; tag.json = (v) => v; return { getDb: () => tag }; });
+const { connectapi } = vi.hoisted(() => ({ connectapi: vi.fn(async () => ({ userData: { weight: 73250, birthDate: "1994-07-01", gender: "MALE", vo2MaxRunning: 52.4 } })) }));
+vi.mock("@/lib/garmin-upload", () => ({ getGarminClient: async () => ({ connectapi }) }));
+import { POST } from "./route";
+
+describe("POST /api/pull-garmin-profile", () => {
+  it("maps Garmin user-settings into user_profile with the Python units and keeps other keys", async () => {
+    const res = await POST(); const j = await res.json();
+    expect(res.status).toBe(200); expect(j.ok).toBe(true);
+    expect(j.profile).toEqual({ weight_kg: 73.3, birth_year: 1994, sex: "male", vo2max: 52.4 });
+    expect(writes[0].key).toBe("user_profile"); expect(writes[0].value).toEqual({ timezone: "Europe/Athens", weight_kg: 73.3, birth_year: 1994, sex: "male", vo2max: 52.4 });
+    expect(connectapi).toHaveBeenCalledWith("/userprofile-service/userprofile/user-settings");
+  });
+});

--- a/web/app/api/pull-garmin-profile/route.ts
+++ b/web/app/api/pull-garmin-profile/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { getDb } from "@/lib/db";
+import { verifySession, SESSION_COOKIE, authEnabled } from "@/lib/auth";
+import { getGarminClient } from "@/lib/garmin-upload";
+import { saveConfigKey } from "@/lib/config";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/pull-garmin-profile — import weight, birth year, sex and VO2max from Garmin into
+ * app_cache 'user_profile' (port of the Python route; same fields, same units: kg, year,
+ * 'male'|'female', ml/kg/min). Returns JSON instead of an HTML toast (#461).
+ */
+export async function POST() {
+  if (authEnabled()) {
+    const store = await cookies();
+    if (!(await verifySession(store.get(SESSION_COOKIE)?.value ?? null))) return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+  }
+  let sql: ReturnType<typeof getDb>;
+  try { sql = getDb(); } catch (err) { return NextResponse.json({ ok: false, error: `DB unavailable: ${err instanceof Error ? err.message : String(err)}` }, { status: 503 }); }
+  try {
+    const client = await getGarminClient();
+    const raw = (await client.connectapi("/userprofile-service/userprofile/user-settings")) as { userData?: Record<string, unknown> };
+    const u = raw?.userData ?? {};
+    const patch: Record<string, unknown> = {};
+    const w = Number(u.weight); if (Number.isFinite(w) && w > 0) patch.weight_kg = Math.round(w / 100) / 10;   // grams → kg, 1 dp
+    const bd = typeof u.birthDate === "string" ? u.birthDate.slice(0, 4) : ""; if (/^\d{4}$/.test(bd)) patch.birth_year = Number(bd);
+    const g = typeof u.gender === "string" ? u.gender.toLowerCase() : ""; if (g === "male" || g === "female") patch.sex = g;
+    const v = Number(u.vo2MaxRunning); if (Number.isFinite(v) && v > 0) patch.vo2max = Math.round(v * 10) / 10;
+    if (Object.keys(patch).length === 0) return NextResponse.json({ ok: false, error: "Garmin returned no profile fields." }, { status: 502 });
+    const merged = await saveConfigKey(sql, "user_profile", patch);
+    return NextResponse.json({ ok: true, profile: { weight_kg: merged.weight_kg ?? null, birth_year: merged.birth_year ?? null, sex: merged.sex ?? null, vo2max: merged.vo2max ?? null }, updated: Object.keys(patch) });
+  } catch (err) {
+    return NextResponse.json({ ok: false, error: `Garmin profile pull failed: ${err instanceof Error ? err.message : String(err)}` }, { status: 502 });
+  }
+}

--- a/web/app/api/routines/sync/route.test.ts
+++ b/web/app/api/routines/sync/route.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi } from "vitest";
+vi.mock("@/lib/auth", () => ({ authEnabled: () => false, verifySession: async () => true, SESSION_COOKIE: "h2g_session" }));
+vi.mock("@/lib/db", () => { const tag = (async () => []) as unknown as { (): unknown; json: <T>(v: T) => T }; tag.json = (v) => v; return { getDb: () => tag }; });
+vi.mock("@/lib/hevy-routines", () => ({ fetchHevyRoutines: async () => [{ id: "a", title: "Push" }, { id: "b", title: "Pull" }, { id: "c", title: "Legs" }] }));
+vi.mock("@/lib/garmin-routine-sync", () => ({ syncRoutine: async (r: { id: string }) => (r.id === "b" ? { status: "error", error: "boom" } : { status: "synced", garminWorkoutId: `g-${r.id}` }) }));
+import { POST } from "./route";
+const req = (body?: unknown) => new Request("http://h/api/routines/sync", { method: "POST", headers: { "content-type": "application/json" }, body: body === undefined ? undefined : JSON.stringify(body) });
+
+describe("POST /api/routines/sync (bulk)", () => {
+  it("syncs every routine and aggregates like the Python stats", async () => {
+    const res = await POST(req()); const j = await res.json();
+    expect(res.status).toBe(200); expect(j).toMatchObject({ ok: false, total: 3, synced: 2, failed: 1 });
+    expect(j.results.map((r: { id: string; status: string }) => `${r.id}:${r.status}`)).toEqual(["a:synced", "b:error", "c:synced"]);
+  });
+  it("limits to the given ids", async () => {
+    const j = await (await POST(req({ ids: ["c"] }))).json(); expect(j).toMatchObject({ ok: true, total: 1, synced: 1, failed: 0 });
+  });
+});

--- a/web/app/api/routines/sync/route.ts
+++ b/web/app/api/routines/sync/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { fetchHevyRoutines } from "@/lib/hevy-routines";
+import { syncRoutine } from "@/lib/garmin-routine-sync";
+import { getDb } from "@/lib/db";
+import { verifySession, SESSION_COOKIE, authEnabled } from "@/lib/auth";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * POST /api/routines/sync  { ids?: string[] } — sync every Hevy routine (or the given ids) to
+ * Garmin as planned workouts, sequentially, aggregating outcomes (port of the Python bulk
+ * route; the per-routine engine is the same syncRoutine the single route uses). (#461)
+ */
+export async function POST(request: Request) {
+  if (authEnabled()) {
+    const store = await cookies();
+    if (!(await verifySession(store.get(SESSION_COOKIE)?.value ?? null))) return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+  }
+  let ids: string[] | null = null;
+  try { const t = await request.text(); if (t) { const b = JSON.parse(t) as { ids?: unknown }; if (Array.isArray(b.ids)) ids = b.ids.map(String); } } catch { return NextResponse.json({ ok: false, error: "Invalid JSON body." }, { status: 400 }); }
+  let sql: ReturnType<typeof getDb>;
+  try { sql = getDb(); } catch (err) { return NextResponse.json({ ok: false, error: `DB unavailable: ${err instanceof Error ? err.message : String(err)}` }, { status: 503 }); }
+  let routines: Awaited<ReturnType<typeof fetchHevyRoutines>>;
+  try { routines = await fetchHevyRoutines(); } catch (err) { return NextResponse.json({ ok: false, error: `Hevy routines unavailable: ${err instanceof Error ? err.message : String(err)}` }, { status: 502 }); }
+  const wanted = ids ? routines.filter((r) => ids!.includes(String(r.id))) : routines;
+  const results: { id: string; title: string; status: string; garminWorkoutId?: string | null; error?: string }[] = [];
+  for (const r of wanted) {
+    const title = String(r.title ?? "");
+    try { const out = await syncRoutine(r, sql); results.push({ id: String(r.id), title, status: out.status, garminWorkoutId: out.garminWorkoutId == null ? null : String(out.garminWorkoutId), error: out.error ?? undefined }); }
+    catch (err) { results.push({ id: String(r.id), title, status: "error", error: err instanceof Error ? err.message : String(err) }); }
+  }
+  const synced = results.filter((x) => x.status === "synced").length; const failed = results.filter((x) => x.status === "error").length;
+  return NextResponse.json({ ok: failed === 0, total: results.length, synced, failed, results });
+}

--- a/web/app/api/settings/route.test.ts
+++ b/web/app/api/settings/route.test.ts
@@ -12,6 +12,7 @@ vi.mock("@/lib/db", () => {
   const tag = (async (strings: TemplateStringsArray, ...values: unknown[]) => {
     const q = strings.join("?");
     if (q.startsWith("SELECT key, value FROM app_cache")) return []; // no existing config
+    if (q.startsWith("SELECT value FROM app_cache")) return [];      // saveConfigKey: no existing row
     if (q.includes("INSERT INTO app_cache")) {
       writes.push({ key: values[0] as string, value: values[1] as Record<string, unknown> });
       return [];

--- a/web/app/api/settings/route.ts
+++ b/web/app/api/settings/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { getDb } from "@/lib/db";
 import { saveGithubPat } from "@/lib/github";
+import { saveConfigKey } from "@/lib/config";
 import { verifySession, SESSION_COOKIE, authEnabled } from "@/lib/auth";
 
 // Writes config to the live hevy2garmin Postgres (app_cache) at request time.
@@ -151,20 +152,7 @@ export async function POST(request: Request) {
 
   try {
     if (githubPat) await saveGithubPat(sql, githubPat);
-    const existing = (await sql`SELECT key, value FROM app_cache WHERE key = ANY(${keys})`) as {
-      key: string;
-      value: unknown;
-    }[];
-    const existingMap = new Map(existing.map((r) => [r.key, isObj(r.value) ? r.value : {}]));
-
-    for (const key of keys) {
-      const merged = { ...(existingMap.get(key) ?? {}), ...changes[key] };
-      await sql`
-        INSERT INTO app_cache (key, value)
-        VALUES (${key}, ${sql.json(merged)})
-        ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()
-      `;
-    }
+    for (const key of keys) await saveConfigKey(sql, key, changes[key]);
     return NextResponse.json({ ok: true, saved: githubPat ? [...keys, "github_pat"] : keys });
   } catch (err) {
     console.error("settings write failed:", err);

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -57,6 +57,7 @@ function LoginForm() {
       <form onSubmit={onSubmit} className="flex flex-col gap-3">
         <input
           type="password"
+          data-testid="login-password"
           autoFocus
           value={password}
           onChange={(e) => setPassword(e.target.value)}
@@ -70,6 +71,7 @@ function LoginForm() {
         )}
         <button
           type="submit"
+          data-testid="login-submit"
           disabled={loading || password.length === 0}
           className="rounded-lg bg-teal px-4 py-3 font-medium text-black transition-opacity disabled:opacity-50"
         >

--- a/web/components/settings-form.tsx
+++ b/web/components/settings-form.tsx
@@ -70,6 +70,22 @@ export function SettingsForm(p: Props) {
   const router = useRouter();
   const [autoSync, setAutoSync] = useState(p.autoSyncEnabled);
   const [githubPat, setGithubPat] = useState("");
+  const [pulling, setPulling] = useState(false);
+  const [pullMsg, setPullMsg] = useState<string | null>(null);
+  async function pullFromGarmin() {
+    setPulling(true); setPullMsg(null);
+    try {
+      const res = await fetch("/api/pull-garmin-profile", { method: "POST" });
+      const j = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string; profile?: { weight_kg?: number | null; birth_year?: number | null; sex?: string | null; vo2max?: number | null } };
+      if (!res.ok || !j.ok || !j.profile) { setPullMsg(j.error ?? `Request failed (${res.status}).`); return; }
+      if (j.profile.weight_kg != null) setWeight(String(j.profile.weight_kg));
+      if (j.profile.birth_year != null) setBirthYear(String(j.profile.birth_year));
+      if (j.profile.sex) setSex(j.profile.sex);
+      if (j.profile.vo2max != null) setVo2max(String(j.profile.vo2max));
+      setPullMsg("Pulled from Garmin. Values updated below; save to keep them.");
+    } catch (err) { setPullMsg(err instanceof Error ? err.message : String(err)); }
+    finally { setPulling(false); }
+  }
   const [interval, setIntervalMin] = useState(p.autoSyncInterval);
   const [hrFusion, setHrFusion] = useState(p.hrFusionEnabled);
   const [strategy, setStrategy] = useState(p.mergeWatchStrategy);
@@ -202,6 +218,10 @@ export function SettingsForm(p: Props) {
           <div className={cardCls}>
             <label className={labelCls} htmlFor="sf-vo2max">VO₂max</label>
             <input id="sf-vo2max" type="number" min={1} max={99} step={0.1} value={vo2max} onChange={(e) => setVo2max(e.target.value)} placeholder="45" className={controlCls} />
+          </div>
+          <div className="col-span-full flex items-center gap-3">
+            <button type="button" onClick={pullFromGarmin} disabled={pulling} className="rounded-lg border border-border px-3 py-1.5 text-xs text-text disabled:opacity-50">{pulling ? "Pulling…" : "Pull from Garmin"}</button>
+            {pullMsg && <span className="text-xs text-text-muted">{pullMsg}</span>}
           </div>
         </div>
         <div className={`${cardCls} mt-4`}>

--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("dashboard smoke (no database, password auth)", () => {
+  test("gated pages redirect to login, login works, pages render, /sync redirects", async ({ page }) => {
+    await page.goto("/dashboard");
+    await expect(page).toHaveURL(/\/login/);
+    await page.getByTestId("login-password").fill("test-pw");
+    await page.getByTestId("login-submit").click();
+    await expect(page).toHaveURL(/\/dashboard/);
+    await expect(page.locator("h1").first()).toBeVisible();
+    for (const path of ["/setup", "/routines", "/workouts", "/settings"]) {
+      const res = await page.goto(path);
+      expect(res?.status(), `${path} status`).toBeLessThan(500);
+      await expect(page.locator("h1").first()).toBeVisible();
+    }
+    await page.goto("/sync");
+    await expect(page).toHaveURL(/\/dashboard/);
+  });
+  test("a wrong password stays on login with an error", async ({ page }) => {
+    await page.goto("/login");
+    await page.getByTestId("login-password").fill("nope");
+    await page.getByTestId("login-submit").click();
+    await expect(page.getByText("Incorrect password")).toBeVisible();   // (role=alert is shared with Next's route announcer)
+    await expect(page).toHaveURL(/\/login/);
+  });
+});

--- a/web/lib/config.ts
+++ b/web/lib/config.ts
@@ -1,0 +1,14 @@
+import type { getDb } from "./db";
+type Sql = ReturnType<typeof getDb>;
+const isObj = (v: unknown): v is Record<string, unknown> => typeof v === "object" && v !== null && !Array.isArray(v);
+
+/** Merge `patch` into the app_cache config `key` (the Python `save_config` shape): existing keys are kept, patched keys win. */
+export async function saveConfigKey(sql: Sql, key: string, patch: Record<string, unknown>): Promise<Record<string, unknown>> {
+  const rows = (await sql`SELECT value FROM app_cache WHERE key = ${key} LIMIT 1`) as { value: unknown }[];
+  const merged = { ...(isObj(rows[0]?.value) ? rows[0].value : {}), ...patch };
+  await sql`
+    INSERT INTO app_cache (key, value)
+    VALUES (${key}, ${sql.json(merged)})
+    ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()`;
+  return merged;
+}

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -7,6 +7,10 @@ const nextConfig: NextConfig = {
   output: process.env.VERCEL ? undefined : "standalone",
   // Don't auto-generate AGENTS.md / CLAUDE.md on build (those are local-only).
   agentRules: false,
+  // Parity with the Python dashboard's GET /sync → dashboard (#461).
+  async redirects() {
+    return [{ source: "/sync", destination: "/dashboard", permanent: false }];
+  },
 };
 
 export default nextConfig;

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = process.env.E2E_PORT ?? "8096";
+
+/**
+ * Parity smoke for the web dashboard (#461). Runs against a production build started with ONLY
+ * a password in the environment: no database, so every page must render its "no database"
+ * state instead of failing — that is what a fresh fork sees before it wires Neon.
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 30_000,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? "github" : "list",
+  use: { baseURL: `http://127.0.0.1:${PORT}`, trace: "retain-on-failure" },
+  projects: [
+    { name: "desktop", use: { ...devices["Desktop Chrome"] } },
+    { name: "mobile", use: { ...devices["Pixel 7"] } },
+  ],
+  webServer: {
+    command: `npx next start --port ${PORT} --hostname 127.0.0.1`,
+    url: `http://127.0.0.1:${PORT}/login`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+    env: { H2G_PASSWORD: "test-pw", NODE_ENV: "production", DATABASE_URL: "" },
+  },
+});

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, configDefaults } from "vitest/config";
 import path from "path";
 
 // Minimal config: resolve the `@/` path alias (matches tsconfig) so route
@@ -6,6 +6,8 @@ import path from "path";
 // and all other behaviour stay on the vitest defaults. `.test.ts` files next to
 // the code they cover (e.g. lib/dedup.test.ts) are picked up automatically.
 export default defineConfig({
+  // Playwright specs live in e2e/ and are not vitest tests.
+  test: { exclude: [...configDefaults.exclude, "e2e/**"] },
   resolve: {
     alias: { "@": path.resolve(__dirname, ".") },
   },


### PR DESCRIPTION
## The sentence
For `repo://hevy2garmin/web`, we know `python_parity := complete|gaps` (observed by the route inventory diff and the Playwright smoke), and can do `serve_dashboard` for a fresh fork with only a password set (tier none; executor script; reversible; shared; interactive), producing `page.rendered` (observed) for every page, so that `cutover_ready` no longer waits on route gaps, rendered at CI (check-web now runs the smoke), governed by policy a-page-that-needs-a-database-to-render-is-a-bug.

## Done is an observation
- Local: tsc clean, 213 vitest tests, production build, Playwright desktop 2/2 against a build started with no database (the fresh-fork posture).
- Route tests: pull-garmin-profile maps Garmin units to the Python config shape and preserves other keys; bulk routines sync aggregates outcomes and honours an ids filter.
- This PR's CI is the verify_cmd; the new Playwright step runs in check-web.

## Not ported, by decision
/api/reload-data: the web reads Hevy live on every page (force-dynamic); the Python cache it clears does not exist here.

## Forkers
Additive; no env change. The smoke proves every page renders before a database is wired, which is exactly a forker's first minute.

Closes #461
