### PR TITLE
fix(web): DEMO_MODE refuses every mutating /api method in the proxy (#471)

### DIFF
--- a/web/proxy.test.ts
+++ b/web/proxy.test.ts
@@ -5,18 +5,20 @@ import { proxy } from "./proxy";
 // Auth configured (H2G_PASSWORD), no session cookie on any request: the shape of a
 // Vercel Cron / GitHub Actions caller. The epoch endpoint is stubbed so the proxy
 // never fetches.
-function req(path: string, headers: Record<string, string> = {}): NextRequest {
-  return new NextRequest(`http://h${path}`, { headers });
+function req(path: string, headers: Record<string, string> = {}, method = "GET"): NextRequest {
+  return new NextRequest(`http://h${path}`, { headers, method });
 }
 const passedThrough = (res: Response) => res.status === 200 && res.headers.get("x-middleware-next") === "1";
 
 beforeEach(() => {
   process.env.H2G_PASSWORD = "test-pw";
   delete process.env.HEVY2GARMIN_SECRET;
+  delete process.env.DEMO_MODE;
   vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({ n: 0 }), { status: 200 })));
 });
 afterEach(() => {
   delete process.env.H2G_PASSWORD;
+  delete process.env.DEMO_MODE;
   vi.unstubAllGlobals();
 });
 
