### PR TITLE
fix(web): create the schema on first database use; CI empty-db job drops the Python bootstrap (#475)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,21 +249,14 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Install the Python package (for the schema bootstrap)
-        run: pip install -e ".[cloud]"
-
-      - name: Create the schema, insert nothing
+      # No Python bootstrap here on purpose (#475): the database starts with zero
+      # tables and the web app must create them itself on first use. Putting the
+      # Python _ensure_tables() back would hide the exact bug this job exists for.
+      - name: The database really is empty
         run: |
-          python -c "
-          import os
-          from hevy2garmin.db_postgres import PostgresDatabase
-          PostgresDatabase(os.environ['DATABASE_URL'])._ensure_tables()
-          print('schema created')
-          "
+          N=$(psql "$DATABASE_URL" -tAc "SELECT count(*) FROM pg_tables WHERE schemaname = 'public'")
+          echo "tables before: $N"
+          [ "$N" = "0" ] || { echo "expected an empty database"; exit 1; }
 
       - uses: actions/setup-node@v4
         with:
@@ -303,6 +296,13 @@ jobs:
             cat start.log
             exit 1
           fi
+
+      - name: The web app created the nine tables itself
+        run: |
+          for t in synced_workouts sync_log hr_cache pending_uploads platform_credentials custom_mappings app_cache synced_routines routine_schedules; do
+            psql "$DATABASE_URL" -tAc "SELECT to_regclass('public.$t')" | grep -qx "$t" || { echo "missing table: $t"; exit 1; }
+          done
+          echo "all nine tables present"
 
       - name: The write must have persisted, not just returned 200
         run: |

--- a/web/lib/db.test.ts
+++ b/web/lib/db.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// A fake postgres.js client: callable as a tagged template, with `unsafe` and `json`.
+const calls: string[] = [];
+vi.mock("postgres", () => ({
+  default: () => {
+    const client = (strings: TemplateStringsArray) => { calls.push(`query:${strings.join("?").trim()}`); return Promise.resolve([{ ok: 1 }]); };
+    client.unsafe = (text: string) => { calls.push(`unsafe:${text.split("\n")[0].trim()}`); return Promise.resolve([]); };
+    client.json = (v: unknown) => v;
+    return client;
+  },
+}));
+
+import { getDb } from "./db";
+import { SCHEMA_STATEMENTS, resetSchemaForTests } from "./schema";
+
+beforeEach(() => { calls.length = 0; resetSchemaForTests(); process.env.DATABASE_URL = "postgresql://x"; });
+
+describe("getDb runs the schema bootstrap before the first query (#475)", () => {
+  it("the CREATEs precede the query, and later queries do not repeat them", async () => {
+    const sql = getDb();
+    const rows = await sql`SELECT 1`;
+    expect(rows).toEqual([{ ok: 1 }]);
+    const unsafeCount = calls.filter((c) => c.startsWith("unsafe:")).length;
+    expect(unsafeCount).toBe(SCHEMA_STATEMENTS.length);
+    expect(calls.indexOf("query:SELECT 1")).toBe(SCHEMA_STATEMENTS.length);
+    await sql`SELECT 2`;
+    expect(calls.filter((c) => c.startsWith("unsafe:")).length).toBe(SCHEMA_STATEMENTS.length);
+  });
+});

--- a/web/lib/db.ts
+++ b/web/lib/db.ts
@@ -1,4 +1,5 @@
 import postgres from "postgres";
+import { ensureSchema } from "./schema";
 
 /**
  * Tagged-template SQL function matching the @neondatabase/serverless shape
@@ -29,8 +30,11 @@ export function getDb(): SqlTag {
   }
   const client = postgres(url, { prepare: false });
 
+  // Every query waits for the one-time schema bootstrap (#475), so the first
+  // write on a fresh database cannot outrun the CREATE TABLE statements.
   const tag = ((strings: TemplateStringsArray, ...values: unknown[]) =>
-    (client as unknown as (s: TemplateStringsArray, ...v: unknown[]) => Promise<unknown[]>)(strings, ...values)
+    ensureSchema(client)
+      .then(() => (client as unknown as (s: TemplateStringsArray, ...v: unknown[]) => Promise<unknown[]>)(strings, ...values))
       .then((rows) => Array.from(rows) as Row[])) as SqlTag;
 
   tag.json = <T,>(value: T) => (client as unknown as { json: (v: T) => unknown }).json(value);

--- a/web/lib/schema.test.ts
+++ b/web/lib/schema.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { ensureSchema, resetSchemaForTests, SCHEMA_STATEMENTS, SCHEMA_TABLES } from "./schema";
+
+function runner(failOn?: string) {
+  const ran: string[] = [];
+  return {
+    ran,
+    db: {
+      unsafe: vi.fn(async (text: string) => {
+        ran.push(text);
+        if (failOn && text.includes(failOn)) throw new Error(`boom on ${failOn}`);
+        return [];
+      }),
+    },
+  };
+}
+
+beforeEach(() => resetSchemaForTests());
+
+describe("ensureSchema (#475)", () => {
+  it("creates the nine Python tables, every statement IF NOT EXISTS", () => {
+    const creates = SCHEMA_STATEMENTS.filter((s) => s.startsWith("CREATE TABLE"));
+    expect(creates).toHaveLength(9);
+    for (const t of SCHEMA_TABLES) expect(creates.some((s) => s.includes(`IF NOT EXISTS ${t} (`))).toBe(true);
+    for (const s of SCHEMA_STATEMENTS) expect(s).toMatch(/IF NOT EXISTS/);
+  });
+
+  it("runs every statement in order, once", async () => {
+    const { db, ran } = runner();
+    expect(await ensureSchema(db)).toBe(true);
+    expect(ran).toEqual([...SCHEMA_STATEMENTS]);
+  });
+
+  it("is memoised per process: concurrent and later callers share one run", async () => {
+    const { db } = runner();
+    await Promise.all([ensureSchema(db), ensureSchema(db), ensureSchema(db)]);
+    await ensureSchema(db);
+    expect(db.unsafe).toHaveBeenCalledTimes(SCHEMA_STATEMENTS.length);
+  });
+
+  it("never rejects: a failing statement logs, resolves false, and does not block queries", async () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { db } = runner("app_cache");
+    await expect(ensureSchema(db)).resolves.toBe(false);
+    expect(spy).toHaveBeenCalledOnce();
+    expect(String(spy.mock.calls[0][0])).toContain("app_cache");
+    spy.mockRestore();
+  });
+});

--- a/web/lib/schema.ts
+++ b/web/lib/schema.ts
@@ -1,0 +1,135 @@
+/**
+ * The web app creates its own schema on first database use (#475).
+ *
+ * `src/hevy2garmin/db_postgres.py` bootstraps nine tables in `_ensure_tables`;
+ * until now `web/` created none, so a web-only fork against a brand-new Neon
+ * database rendered every page (reads degrade to empty) and 500'd on every
+ * write ("relation app_cache does not exist"). Same statements, same order,
+ * every one `IF NOT EXISTS`, so running them against a populated database is
+ * a no-op.
+ *
+ * Runs once per process: `getDb()` makes every query wait on the memoised
+ * promise, so the first write cannot race the CREATEs. It never rejects; on
+ * failure it logs and lets the real query report the real error, the same
+ * contract as normalizeGarminTokenRow.
+ */
+export const SCHEMA_STATEMENTS: readonly string[] = [
+  `CREATE TABLE IF NOT EXISTS synced_workouts (
+     hevy_id TEXT PRIMARY KEY,
+     garmin_activity_id TEXT,
+     title TEXT,
+     synced_at TIMESTAMPTZ DEFAULT NOW(),
+     calories INTEGER,
+     avg_hr INTEGER,
+     status VARCHAR(20) DEFAULT 'success'
+   )`,
+  `CREATE TABLE IF NOT EXISTS sync_log (
+     id BIGSERIAL PRIMARY KEY,
+     time TIMESTAMPTZ DEFAULT NOW(),
+     synced INTEGER DEFAULT 0,
+     skipped INTEGER DEFAULT 0,
+     failed INTEGER DEFAULT 0,
+     trigger VARCHAR(50) DEFAULT 'manual'
+   )`,
+  `CREATE TABLE IF NOT EXISTS hr_cache (
+     hevy_id TEXT PRIMARY KEY,
+     data JSONB NOT NULL,
+     cached_at TIMESTAMPTZ DEFAULT NOW()
+   )`,
+  `CREATE TABLE IF NOT EXISTS pending_uploads (
+     hevy_id TEXT PRIMARY KEY,
+     phase TEXT NOT NULL,
+     next_step TEXT,
+     upload_id TEXT,
+     garmin_activity_id TEXT,
+     watch_activity_id TEXT,
+     pre_upload_ids JSONB NOT NULL DEFAULT '[]',
+     payload JSONB NOT NULL DEFAULT '{}',
+     resolution_source TEXT,
+     attempt_count INTEGER NOT NULL DEFAULT 0,
+     delete_attempt_count INTEGER NOT NULL DEFAULT 0,
+     last_error TEXT,
+     locked_until TIMESTAMPTZ,
+     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+   )`,
+  `CREATE TABLE IF NOT EXISTS platform_credentials (
+     platform VARCHAR(50) PRIMARY KEY,
+     auth_type VARCHAR(20) NOT NULL DEFAULT 'oauth',
+     credentials JSONB NOT NULL DEFAULT '{}',
+     connected_at TIMESTAMPTZ,
+     expires_at TIMESTAMPTZ,
+     status VARCHAR(20) DEFAULT 'disconnected'
+   )`,
+  `CREATE TABLE IF NOT EXISTS custom_mappings (
+     hevy_name TEXT PRIMARY KEY,
+     category INTEGER NOT NULL,
+     subcategory INTEGER NOT NULL DEFAULT 0
+   )`,
+  // Columns added after the first release; a database bootstrapped by an older
+  // Python build lacks them. Idempotent.
+  `ALTER TABLE synced_workouts ADD COLUMN IF NOT EXISTS hevy_updated_at TEXT`,
+  `ALTER TABLE synced_workouts ADD COLUMN IF NOT EXISTS sync_method TEXT DEFAULT 'upload'`,
+  `ALTER TABLE synced_workouts ADD COLUMN IF NOT EXISTS resolution_reason TEXT`,
+  `ALTER TABLE synced_workouts ADD COLUMN IF NOT EXISTS resolved_at TIMESTAMPTZ`,
+  `ALTER TABLE synced_workouts ADD COLUMN IF NOT EXISTS resolution_source TEXT`,
+  `CREATE TABLE IF NOT EXISTS app_cache (
+     key TEXT PRIMARY KEY,
+     value JSONB NOT NULL,
+     updated_at TIMESTAMPTZ DEFAULT NOW()
+   )`,
+  `CREATE TABLE IF NOT EXISTS synced_routines (
+     hevy_routine_id TEXT PRIMARY KEY,
+     garmin_workout_id TEXT,
+     title TEXT,
+     hevy_updated_at TEXT,
+     scheduled_date TEXT,
+     content_hash TEXT,
+     synced_at TIMESTAMPTZ DEFAULT NOW(),
+     status VARCHAR(20) DEFAULT 'success'
+   )`,
+  `ALTER TABLE synced_routines ADD COLUMN IF NOT EXISTS content_hash TEXT`,
+  `CREATE TABLE IF NOT EXISTS routine_schedules (
+     hevy_routine_id TEXT NOT NULL,
+     schedule_id TEXT NOT NULL,
+     scheduled_date TEXT,
+     PRIMARY KEY (hevy_routine_id, schedule_id)
+   )`,
+];
+
+/** The nine tables the Python bootstrap creates; the CI empty-database job asserts on them. */
+export const SCHEMA_TABLES = [
+  "synced_workouts", "sync_log", "hr_cache", "pending_uploads", "platform_credentials",
+  "custom_mappings", "app_cache", "synced_routines", "routine_schedules",
+] as const;
+
+/** A raw-SQL runner: postgres.js `client.unsafe(text)`. */
+export type UnsafeRunner = { unsafe: (text: string) => Promise<unknown> };
+
+let ready: Promise<boolean> | null = null;
+
+/**
+ * Run the schema statements once per process. Resolves true when every
+ * statement ran, false when one failed (already logged). Never rejects.
+ */
+export function ensureSchema(db: UnsafeRunner): Promise<boolean> {
+  if (ready) return ready;
+  ready = (async () => {
+    for (const text of SCHEMA_STATEMENTS) {
+      try {
+        await db.unsafe(text);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`[schema] ${text.split("\n")[0].trim()} failed: ${msg}`);
+        return false;
+      }
+    }
+    return true;
+  })();
+  return ready;
+}
+
+/** Tests only. */
+export function resetSchemaForTests(): void {
+  ready = null;
+}


