### PR TITLE
Record the Vercel preview gap (#478) in the cutover gate

### DIFF
--- a/docs/CUTOVER.md
+++ b/docs/CUTOVER.md
@@ -48,9 +48,22 @@ regression in the other.
 A gap the gate does not close, which is how #475 survived a fully green suite.
 The smoke runs with no `DATABASE_URL` at all, and the fresh-fork job proves the
 app installs, builds and answers with a bare environment but never provisions a
-database. Neither covers a database that is present and empty, which is exactly
-where a forker lands after adding Neon as the README tells them to. Until
-something covers that, a green gate says nothing about a first-run fork.
+database. Neither covered a database that is present and empty, which is exactly
+where a forker lands after adding Neon as the README tells them to.
+`Web against an empty database` now covers that, asserting a write round-trips
+and the row actually lands, since reads return 200 either way.
+
+**The green `Vercel` check on a PR is not about the web app
+([#478](https://github.com/drkostas/hevy2garmin/issues/478)).** `hevy2garmin-demo`
+is the project linked to this repository, so it produces every preview, and it
+builds the Python dashboard. `hevy2garmin-web` has no GitHub link at all and
+therefore cannot produce one; its last deployment was manual. So nothing verifies
+that the web app deploys on Vercel, which is the thing the cutover moves everyone
+to. That matters because `next.config.ts` switches output on `process.env.VERCEL`,
+making the build that ships to Vercel different from the one every local and CI
+check exercises, and because #466 already hit a failure that reproduced only on
+Vercel. Before flipping, at minimum redeploy `hevy2garmin-web` from current
+`main` and exercise it.
 
 What the smoke does not prove: it exercises routing, auth, rendering and nav
 reachability, not the production server shape. `next.config.ts` sets


### PR DESCRIPTION
Records the third and last gap in the gate, [#478](https://github.com/drkostas/hevy2garmin/issues/478), and updates the empty-database paragraph now that #477 covers it.

## The gap

`hevy2garmin-demo` is the project linked to this repository, so it produces every PR preview, and it builds the **Python** dashboard. `hevy2garmin-web` has `link: null`, no GitHub connection, so it cannot produce a preview at all; its latest deployment is manual and predates recent merges.

So the green `Vercel` check on every PR is evidence about the path the cutover moves people **off**, not the one it moves them **to**.

## Why it is not cosmetic

`next.config.ts` switches build output by platform:

```ts
output: process.env.VERCEL ? undefined : "standalone",
```

with a comment recording that forcing standalone on Vercel corrupts the Edge middleware bundle. The build that ships to Vercel is therefore a different build from the one every local and CI check exercises, and nothing verifies it.

There is precedent in this repo: #466 tested a root `vercel.json` flip and it failed on Vercel under Next 16.1 with an error that reproduced nowhere else. A web preview is what catches that class.

## The gate's three gaps, now all recorded

1. No mobile Playwright project — closed by #469.
2. No coverage of a present-but-empty database — closed by #477.
3. No Vercel deployment of the web app — #478, open.

The first two are closed and the runbook says so. The third is open and the runbook now tells you not to read a green Vercel check as evidence about the web.

## Verification

- vitest 213/213 across 40 files
- `tsc --noEmit` clean

## Not in this PR

Documentation only. Connecting `hevy2garmin-web` to the repository changes what deploys on every future push, so that is yours.
