### PR TITLE
Flag the DEMO_MODE gap at the flip, correct the HEVY_API_KEY precedence

### DIFF
--- a/docs/CUTOVER.md
+++ b/docs/CUTOVER.md
@@ -111,6 +111,15 @@ Cloudflare Worker from `/setup`, overridable with `GARMIN_LOGIN_WORKER_URL`. Gar
 blocks SSO from cloud IPs, which is why the web path uses the Worker rather than
 logging in directly.
 
+**`DEMO_MODE` does not hold on the web path yet ([#471](https://github.com/drkostas/hevy2garmin/issues/471)).**
+Do not flip a deployment that relies on it until that is fixed. `web/.env.example`
+says `true` means every mutating `/api` call is refused, but of the 30 route files
+under `web/app/api` exporting a `POST`, `PUT`, `PATCH` or `DELETE`, one calls
+`demoMode()`, and `proxy.ts` adds no middleware check. Python enforces it at 11
+sites. This is dormant rather than live, because the public demo still serves the
+Python dashboard, but a demo that flips to `web` stops being read-only while its
+`.env.example` still claims otherwise.
+
 ## Auth environment
 
 The web path accepts the Python names, so an existing deployment does not have to

--- a/web/.env.example
+++ b/web/.env.example
@@ -9,7 +9,7 @@ HEVY2GARMIN_SECRET=change-me-32-random-chars                 # signs the login s
 CRON_SECRET=change-me-32-random-chars                        # Vercel Cron / GitHub Actions call /api/cron/sync with this bearer
 
 # Optional
-HEVY_API_KEY=                                                # normally saved in-app at /setup; env is the fallback
+HEVY_API_KEY=                                                # leave EMPTY if you save the key in-app at /setup: when set, this WINS over the saved key (resolution is arg, then env, then the DB), so rotating in-app has no effect until you clear it here
 GITHUB_PAT=                                                  # for auto-sync via GitHub Actions on your fork; normally saved in-app
 GITHUB_REPO=you/hevy2garmin                                  # your fork, for the auto-sync workflow dispatch
 GARMIN_LOGIN_WORKER_URL=                                     # override the Garmin login Worker used by /setup (leave empty for the default)


### PR DESCRIPTION
Two places where the web path documents a promise it does not keep. Both came from taking each claim in `web/.env.example` and checking it against the code rather than assuming it was accurate.

## DEMO_MODE, filed as #471

The runbook now says plainly: do not flip a deployment that relies on `DEMO_MODE` until #471 is fixed.

Of the 30 route files under `web/app/api` exporting `POST`, `PUT`, `PATCH` or `DELETE`, exactly one calls `demoMode()`, and `proxy.ts` adds no middleware check. The Python server enforces it at 11 sites.

Dormant today, not live: the public demo still serves the Python dashboard (`/dashboard` 404s, `/` returns htmx markup with no `_next/static`). I confirmed with GET only and sent no mutating request. But a demo that flips to `web` quietly stops being read-only while its `.env.example` still promises it is.

## HEVY_API_KEY precedence was documented backwards

`.env.example` said the in-app key at `/setup` is normal and env is "the fallback". The actual resolution in `hevy-sync.ts` is:

```ts
const apiKey = explicit || fromEnv || (await keyFromDb());
```

Env **wins** over the saved key. The failure that produces: set `HEVY_API_KEY` in Vercel, later rotate the key at `/setup`, and syncing keeps using the stale env value while the app looks like it saved the new one.

I corrected the wording rather than the precedence. Env overriding stored state is a defensible design and someone may already depend on it; silently reversing it would be the more disruptive change and is yours to decide.

## Claims that held

Worth recording, since a clean check is also a result:

- `CRON_SECRET` is genuinely enforced on `/api/cron/sync` (bearer compared, 401 otherwise).
- The `HEVY_API_KEY` env fallback does exist, it is just ordered differently than documented.
- No intervals.icu support hides in the web under another name; every "intervals" hit is auto-sync minutes, and Python's ICU surface is the single `try_delete_icu_activity`.

## Verification

- vitest 213/213 across 40 files
- `tsc --noEmit` clean

## Not in this PR

Documentation only. No code, no config, and no fix for #471, which is product and security behaviour and needs your call on middleware versus per-route.
