### PR TITLE
Changelog entries for #468 and #469, plus a correction to CUTOVER.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,13 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Web dashboard: the GitHub token can be saved in-app and the auto-sync GitHub Actions workflow is created from the dashboard, with the generated workflow tested against the Python generator's output ([#463](https://github.com/drkostas/hevy2garmin/pull/463)).
 - Web dashboard: `H2G_SECRET` and `H2G_PASSWORD_HASH` (argon2) work the same as in the Python dashboard ([#464](https://github.com/drkostas/hevy2garmin/pull/464)).
 - Web dashboard: pull the Garmin profile, sync all routines at once, `/sync` redirects to the dashboard, and a Playwright smoke test runs in CI ([#465](https://github.com/drkostas/hevy2garmin/pull/465)).
+- `docs/CUTOVER.md`, a runbook for moving a deployment to the web dashboard: the checks that gate the flip, the one Vercel setting that performs it, the one that reverses it, and the behaviour you inherit ([#468](https://github.com/drkostas/hevy2garmin/pull/468), [#469](https://github.com/drkostas/hevy2garmin/pull/469)). It calls out that intervals.icu cleanup is Python-only, so `INTERVALS_API_KEY` goes inert and deleted watch duplicates stay on intervals.icu, and that `sync_log` is written only by the Python path, so its history panel shows a gap for any window the web path was live.
 
 ### Fixed
 - Garmin credential rows written flat by the Python login are read by the web dashboard, and nested rows written by the web dashboard are read by the Python one; both self-heal on start ([#463](https://github.com/drkostas/hevy2garmin/pull/463)).
+- The web parity smoke covers all eight pages, not six, and checks each is reachable by clicking the nav rather than only by direct URL ([#468](https://github.com/drkostas/hevy2garmin/pull/468)).
+- The parity smoke runs on its own port instead of the one `npm run dev` uses, so it can no longer attach to a running dev server and test against that developer's `.env.local` and database ([#468](https://github.com/drkostas/hevy2garmin/pull/468)).
+- CI runs the mobile Playwright project as well as desktop. The two navs are separate markup, so a mobile-only regression previously merged green ([#469](https://github.com/drkostas/hevy2garmin/pull/469)).
 
 ## [0.10.1] - 2026-08-30
 

--- a/docs/CUTOVER.md
+++ b/docs/CUTOVER.md
@@ -67,10 +67,11 @@ Clear the Root Directory field and redeploy. The next deployment serves the Pyth
 dashboard again.
 
 No data migration is involved in either direction, and nothing you synced while the
-web path was live is lost by going back. Nine of the ten tables are shared under
-identical names: `synced_workouts`, `pending_uploads`, `platform_credentials`,
-`custom_mappings`, `app_cache`, `hr_cache`, `routine_schedules`, `synced_routines`
-and `user_profile`.
+web path was live is lost by going back. Python declares nine tables and the web
+reads and writes eight of them under identical names: `synced_workouts`,
+`pending_uploads`, `platform_credentials`, `custom_mappings`, `app_cache`,
+`hr_cache`, `routine_schedules` and `synced_routines`. (`user_profile` is not a
+table; it is a key inside `app_cache`.)
 
 One exception, worth knowing before you roll back. `sync_log` is written only by
 the Python path, from `syncstate.record_sync_log`, and holds the per-run counts


### PR DESCRIPTION
The repo keeps a per-PR `[Unreleased]` section, and #466 records that the entries for #462-#465 had gone missing and needed backfilling. I merged #468 and #469 and skipped the convention both times. This is my own omission, caught by auditing rather than by anyone noticing.

Entries cover the runbook, the two parity-smoke gaps, the dev-server adoption fix, and the mobile CI project.

The two facts a deploying user would otherwise meet by surprise are stated in the changelog itself rather than left inside the doc:

- intervals.icu cleanup is Python-only, so after the flip `INTERVALS_API_KEY` goes inert and deleted watch duplicates stay on intervals.icu.
- `sync_log` is written only by the Python path, so its history panel shows a gap for any window the web path was live. What actually synced is unaffected, since that lives in the shared `synced_workouts`.

## Verification

- vitest 213/213 across 40 files
- `tsc --noEmit` clean

## Not in this PR

Documentation only. No code, no config.