### PR DESCRIPTION
## What

`web/` never created its database schema (#475). A fork that follows the recommended deploy (Root Directory `web`) against a brand-new Neon database renders every page, because the reads degrade to empty, and 500s on every write ("relation app_cache does not exist"). Setup cannot complete at all.

- `web/lib/schema.ts` (#484): a port of `db_postgres._ensure_tables`. The nine `CREATE TABLE IF NOT EXISTS` statements plus the `ADD COLUMN IF NOT EXISTS` set, same order as Python, every one idempotent. `ensureSchema` is memoised per process and never rejects: a failing statement logs and resolves so the real query reports the real error, the same contract as `normalizeGarminTokenRow`.
- `web/lib/db.ts`: every query through `getDb()` waits on that promise, so the first write on a fresh database cannot outrun the CREATEs. After the first query it is a resolved promise, no extra round trip.
- CI (#485): `check-web-empty-db` no longer installs Python or runs `_ensure_tables()`. It asserts the database starts with zero tables, runs the existing write round-trip, then asserts the web app created all nine tables. Putting the Python bootstrap back would hide the exact bug this job exists for.

## Evidence

- `npx tsc --noEmit` exit 0; vitest 42 files, 218 tests green (schema: 9 tables all IF NOT EXISTS, in-order once, memoised across concurrent callers, never rejects; db: the CREATEs precede the first query and do not repeat).
- Execution proof on a production build against a freshly created local Postgres 17 database:

```
tables before: 0
POST /api/login → session cookie
POST /api/settings {"auto_sync":{"enabled":true,"interval_minutes":720}} → 200 {"ok":true,"saved":["auto_sync"]}
tables after: app_cache,custom_mappings,hr_cache,pending_uploads,platform_credentials,routine_schedules,sync_log,synced_routines,synced_workouts  (count 9)
app_cache.auto_sync = {"enabled": true, "interval_minutes": 720}
```

The scratch database was dropped afterwards. The CI job on this PR is the same proof on a GitHub runner.

Closes #475
Closes #484
Closes #485
