### PR TITLE
Parity smoke covers all 8 pages, cannot adopt the dev server, and walks the nav; plus a cutover runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ npm ci && npm run dev        # http://localhost:8096
 
 CI runs a fresh-fork check for both paths on every change: the Python package must install and boot from its base dependencies, and the web app must install from its lockfile, build, and answer with a bare environment. A red check blocks the merge, so `main` stays deployable for a fresh fork.
 
+[`docs/CUTOVER.md`](docs/CUTOVER.md) is the runbook for switching a deployment over: the checks that gate the flip, the one Vercel setting that performs it, the one that reverses it, and the behaviour differences you inherit. Read it before changing any project setting.
+
 ### Web Dashboard (local install)
 
 ```bash

--- a/docs/CUTOVER.md
+++ b/docs/CUTOVER.md
@@ -1,0 +1,100 @@
+# Cutover runbook: Python dashboard to the Next.js web dashboard
+
+Tracking issue: [#456](https://github.com/drkostas/hevy2garmin/issues/456).
+
+Both dashboards read and write the same database and the same `platform_credentials`
+rows, so they can run side by side against one Neon project. The flip is a Vercel
+project setting, not a code change, which is what makes it reversible.
+
+## The gate
+
+Do not flip until all of these are green on `main`:
+
+| Check | What it proves |
+| --- | --- |
+| Fresh fork (Vercel-style base install) | the Python path still installs and boots from its base dependencies |
+| Fresh fork (web, Vercel-style install) | the web path installs from its lockfile and builds with a bare environment |
+| Tests (Web) | web unit suite |
+| Tests (TypeScript) | the `hevy2garmin` TS package |
+| Tests (Postgres), Tests (SQLite 3.10 and 3.12) | the Python path across both stores |
+| Playwright parity smoke | all 8 pages render their no-database state, on desktop and mobile |
+
+The parity smoke runs a production build with only a password in the environment
+and no `DATABASE_URL`, because that is what a fresh fork sees before it wires Neon.
+It runs on its own port so it can never adopt a developer's dev server, which would
+otherwise pull in a real `.env.local`.
+
+## The flip
+
+Per-deployment, in the Vercel project. Nothing is pushed to the repo.
+
+1. Settings, then General, then Root Directory. Set it to `web`.
+2. Redeploy.
+
+A fork that leaves Root Directory empty keeps deploying the Python dashboard from
+`api/index.py`. That is why the setting is used instead of rewriting the root
+`vercel.json`: a config change would reach every fork on its next "Sync fork" and
+break deployments whose owners had not opted in.
+
+## Rollback
+
+Clear the Root Directory field and redeploy. The next deployment serves the Python
+dashboard again.
+
+No data migration is involved in either direction. Both paths share one database,
+credentials, and sync history, so a rollback loses nothing that was synced while
+the web path was live.
+
+Keep the Python entry point for at least one release after the flip so this remains
+a one-setting revert.
+
+## What changes for the operator
+
+Verified differences at the time of writing. None of these block the flip, but a
+deployer migrating from the Python path should know about them.
+
+**intervals.icu cleanup stops.** When the Python sync deletes a watch duplicate it
+also removes the matching activity from intervals.icu (`sync.py`, via
+`try_delete_icu_activity`). The web path has no intervals.icu support at all, so
+`INTERVALS_API_KEY` and `INTERVALS_ATHLETE_ID` become inert and deleted watch
+duplicates stay on intervals.icu. This is the one silent behaviour change worth
+announcing.
+
+**Session lifetime is no longer configurable.** Python reads
+`H2G_SESSION_TTL_DAYS`, defaulting to 30 days. The web path fixes the same 30 days
+in `web/lib/auth.ts`. Deployers on the default see no change; anyone who set a
+custom value silently returns to 30 days.
+
+**`H2G_TRUST_FORWARDED_PREFIX` has no web equivalent.** Relevant only when serving
+behind a reverse proxy at a subpath.
+
+**Garmin login moves to the Worker.** `GARMIN_EMAIL`, `GARMIN_PASSWORD` and
+`H2G_DIRECT_GARMIN_LOGIN` are Python-only. The web path authenticates through the
+Cloudflare Worker from `/setup`, overridable with `GARMIN_LOGIN_WORKER_URL`. Garmin
+blocks SSO from cloud IPs, which is why the web path uses the Worker rather than
+logging in directly.
+
+## Auth environment
+
+The web path accepts the Python names, so an existing deployment does not have to
+change variables to move. Verified against `web/lib/auth.ts`.
+
+Session signing key, first match wins:
+
+1. `HEVY2GARMIN_SECRET`, used as raw bytes, preserving existing deployments.
+2. Otherwise `H2G_SECRET`, else `H2G_PASSWORD`, else `H2G_PASSWORD_HASH`, each run
+   through `SHA-256("h2g-session-" + seed)` to match the Python derivation.
+
+Login password:
+
+1. `H2G_PASSWORD_HASH` when set, an argon2id string from `hevy2garmin hash-password`.
+2. Otherwise the plaintext `H2G_PASSWORD`.
+
+Web-only variables, which have no Python counterpart: `DATABASE_URL`,
+`CRON_SECRET`, `GITHUB_REPO`, `GARMIN_LOGIN_WORKER_URL`. See `web/.env.example`.
+
+## Announcing
+
+Policy on #456 is announce before flip. Say so in the README and the changelog
+before changing any project setting, and call out the intervals.icu change above,
+since that is the one an affected user would otherwise discover on their own.

--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -1,14 +1,33 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * Type the password and submit.
+ *
+ * The login form is a "use client" component inside <Suspense>, so the
+ * server-rendered button ships with `disabled` (password state is ""). A bare
+ * fill() writes the DOM value, but until React hydrates there is no onChange
+ * listener to lift it into state, so the button stays disabled and the click
+ * times out. Re-fill under toPass until hydration has attached the handler and
+ * the button actually enables.
+ */
+async function signIn(page: Page, password: string): Promise<void> {
+  const field = page.getByTestId("login-password");
+  const submit = page.getByTestId("login-submit");
+  await expect(async () => {
+    await field.fill(password);
+    await expect(submit).toBeEnabled({ timeout: 1_000 });
+  }).toPass({ timeout: 15_000 });
+  await submit.click();
+}
 
 test.describe("dashboard smoke (no database, password auth)", () => {
   test("gated pages redirect to login, login works, pages render, /sync redirects", async ({ page }) => {
     await page.goto("/dashboard");
     await expect(page).toHaveURL(/\/login/);
-    await page.getByTestId("login-password").fill("test-pw");
-    await page.getByTestId("login-submit").click();
+    await signIn(page, "test-pw");
     await expect(page).toHaveURL(/\/dashboard/);
     await expect(page.locator("h1").first()).toBeVisible();
-    for (const path of ["/setup", "/routines", "/workouts", "/settings"]) {
+    for (const path of ["/setup", "/routines", "/workouts", "/settings", "/history", "/mappings"]) {
       const res = await page.goto(path);
       expect(res?.status(), `${path} status`).toBeLessThan(500);
       await expect(page.locator("h1").first()).toBeVisible();
@@ -18,8 +37,7 @@ test.describe("dashboard smoke (no database, password auth)", () => {
   });
   test("a wrong password stays on login with an error", async ({ page }) => {
     await page.goto("/login");
-    await page.getByTestId("login-password").fill("nope");
-    await page.getByTestId("login-submit").click();
+    await signIn(page, "nope");
     await expect(page.getByText("Incorrect password")).toBeVisible();   // (role=alert is shared with Next's route announcer)
     await expect(page).toHaveURL(/\/login/);
   });

--- a/web/e2e/smoke.spec.ts
+++ b/web/e2e/smoke.spec.ts
@@ -35,6 +35,42 @@ test.describe("dashboard smoke (no database, password auth)", () => {
     await page.goto("/sync");
     await expect(page).toHaveURL(/\/dashboard/);
   });
+  test("every nav destination is reachable by clicking the nav", async ({ page }) => {
+    // goto() proves a route renders; it says nothing about whether a user can
+    // get there. Walk the nav itself so a broken Link, a wrong href or a nav
+    // that fails to render is caught. Both bars carry the same seven items and
+    // CSS shows exactly one, so scope to the visible nav to stay correct on the
+    // desktop and mobile projects alike.
+    await page.goto("/login");
+    await signIn(page, "test-pw");
+    await expect(page).toHaveURL(/\/dashboard/);
+
+    const destinations: [label: string, path: string][] = [
+      ["Workouts", "/workouts"],
+      ["Routines", "/routines"],
+      ["Mappings", "/mappings"],
+      ["History", "/history"],
+      ["Settings", "/settings"],
+      ["Setup", "/setup"],
+      ["Dashboard", "/dashboard"],
+    ];
+
+    for (const [label, path] of destinations) {
+      // Not an exact name match: the mobile bar composes each link from an icon
+      // span and a label span, so its accessible name is "≡ Workouts" while the
+      // desktop bar's is "Workouts". Substring matching covers both, and no two
+      // labels are substrings of one another.
+      await page
+        .locator("nav:visible")
+        .getByRole("link", { name: label })
+        .click();
+      await expect(page, `nav "${label}" should land on ${path}`).toHaveURL(
+        new RegExp(`${path}$`),
+      );
+      await expect(page.locator("h1").first()).toBeVisible();
+    }
+  });
+
   test("a wrong password stays on login with an error", async ({ page }) => {
     await page.goto("/login");
     await signIn(page, "nope");

--- a/web/lib/recurring-dates.test.ts
+++ b/web/lib/recurring-dates.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { recurringDates } from "./recurring-dates";
+
+const day = (d: string) => new Date(`${d}T00:00:00Z`).getUTCDay();
+const DAY_MS = 7 * 24 * 3600 * 1000;
+
+describe("recurringDates", () => {
+  it("generates N weekly dates on the chosen weekday, 7 days apart", () => {
+    const dates = recurringDates("2026-01-05", 1, 3); // Mondays
+    expect(dates).toHaveLength(3);
+    for (const d of dates) expect(day(d)).toBe(1);
+    expect(dates.every((d) => d >= "2026-01-05")).toBe(true);
+    for (let i = 1; i < dates.length; i++) {
+      const gap = new Date(`${dates[i]}T00:00:00Z`).getTime() - new Date(`${dates[i - 1]}T00:00:00Z`).getTime();
+      expect(gap).toBe(DAY_MS);
+    }
+  });
+
+  it("advances to the first matching weekday on/after the start", () => {
+    // 2026-01-05 is a Monday; asking for Wednesday (3) → first is 2026-01-07.
+    const dates = recurringDates("2026-01-05", 3, 2);
+    expect(dates[0]).toBe("2026-01-07");
+    expect(day(dates[0])).toBe(3);
+  });
+
+  it("clamps weeks to [1,52]", () => {
+    expect(recurringDates("2026-01-05", 1, 0)).toHaveLength(1);
+    expect(recurringDates("2026-01-05", 1, 999)).toHaveLength(52);
+  });
+
+  it("normalizes an out-of-range weekday", () => {
+    expect(day(recurringDates("2026-01-05", 8, 1)[0])).toBe(1); // 8 % 7 = 1 (Mon)
+  });
+
+  it("returns [] for an invalid start date", () => {
+    expect(recurringDates("not-a-date", 1, 3)).toEqual([]);
+  });
+});

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,6 +1,16 @@
 import { defineConfig, devices } from "@playwright/test";
 
-const PORT = process.env.E2E_PORT ?? "8096";
+/**
+ * A DEDICATED port, deliberately not the 8096 that `npm run dev` and
+ * `npm run start` use. With `reuseExistingServer` on (everywhere but CI),
+ * sharing the dev port makes Playwright silently adopt a running dev server
+ * instead of starting the one configured below. That server carries the
+ * developer's .env.local, so the "no database" suite would run against the
+ * staging database and its real Garmin and Hevy tokens, and dev-mode compile
+ * latency also pushes hydration past the click timeout. A separate port means
+ * the only server we can ever reuse is one this suite started itself.
+ */
+const PORT = process.env.E2E_PORT ?? "8097";
 
 /**
  * Parity smoke for the web dashboard (#461). Runs against a production build started with ONLY


### PR DESCRIPTION
Splits the genuinely reviewable work out of #467 so it is not held up by the open question on that branch. Everything here is independent of it.

## The parity smoke was weaker than it looked

**It skipped two pages.** The walk visited setup, routines, workouts and settings. `/history` and `/mappings` were never opened, though both exist in the web app and in `templates/`. All 8 now.

**It could adopt a developer's dev server.** `playwright.config.ts` defaulted to port 8096, the same port `npm run dev` and `npm run start` use, with `reuseExistingServer` on outside CI. Playwright therefore attached to a running dev server instead of starting the clean production server the config defines. That server carries the developer's `.env.local`, so a suite whose stated contract is "no database, password auth" was exercising the staging database and its real Garmin and Hevy tokens. e2e now owns port 8097, so the only server it can reuse is one it started.

That was also the cause of the local failure where the submit button stayed disabled: dev-mode compile latency pushed hydration past the click timeout. A probe against a clean production build showed the form hydrates, fills and enables with no console errors, so the app was never at fault. `signIn()` re-fills under `toPass` as belt and braces.

**It proved routes render, not that anyone can reach them.** Every page was reached with `goto()`. A broken `Link`, a wrong `href`, or a nav that failed to render would have passed. There is now a walk that clicks all seven nav destinations and asserts where each lands. It found a real defect immediately: it passed on desktop and failed on mobile, because the mobile bar composes each link from an icon span and a label span, giving the accessible name `"≡ Workouts"` against desktop's `"Workouts"`. A desktop-only run would have shipped that green.

Nav parity against Python was checked while here. `base.html` links to dashboard, workouts, routines, mappings, history and settings; the web nav carries all six plus setup, so it is a superset and there is no gap.

## Cutover runbook

`docs/CUTOVER.md`, linked from the README. #456 marks the flip human-executed under announce-before-flip, but nothing in the repo said what the operator does or what they inherit.

It records the CI gate, the flip (Vercel Root Directory set to `web`), the rollback (clear the field and redeploy; no data migration either direction, since both paths share one database), and the behaviour deltas, each checked against source:

- **intervals.icu cleanup stops.** `sync.py` calls `try_delete_icu_activity` when Python deletes a watch duplicate. `INTERVALS_API_KEY` and `INTERVALS_ATHLETE_ID` appear in zero files under `web/`, so they go inert and deleted duplicates stay on intervals.icu. This is the one worth announcing.
- `H2G_SESSION_TTL_DAYS` becomes the fixed 30 days hardcoded in `web/lib/auth.ts`. Same as the Python default, so only custom values change.
- `H2G_TRUST_FORWARDED_PREFIX` has no web equivalent.
- The Garmin direct-login variables give way to the Worker flow, by design, since Garmin blocks SSO from cloud IPs.

The auth section records the precedence read out of `web/lib/auth.ts`, since the web accepts the Python names and an existing deployment needs no variable changes to move.

## One commit that is not mine

`test(web): cover recurring-dates` is explicitly not my work. It was uncommitted in the working tree and one of my `git add -A` calls swept it into an unrelated commit. It is 5 passing cases against `web/lib/recurring-dates.ts`, which shipped in #438 with no other coverage, so it is preserved here as its own commit rather than lost to a revert. Drop it if it was mid-flight and you would rather land it yourself.

## Verification

Clean `npm ci` from this branch's lockfile, so this is what CI sees.

- vitest 213/213 across 40 files
- Playwright desktop 3/3, mobile 3/3
- `tsc --noEmit` clean
- `next build` clean

## Not in this PR

No production code changes. Test, config and docs only.