@@ -57,5 +59,56 @@ describe("proxy: /api/cron is public so the route's own CRON_SECRET check runs (
   it("with auth disabled everything is open, including /api/settings", async () => {
     delete process.env.H2G_PASSWORD;
     expect(passedThrough(await proxy(req("/api/settings")))).toBe(true);
+  });
+});
+
+describe("proxy: DEMO_MODE refuses every mutating /api method (#471)", () => {
+  const demoBody = { ok: false, error: "Read-only in demo mode" };
+
+  for (const method of ["POST", "PUT", "PATCH", "DELETE"]) {
+    it(`${method} /api/mapping is 403 JSON, even with a valid-looking bearer`, async () => {
+      process.env.DEMO_MODE = "true";
+      const res = await proxy(req("/api/mapping", { authorization: "Bearer x" }, method));
+      expect(res.status).toBe(403);
+      expect(res.headers.get("content-type")).toContain("application/json");
+      expect(await res.json()).toEqual(demoBody);
+    });
+  }
+
+  it("the refusal comes before auth: a signed-in session is still refused", async () => {
+    process.env.DEMO_MODE = "1";
+    const res = await proxy(req("/api/unsync-all", {}, "POST"));
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual(demoBody);
+  });
+
+  it("a demo with auth disabled is still read-only", async () => {
+    process.env.DEMO_MODE = "yes";
+    delete process.env.H2G_PASSWORD;
+    expect((await proxy(req("/api/settings", {}, "POST"))).status).toBe(403);
+    expect(passedThrough(await proxy(req("/api/settings")))).toBe(true);
+  });
+
+  it("GET stays readable and login/logout stay allowed in demo", async () => {
+    process.env.DEMO_MODE = "on";
+    expect(passedThrough(await proxy(req("/api/login", {}, "POST")))).toBe(true);
+    expect(passedThrough(await proxy(req("/api/logout", {}, "POST")))).toBe(true);
+    // GET /api/settings without a session is the normal auth 401, not the demo 403.
+    expect((await proxy(req("/api/settings"))).status).toBe(401);
+  });
+
+  it("pages are not affected by demo mode", async () => {
+    process.env.DEMO_MODE = "true";
+    const res = await proxy(req("/dashboard", {}, "POST"));
+    expect(res.headers.get("location")).toBe("http://h/login?next=%2Fdashboard");
+  });
+
+  it("with DEMO_MODE off (unset, false, 0) nothing changes", async () => {
+    for (const v of [undefined, "false", "0", ""]) {
+      if (v === undefined) delete process.env.DEMO_MODE; else process.env.DEMO_MODE = v;
+      const res = await proxy(req("/api/mapping", {}, "POST"));
+      expect(res.status).toBe(401);
+      expect(await res.text()).toBe("Unauthorized");
+    }
   });
 });

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -123,11 +123,34 @@ async function currentEpoch(origin: string): Promise<number> {
 const PUBLIC_PATHS = ["/login", "/api/login", "/api/logout", "/api/session-epoch", "/api/cron"];
 const STATIC_PREFIX = /^\/(_next|favicon|manifest|icons|robots|sitemap)/;
 
+/* Demo mode (#471). Mirrors lib/demo.ts (inlined: the proxy bundler rejects
+   cross-module imports). The public demo is read-only: one guard here refuses
+   every mutating /api call instead of 30 route-level checks, of which exactly
+   one existed. Signing in and out stays allowed so the demo can be browsed. */
+const MUTATING = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+const DEMO_ALLOWED = ["/api/login", "/api/logout"];
+function demoMode(): boolean {
+  const v = (process.env.DEMO_MODE ?? "").trim().toLowerCase();
+  return v === "1" || v === "true" || v === "yes" || v === "on";
+}
+function demoRefusal(): NextResponse {
+  return NextResponse.json({ ok: false, error: "Read-only in demo mode" }, { status: 403 });
+}
+
 /** Gate every page + API route behind the shared-password session (mirrors auth.py).
     When no secret/password is set, auth is disabled and everything is open. */
 export async function proxy(req: NextRequest) {
   const { pathname } = req.nextUrl;
   if (STATIC_PREFIX.test(pathname)) return NextResponse.next();
+  // Before the auth gate on purpose: a demo with auth disabled is still read-only.
+  if (
+    demoMode() &&
+    pathname.startsWith("/api/") &&
+    MUTATING.has(req.method.toUpperCase()) &&
+    !DEMO_ALLOWED.some((p) => pathname === p || pathname.startsWith(`${p}/`))
+  ) {
+    return demoRefusal();
+  }
   if (!authEnabled()) return NextResponse.next();
   // Let the epoch endpoint through BEFORE reading the epoch, or currentEpoch()
   // (which fetches it) would recurse into the proxy forever.


### PR DESCRIPTION
## What

`web/.env.example` promises `DEMO_MODE=true` means a read-only demo where every mutating `/api` call is refused. Only 1 of 30 mutating route files (`unsync-all`) checked `demoMode()`, and the proxy had no demo check, so a web-path demo would have let visitors write to the maintainer's data the moment Root Directory flips to `web` (#471).

- `web/proxy.ts` (#486): one guard, before the auth gate. When `DEMO_MODE` is on, `POST`/`PUT`/`PATCH`/`DELETE` under `/api/` return `{"ok":false,"error":"Read-only in demo mode"}` with 403. `/api/login` and `/api/logout` stay allowed so the demo can be browsed. GET is untouched; pages are untouched. `demoMode()` is inlined (same logic as `lib/demo.ts`) because the proxy bundler rejects cross-module imports.
- Placed before the auth gate on purpose: a demo with auth disabled is still read-only.

## Evidence (#487)

- `web/proxy.test.ts`: 16 tests. New: each of POST/PUT/PATCH/DELETE on `/api/mapping` is 403 JSON even with a bearer; a signed-in POST `/api/unsync-all` is still refused; a demo with auth disabled refuses POST and passes GET; login/logout pass and GET `/api/settings` without a session is the ordinary 401, not the demo 403; pages are unaffected; with `DEMO_MODE` unset, `false`, `0` or empty nothing changes. `npx tsc --noEmit` exit 0; vitest 41 files, 229 tests green.
- Execution proof on a production build, `DEMO_MODE=true`, auth configured, **no `DATABASE_URL`** so any mutating route that ran would have thrown "DATABASE_URL not set":

```
POST   /api/login                       → 200, session cookie issued
POST   /api/mapping      (no session)   → 403 application/json {"ok":false,"error":"Read-only in demo mode"}
POST   /api/unsync-all   (with session) → 403 application/json {"ok":false,"error":"Read-only in demo mode"}
DELETE /api/mapping/x    (with session) → 403 {"ok":false,"error":"Read-only in demo mode"}
GET    /api/settings     (with session) → 405 from the route itself (it has no GET handler): reads pass the guard
POST   /api/logout                      → 200
server log: 0 lines mentioning DATABASE_URL or unsync → no mutating route code ran
```

Closes #471
Closes #486
Closes #487
