### PR TITLE
CI: cover a database that is present and empty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,3 +215,100 @@ jobs:
             case "$code" in 2*|3*) echo "GET /login -> $code"; exit 0;; esac
           done
           echo "dashboard did not answer on /login"; cat start.log; exit 1
+
+  check-web-empty-db:
+    # The gap that let #475 through. check-web runs the Playwright smoke with NO
+    # DATABASE_URL, and check-fresh-fork-web never provisions a database, so
+    # nothing covered a database that is PRESENT and EMPTY — which is exactly
+    # where a forker lands after adding Neon as the README tells them to.
+    # Reads were never the problem: every page returns 200 against an empty
+    # database. This asserts a WRITE round-trips, which is what actually broke.
+    name: Web against an empty database
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: h2g_empty
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgresql://test:test@localhost:5432/h2g_empty
+      H2G_PASSWORD: ci-test-password
+      HEVY2GARMIN_SECRET: ci-test-secret-32-chars-abcdefgh
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install the Python package (for the schema bootstrap)
+        run: pip install -e ".[cloud]"
+
+      - name: Create the schema, insert nothing
+        run: |
+          python -c "
+          import os
+          from hevy2garmin.db_postgres import PostgresDatabase
+          PostgresDatabase(os.environ['DATABASE_URL'])._ensure_tables()
+          print('schema created')
+          "
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install and build the web app
+        working-directory: web
+        run: |
+          npm ci
+          npm run build
+
+      - name: A write must round-trip against an empty database
+        working-directory: web
+        run: |
+          npx next start --port 8100 --hostname 127.0.0.1 > start.log 2>&1 &
+          for i in $(seq 1 40); do
+            sleep 1
+            curl -sf -o /dev/null http://127.0.0.1:8100/login && break
+          done
+
+          COOKIE=$(curl -s -i -X POST -H 'Content-Type: application/json' \
+            -d '{"password":"'"$H2G_PASSWORD"'"}' \
+            http://127.0.0.1:8100/api/login \
+            | grep -i '^set-cookie:' | head -1 | sed 's/^[Ss]et-[Cc]ookie: //' | cut -d';' -f1)
+          if [ -z "$COOKIE" ]; then echo "could not authenticate"; cat start.log; exit 1; fi
+
+          CODE=$(curl -s -o body.json -w '%{http_code}' -X POST \
+            -H 'Content-Type: application/json' -H "Cookie: $COOKIE" \
+            -d '{"auto_sync":{"enabled":true,"interval_minutes":720}}' \
+            http://127.0.0.1:8100/api/settings)
+
+          echo "POST /api/settings -> $CODE"; cat body.json; echo
+          if [ "$CODE" != "200" ]; then
+            echo "A write failed against an empty database. See #475."
+            cat start.log
+            exit 1
+          fi
+
+      - name: The write must have persisted, not just returned 200
+        run: |
+          VAL=$(psql "$DATABASE_URL" -At -c "SELECT value::text FROM app_cache WHERE key='auto_sync';")
+          echo "app_cache.auto_sync = $VAL"
+          case "$VAL" in
+            *720*) echo "persisted";;
+            *) echo "the row is missing or wrong; a 200 was returned without a durable write"; exit 1;;
+          esac


### PR DESCRIPTION
Closes the CI gap that let #475 through, rather than only documenting it.

## The gap

Two existing checks straddle the failing configuration and neither lands on it:

- `check-web` runs the Playwright smoke with **no** `DATABASE_URL`, so it exercises the "no database" state.
- `check-fresh-fork-web` proves the app installs, builds and answers with a bare environment, and never provisions a database.

Nothing covered a database that is **present and empty**, which is exactly where a forker lands after adding Neon Postgres as the README instructs them to.

## Why it needs a write, not a page load

Reads were never the problem. Against a database with zero tables, all seven pages return 200 with no error text. That is what made #475 invisible: the dashboard looks healthy and only writes fail. So the job asserts a write round-trips, and then separately checks the row actually landed in `app_cache` rather than trusting the 200.

## What it does and does not catch

Stated plainly because the distinction matters.

It **does not** catch #475. It bootstraps the schema from the Python side first, so it runs green today. #475 is the separate fact that the web never creates the schema itself.

It **does** guard the path where first-run bugs live: schema present, zero rows. Empty-data crashes, first-insert failures, missing-default handling. And once #475 is fixed, deleting the bootstrap step turns this job into the regression test for it.

## Verification

- Workflow YAML parses; the job registers alongside the existing six.
- The runtime sequence is not speculative. It is the one I ran by hand against a local Postgres while investigating #475: create schema, start the production build, authenticate, POST `/api/settings`, confirm `app_cache` holds the value.
- vitest 213/213, `tsc --noEmit` clean.

CI on this PR is the real proof, since only a runner can confirm the service container, `psql` availability and the Python bootstrap.

## Not in this PR

No product code. One CI job.
