### PR TITLE
fix(web): /api/cron is public in the proxy so the route's CRON_SECRET check runs (#473)

### DIFF
--- a/web/proxy.test.ts
+++ b/web/proxy.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { proxy } from "./proxy";
+
+// Auth configured (H2G_PASSWORD), no session cookie on any request: the shape of a
+// Vercel Cron / GitHub Actions caller. The epoch endpoint is stubbed so the proxy
+// never fetches.
+function req(path: string, headers: Record<string, string> = {}): NextRequest {
+  return new NextRequest(`http://h${path}`, { headers });
+}
+const passedThrough = (res: Response) => res.status === 200 && res.headers.get("x-middleware-next") === "1";
+
+beforeEach(() => {
+  process.env.H2G_PASSWORD = "test-pw";
+  delete process.env.HEVY2GARMIN_SECRET;
+  vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ n: 0 }), { status: 200 })));
+});
+afterEach(() => {
+  delete process.env.H2G_PASSWORD;
+  vi.unstubAllGlobals();
+});
+
+describe("proxy: /api/cron is public so the route's own CRON_SECRET check runs (#473)", () => {
+  it("a bearer on /api/cron/sync reaches the route", async () => {
+    const res = await proxy(req("/api/cron/sync", { authorization: "Bearer test-cron-secret" }));
+    expect(passedThrough(res)).toBe(true);
+  });
+
+  it("/api/cron/webhook passes too; the route, not the proxy, decides on the secret", async () => {
+    const res = await proxy(req("/api/cron/webhook"));
+    expect(passedThrough(res)).toBe(true);
+  });
+
+  it("/api/cronjobs is NOT public: the prefix match is on the path segment", async () => {
+    const res = await proxy(req("/api/cronjobs/x", { authorization: "Bearer test-cron-secret" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("an ordinary API route without a session stays gated with the proxy's plain 401", async () => {
+    const res = await proxy(req("/api/settings", { authorization: "Bearer test-cron-secret" }));
+    expect(res.status).toBe(401);
+    expect(await res.text()).toBe("Unauthorized");
+  });
+
+  it("a page without a session is redirected to /login with ?next=", async () => {
+    const res = await proxy(req("/dashboard"));
+    expect(res.status).toBeGreaterThanOrEqual(300);
+    expect(res.headers.get("location")).toBe("http://h/login?next=%2Fdashboard");
+  });
+
+  it("the login and epoch endpoints stay public", async () => {
+    expect(passedThrough(await proxy(req("/login")))).toBe(true);
+    expect(passedThrough(await proxy(req("/api/login")))).toBe(true);
+    expect(passedThrough(await proxy(req("/api/session-epoch")))).toBe(true);
+  });
+
+  it("with auth disabled everything is open, including /api/settings", async () => {
+    delete process.env.H2G_PASSWORD;
+    expect(passedThrough(await proxy(req("/api/settings")))).toBe(true);
+  });
+});

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -117,7 +117,10 @@ async function currentEpoch(origin: string): Promise<number> {
   return epochCache.n;
 }
 
-const PUBLIC_PATHS = ["/login", "/api/login", "/api/logout", "/api/session-epoch"];
+// /api/cron/* carries a bearer (Vercel Cron, the generated GitHub Actions workflow) and no
+// session cookie; each cron route checks CRON_SECRET itself. Gating it here 401'd every
+// scheduled sync before that check ran (#473).
+const PUBLIC_PATHS = ["/login", "/api/login", "/api/logout", "/api/session-epoch", "/api/cron"];
 const STATIC_PREFIX = /^\/(_next|favicon|manifest|icons|robots|sitemap)/;
 
 /** Gate every page + API route behind the shared-password session (mirrors auth.py).


### PR DESCRIPTION
## What

Vercel Cron and the generated GitHub Actions workflow call `/api/cron/*` with `Authorization: Bearer <CRON_SECRET>` and no session cookie. `web/proxy.ts` gated every `/api/*` behind the session and answered a plain-text 401 before the route could compare `CRON_SECRET`, so scheduled sync never ran on the web path whenever auth was configured (#473).

- `/api/cron` added to `PUBLIC_PATHS` (#481). The match is on the path segment, so `/api/cronjobs/...` stays gated. Each cron route still enforces `CRON_SECRET` itself.
- `web/proxy.test.ts` (#482): with auth configured and no session, a bearer on `/api/cron/sync` reaches the route, `/api/cron/webhook` passes, `/api/cronjobs/x` is 401, `/api/settings` with the same bearer is the proxy's plain 401, `/dashboard` redirects to `/login?next=`, `/login` `/api/login` `/api/session-epoch` stay public, and with auth disabled everything is open.

## Execution proof (production build, `next start`, `H2G_PASSWORD` + `HEVY2GARMIN_SECRET` + `CRON_SECRET` set, no `DATABASE_URL`, no `GITHUB_PAT`, so nothing could sync)

```
GET /api/cron/sync   Bearer test-cron-secret  → 500 application/json {"ok":false,"error":"No Hevy API key available (arg, HEVY_API_KEY, or platform_credentials).","ran":0}
GET /api/cron/sync   Bearer nope              → 401 application/json {"ok":false,"error":"Unauthorized."}
GET /api/settings    Bearer test-cron-secret  → 401 text/plain       Unauthorized
GET /api/cronjobs/x  Bearer test-cron-secret  → 401
```

Before this change both cron calls returned the proxy's plain-text `Unauthorized` (the tell in #473). Now the wrong bearer gets the route's JSON and the right bearer runs the handler.

- `npx tsc --noEmit` exit 0; vitest 41 files, 220 tests green.

Closes #473
Closes #481
Closes #482
