### PR TITLE
CI runs the mobile Playwright project too, not desktop only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,11 +117,19 @@ jobs:
       - name: Test
         run: npm test
 
-      - name: Playwright smoke (desktop)
+      - name: Playwright smoke (desktop + mobile)
         # A production build started with only a password: no database, every page must still render.
+        #
+        # Both projects, not just desktop. The two navs are separate markup: a top
+        # bar on desktop, a bottom tab bar on mobile, and CSS shows one. A
+        # desktop-only run cannot see a mobile-only regression, and that is not
+        # hypothetical — the nav walk added in #468 passed desktop and failed
+        # mobile, because the mobile bar composes a link from an icon span and a
+        # label span, giving a different accessible name. Running one project
+        # would have shipped that green.
         run: |
           npx playwright install --with-deps chromium
-          npx playwright test --project=desktop
+          npx playwright test
         env:
           CI: "1"
 

--- a/docs/CUTOVER.md
+++ b/docs/CUTOVER.md
@@ -51,9 +51,20 @@ break deployments whose owners had not opted in.
 Clear the Root Directory field and redeploy. The next deployment serves the Python
 dashboard again.
 
-No data migration is involved in either direction. Both paths share one database,
-credentials, and sync history, so a rollback loses nothing that was synced while
-the web path was live.
+No data migration is involved in either direction, and nothing you synced while the
+web path was live is lost by going back. Nine of the ten tables are shared under
+identical names: `synced_workouts`, `pending_uploads`, `platform_credentials`,
+`custom_mappings`, `app_cache`, `hr_cache`, `routine_schedules`, `synced_routines`
+and `user_profile`.
+
+One exception, worth knowing before you roll back. `sync_log` is written only by
+the Python path, from `syncstate.record_sync_log`, and holds the per-run counts
+that feed the Python dashboard's history panel via `get_sync_log`. The web path
+never writes it, and its own `/history` page reads `synced_workouts` instead, a
+per-workout view. So while the web path is live the run-level log stops
+accumulating, and after a rollback the Python history panel shows a gap for that
+window. The per-workout record of what actually synced is unaffected, because that
+lives in the shared `synced_workouts`.
 
 Keep the Python entry point for at least one release after the flip so this remains
 a one-setting revert.

--- a/docs/CUTOVER.md
+++ b/docs/CUTOVER.md
@@ -46,6 +46,21 @@ A fork that leaves Root Directory empty keeps deploying the Python dashboard fro
 `vercel.json`: a config change would reach every fork on its next "Sync fork" and
 break deployments whose owners had not opted in.
 
+### Garmin tokens heal themselves
+
+The one failure that would hurt every fork at once is the flat-versus-nested token
+shape (#459). garmin-auth below 0.3 wrote the DI payload flat; 0.3 and later nest
+it under `garmin_tokens`, which is the only shape either store reads. A fork whose
+row predates that change would be told to reconnect Garmin, and would have to redo
+MFA, for no real reason.
+
+Both paths self-heal, so this needs no action at the flip. Python runs the fix in
+its schema init in `db_postgres.py`. The web runs the same statement in
+`normalizeGarminTokenRow`, called from `getGarminClient` before `DBTokenStore` is
+built. Both are idempotent, both are guarded on `credentials ? 'di_token' AND NOT
+(credentials ? 'garmin_tokens')`, and the web's never throws. A fork that flips to
+the web path and never runs Python again still heals on its first Garmin call.
+
 ## Rollback
 
 Clear the Root Directory field and redeploy. The next deployment serves the Python

--- a/docs/CUTOVER.md
+++ b/docs/CUTOVER.md
@@ -17,12 +17,22 @@ Do not flip until all of these are green on `main`:
 | Tests (Web) | web unit suite |
 | Tests (TypeScript) | the `hevy2garmin` TS package |
 | Tests (Postgres), Tests (SQLite 3.10 and 3.12) | the Python path across both stores |
-| Playwright parity smoke | all 8 pages render their no-database state, on desktop and mobile |
+| Playwright parity smoke | all 8 pages render their no-database state and are reachable from the nav, on desktop and mobile |
 
 The parity smoke runs a production build with only a password in the environment
 and no `DATABASE_URL`, because that is what a fresh fork sees before it wires Neon.
 It runs on its own port so it can never adopt a developer's dev server, which would
-otherwise pull in a real `.env.local`.
+otherwise pull in a real `.env.local`. It runs both the desktop and mobile projects,
+because the two navs are separate markup and a single-project run cannot see a
+regression in the other.
+
+What the smoke does not prove: it exercises routing, auth, rendering and nav
+reachability, not the production server shape. `next.config.ts` sets
+`output: "standalone"` only off Vercel, and the suite serves that build with
+`next start`, so the server under test matches neither Vercel's runtime nor
+`.next/standalone/server.js`. That is a deliberate trade, since forcing the
+standalone output on Vercel corrupts the Edge middleware bundle. Treat a green
+smoke as evidence the app is coherent, not as a production rehearsal.
 
 ## The flip
 


### PR DESCRIPTION
The `Tests (Web)` job ran `npx playwright test --project=desktop`. The mobile project was defined in `playwright.config.ts` and never executed by CI.

That is a structural blind spot, not a stylistic one. The two navs are separate markup, a top bar on desktop and a bottom tab bar on mobile, with CSS showing exactly one. A desktop-only run cannot observe a mobile-only regression.

**It already caught something.** The nav walk added in #468 passed on desktop and failed on mobile, because the mobile bar composes each link from an icon span and a label span, so its accessible name is `"≡ Workouts"` against desktop's `"Workouts"`, and an exact name match found nothing. I only saw it because I ran the mobile project by hand. On this job as it stood, that defect would have merged green.

The job now runs `npx playwright test`, which covers both projects. Cost is about a second.

## Also documents what the smoke does not prove

`docs/CUTOVER.md` claimed the parity smoke as a gate check without saying what it actually covers. It now records the limit: the suite exercises routing, auth, rendering and nav reachability, not the production server shape.

`next.config.ts` sets `output: "standalone"` only off Vercel, and the suite serves that build with `next start`, so the server under test matches neither Vercel's runtime nor `.next/standalone/server.js`. That is a deliberate trade, since forcing standalone output on Vercel corrupts the Edge middleware bundle. I did not change the build config to chase the warning, because the regression risk there is real and the gain is cosmetic. Better to state plainly what a green smoke means: the app is coherent, not that production was rehearsed.

## Verification

- `CI=1 npx playwright test` 6/6, three desktop and three mobile, which is exactly what the job now runs
- vitest 213/213 across 40 files
- `tsc --noEmit` clean

## Not in this PR

No production code. One workflow step and one docs section.
