### PR TITLE
Mark the cutover blocked on #473 at the top of the gate

### DIFF
--- a/docs/CUTOVER.md
+++ b/docs/CUTOVER.md
@@ -8,6 +8,15 @@ project setting, not a code change, which is what makes it reversible.
 
 ## The gate
 
+**Blocked right now.** Do not flip any deployment until
+[#473](https://github.com/drkostas/hevy2garmin/issues/473) is fixed: with auth
+configured, which `web/.env.example` marks as required, the middleware answers
+`/api/cron/*` with a 401 before the route can check `CRON_SECRET`, so scheduled
+syncing does not run at all on the web path. Python exempts those paths, so the
+same deployment syncs on Python and silently stops on the web. Verified against a
+production build, and the one-line fix is verified in that issue too.
+
+
 Do not flip until all of these are green on `main`:
 
 | Check | What it proves |


### PR DESCRIPTION
The runbook's gate section listed the checks that must be green, but a green gate is not sufficient while #473 is open. This puts the blocker first.

**Do not flip any deployment until [#473](https://github.com/drkostas/hevy2garmin/issues/473) is fixed.** With auth configured, which `web/.env.example` marks as required, `web/proxy.ts` answers `/api/cron/*` with a 401 before the route can check `CRON_SECRET`. Scheduled syncing does not run at all on the web path. Python exempts those paths at `server.py:367`, so the same deployment syncs on Python and silently stops on the web.

Reproduced against a production build: a correct bearer and a wrong bearer both return plain-text `Unauthorized`, which is the middleware's response rather than the route's JSON one, so the request never arrives at the handler.

The fix is verified in that issue too. With `/api/cron` in `PUBLIC_PATHS`, a correct bearer reaches the route (503 on the deliberately-unset DB), a wrong bearer gets the route's own JSON 401, and an ordinary API route stays gated behind plain-text 401. I applied that change locally, tested, and reverted it; nothing is committed here.

## Why at the top rather than in the deltas list

Everything else in "What changes for the operator" is something you read, accept and live with: intervals.icu cleanup stopping, the session TTL becoming fixed, the `sync_log` gap. This one is different in kind. It means the flip breaks the product's core function, so it belongs before the gate table rather than after it.

## Verification

- vitest 213/213 across 40 files
- `tsc --noEmit` clean

## Not in this PR

Documentation only. No fix for #473, which is auth behaviour and yours to decide.
