### PR TITLE
docs: the Next.js web dashboard is the recommended Vercel deploy (Root Directory web) (#456)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+- The Next.js web dashboard in `web/` is now the recommended Vercel deploy: set **Root Directory** to `web` when importing a fork, or change it in an existing project's settings and redeploy ([#456](https://github.com/drkostas/hevy2garmin/issues/456)). The Python dashboard keeps working for existing deployments (Root Directory empty) but no longer gets new features. Both read the same database and credential rows.
+
+### Added
+- Web dashboard: a fresh-fork CI check (install from the lockfile, build, answer with a bare environment), `web/.env.example`, and a README section ([#462](https://github.com/drkostas/hevy2garmin/pull/462)).
+- Web dashboard: the GitHub token can be saved in-app and the auto-sync GitHub Actions workflow is created from the dashboard, with the generated workflow tested against the Python generator's output ([#463](https://github.com/drkostas/hevy2garmin/pull/463)).
+- Web dashboard: `H2G_SECRET` and `H2G_PASSWORD_HASH` (argon2) work the same as in the Python dashboard ([#464](https://github.com/drkostas/hevy2garmin/pull/464)).
+- Web dashboard: pull the Garmin profile, sync all routines at once, `/sync` redirects to the dashboard, and a Playwright smoke test runs in CI ([#465](https://github.com/drkostas/hevy2garmin/pull/465)).
+
+### Fixed
+- Garmin credential rows written flat by the Python login are read by the web dashboard, and nested rows written by the web dashboard are read by the Python one; both self-heal on start ([#463](https://github.com/drkostas/hevy2garmin/pull/463)).
+
 ## [0.10.1] - 2026-08-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ Sign up at [github.com](https://github.com/signup). You'll use this to sign into
 
 1. Go to [vercel.com/new](https://vercel.com/new) and sign in with GitHub
 2. Find **hevy2garmin** in your repo list and click **Import**. If your fork isn't listed even though GitHub shows it, click **Adjust GitHub App Permissions** (or **Configure GitHub App**) and grant Vercel access to the repo, then it will appear.
-3. **Add a database (required).** If you see an **Integrations** or **Storage** section during import, add **Neon Postgres** (it's free). This is where your sync history lives. If you don't see it during import, that's fine: deploy first, then open your project's **Storage** tab, add **Neon Postgres**, and redeploy. A serverless host has a read-only filesystem, so with no database the app can't save anything and shows an "internal server error".
-4. Click **Deploy** and wait about a minute for it to build. You don't need to set any environment variables: you enter your Hevy key and Garmin login in the app on the next step. If the deployed page shows an "internal server error", it almost always means the database step was skipped: add **Neon Postgres** from the **Storage** tab, then redeploy.
+3. **Root Directory: `web`.** On the import screen click **Edit** next to **Root Directory** and enter `web`. This deploys the current dashboard (Next.js). Leaving it empty deploys the older Python dashboard, which still works but no longer gets new features.
+4. **Add a database (required).** If you see an **Integrations** or **Storage** section during import, add **Neon Postgres** (it's free). This is where your sync history lives. If you don't see it during import, that's fine: deploy first, then open your project's **Storage** tab, add **Neon Postgres**, and redeploy. A serverless host has a read-only filesystem, so with no database the app can't save anything and shows an "internal server error".
+5. Click **Deploy** and wait about a minute for it to build. You don't need to set any environment variables: you enter your Hevy key and Garmin login in the app on the next step. If you want a login on your dashboard, add `H2G_PASSWORD` under **Environment Variables** (you can also do this later, see [Securing the dashboard](#securing-the-dashboard)). If the deployed page shows an "internal server error", it almost always means the database step was skipped: add **Neon Postgres** from the **Storage** tab, then redeploy.
 
 **Step 5: Connect Hevy and Garmin**
 
@@ -112,9 +113,13 @@ To keep future workouts syncing automatically, toggle **Auto-sync** on the dashb
 
 **That's it.** Check [Garmin Connect](https://connect.garmin.com/modern/activities) to see your workouts with proper exercise names, sets, reps, and weights.
 
-### Web dashboard rebuild (Next.js, preview)
+### Web dashboard (Next.js)
 
-A Next.js rebuild of the dashboard lives in `web/`. It uses the same database and the same `platform_credentials` rows as the Python dashboard, so both can run against one Neon project. Vercel still serves the Python dashboard from `api/index.py` until the cutover is announced here and in the changelog. To try the rebuild now:
+The dashboard Vercel deploys with **Root Directory** `web` is a Next.js app. It uses the same database and the same `platform_credentials` rows as the Python dashboard, so both can run against one Neon project, and switching between them loses nothing.
+
+**Already deployed the Python dashboard on Vercel?** Open your Vercel project, go to **Settings > General > Root Directory**, enter `web`, save, then open **Deployments** and **Redeploy** the latest one. Your database, credentials and sync history carry over as they are. To go back, clear the Root Directory and redeploy. The Python dashboard (`api/index.py`, Root Directory empty) keeps working for existing deployments, but new features land in `web/` only.
+
+To run it locally:
 
 ```bash
 cd web

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,0 +1,5 @@
+{
+  "crons": [
+    { "path": "/api/cron/sync", "schedule": "0 8 * * *" }
+  ]
+}


### PR DESCRIPTION
Held as a draft for an explicit go: this is the forker-visible step of the cutover checklist (#456).

## What it does

- README fork-deploy steps: **Root Directory = `web`** on import (Next.js dashboard). Leaving it empty still deploys the Python dashboard.
- Migration note for existing Vercel deployments: Settings > General > Root Directory `web`, redeploy; same database, credentials and sync history; reversible by clearing the field.
- CHANGELOG `[Unreleased]`: the cutover entry plus the #462-#465 entries that were missing.
- `web/vercel.json` with the daily `/api/cron/sync` cron, so a Root-Directory-`web` project keeps the schedule the root `vercel.json` had.

## Why not flip the root `vercel.json` instead

A root-level `{"builds": [{"src": "web/package.json", "use": "@vercel/next"}]}` was deployed to a throwaway project to test the silent flip. The build fails on Vercel with Next 16.1: `Cannot patch preview comments when immutable static file upload is enabled. Upgrade to next@v16.3.0-canary.32 or newer`. The legacy `builds` path pulls the newest `@vercel/next`, which no longer supports this Next version; the framework preset with Root Directory `web` (what `hevy2garmin-web` already runs) works. So a silent flip would break every fork on its next "Sync fork", while the Root Directory route changes nothing for existing deployments until their owner acts. The throwaway project was deleted.

## Not in this PR

- No change to `api/index.py` or the root `vercel.json`: existing forks keep deploying the Python dashboard.
- No date for retiring the Python dashboard; the README says it no longer gets new features.
