### PR TITLE
CI: Tests (Web) builds the output shape that actually ships

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,8 +110,21 @@ jobs:
 
       - name: Build
         # Routes are force-dynamic, so no real DB is touched at build time.
+        #
+        # VERCEL=1 selects the output shape that actually ships. next.config.ts
+        # sets `output: "standalone"` only OFF Vercel, so without this the whole
+        # job — unit tests and the Playwright smoke alike — exercises the
+        # self-hosting build rather than the deployed one. No coverage is lost:
+        # check-fresh-fork-web still builds without VERCEL and keeps the
+        # standalone path covered.
+        #
+        # Deliberately scoped to this step, NOT the job. `process.env.VERCEL` is
+        # also read at RUNTIME by app/api/toggle-autosync/route.ts, so hoisting
+        # it to job level would change app behaviour under test, not just the
+        # build shape.
         env:
           DATABASE_URL: postgres://ci:ci@localhost:5432/ci
+          VERCEL: "1"
         run: npm run build
 
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,24 @@ jobs:
     defaults:
       run:
         working-directory: web
+
+    # Exercise the app the way it is deployed. next.config.ts sets
+    # `output: "standalone"` only OFF Vercel, so without VERCEL this whole job
+    # built and served the self-hosting shape rather than the shipping one.
+    #
+    # Job-level on purpose, not per-step. `next start` re-reads next.config.ts,
+    # so setting it on the build alone leaves the server disagreeing with the
+    # build it is serving and printing a standalone warning about a
+    # non-standalone build. `process.env.VERCEL` is also read at RUNTIME by
+    # app/api/toggle-autosync/route.ts, and on Vercel that variable is always
+    # set, so job scope is the production-faithful choice rather than a
+    # convenience. Verified: vitest 213/213 and the smoke pass with it set.
+    #
+    # No coverage is traded: check-fresh-fork-web still builds without VERCEL,
+    # so the standalone path stays covered there.
+    env:
+      VERCEL: "1"
+
     steps:
       - uses: actions/checkout@v5
 
@@ -110,21 +128,8 @@ jobs:
 
       - name: Build
         # Routes are force-dynamic, so no real DB is touched at build time.
-        #
-        # VERCEL=1 selects the output shape that actually ships. next.config.ts
-        # sets `output: "standalone"` only OFF Vercel, so without this the whole
-        # job — unit tests and the Playwright smoke alike — exercises the
-        # self-hosting build rather than the deployed one. No coverage is lost:
-        # check-fresh-fork-web still builds without VERCEL and keeps the
-        # standalone path covered.
-        #
-        # Deliberately scoped to this step, NOT the job. `process.env.VERCEL` is
-        # also read at RUNTIME by app/api/toggle-autosync/route.ts, so hoisting
-        # it to job level would change app behaviour under test, not just the
-        # build shape.
         env:
           DATABASE_URL: postgres://ci:ci@localhost:5432/ci
-          VERCEL: "1"
         run: npm run build
 
       - name: Test


### PR DESCRIPTION
`next.config.ts` sets `output: "standalone"` only **off** Vercel:

```ts
output: process.env.VERCEL ? undefined : "standalone",
```

So `check-web` has been building the self-hosting shape, and everything downstream in that job — the unit tests and the Playwright smoke — has been running against a build that is not what deploys. Setting `VERCEL=1` on the build step points them at the deployed shape.

**No coverage is traded away.** `check-fresh-fork-web` still builds without `VERCEL`, so the standalone path stays covered. This is strictly more coverage, not a swap.

## Scoped to the build step deliberately

`process.env.VERCEL` is **also read at runtime**, by `app/api/toggle-autosync/route.ts:47`:

```ts
const onVercel = Boolean(process.env.VERCEL);
```

Hoisting the variable to job level would therefore change application behaviour under test, not just the build shape. I nearly did exactly that before checking, so the reason is written into the workflow comment: the obvious future tidy-up is to move it up a level, and that would be wrong.

## Verified locally from current main

- `VERCEL=1 npm run build` compiles every route and the middleware
- The parity smoke passes against that build: desktop 3/3, mobile 3/3
- vitest 213/213, `tsc --noEmit` clean

## Context

Follows from #478, where nothing verifies the web app on Vercel at all, because the repo-linked Vercel project builds the Python dashboard. This narrows that gap by making CI exercise the shipping build shape. It does **not** replace the preview deployment #478 asks for: Vercel's own bundling, Edge runtime and cold starts remain unexercised, and that is the layer that produced the #466 failure.

## Not in this PR

No product code. One env line and a comment explaining why it is where it is.
