### PR TITLE
fix(web): read Garmin connectivity from the token row, not the garmin row

### DIFF
--- a/web/app/api/hevy/status/route.ts
+++ b/web/app/api/hevy/status/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getDb } from "@/lib/db";
+import { loadGarminConnection, loadHevyConnection } from "@/lib/connections";
 
 // Reads the live hevy2garmin Postgres at request time — never at build.
 export const dynamic = "force-dynamic";
@@ -45,20 +46,16 @@ export async function GET() {
     return NextResponse.json(EMPTY);
   }
 
-  // Connection status from platform_credentials. `.catch` guards a missing table
-  // (fresh deploy that hasn't run the Python schema bootstrap yet).
-  const connected = await sql`
-    SELECT platform, status
-    FROM platform_credentials
-    WHERE platform IN ('hevy', 'garmin')
-  `.catch(() => [] as Array<{ platform: string; status: string }>);
-
-  const hevyConnected = connected.some(
-    (r) => r.platform === "hevy" && r.status === "connected",
-  );
-  const garminConnected = connected.some(
-    (r) => r.platform === "garmin" && r.status === "connected",
-  );
+  // Connection status from platform_credentials. See lib/connections.ts for which row means
+  // what; both helpers guard a missing table (fresh deploy that hasn't bootstrapped the schema).
+  // This used to test status === 'connected', a value nothing writes, so both flags were always
+  // false, and it read Garmin off the 'garmin' row a web login never creates (#495).
+  const [hevyConn, garminConn] = await Promise.all([
+    loadHevyConnection(sql),
+    loadGarminConnection(sql),
+  ]);
+  const hevyConnected = hevyConn.connected;
+  const garminConnected = garminConn.connected;
 
   // Aggregate counts over synced_workouts (success terminal state only).
   const counts = await sql`

--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -1,4 +1,5 @@
 import { getDb } from "@/lib/db";
+import { loadGarminConnection, loadHevyConnection } from "@/lib/connections";
 import { SyncPanel } from "@/components/sync-panel";
 import { SyncLoop } from "@/components/sync-loop";
 import { BatchSync } from "@/components/batch-sync";
@@ -72,12 +73,9 @@ async function loadDashboard(): Promise<DashboardData> {
 
   // Every query is guarded so a missing/empty table degrades to a sane default
   // rather than crashing the whole page render.
-  const [connected, counts, recent, syncLog, autoSync, pendingRow, routinesRow] = await Promise.all([
-    sql`
-      SELECT platform, status
-      FROM platform_credentials
-      WHERE platform IN ('hevy', 'garmin')
-    `.catch(() => [] as Array<{ platform: string; status: string }>),
+  const [hevyConn, garminConn, counts, recent, syncLog, autoSync, pendingRow, routinesRow] = await Promise.all([
+    loadHevyConnection(sql),
+    loadGarminConnection(sql),
     sql`
       SELECT
         count(*) FILTER (WHERE COALESCE(status, 'success') = 'success')::int AS total,
@@ -123,14 +121,11 @@ async function loadDashboard(): Promise<DashboardData> {
 
   return {
     dbConfigured: true,
-    // A saved credential row is "connected" unless explicitly disconnected.
-    // The DB uses status='active' for a live connection (not 'connected').
-    hevyConnected:
-      connected.some((r) => r.platform === "hevy" && r.status !== "disconnected") ||
-      recent.length > 0,
+    // See lib/connections.ts for which row means what. The `recent` fallbacks keep a user who
+    // synced under an older build showing as connected even if their credential row is odd.
+    hevyConnected: hevyConn.connected || recent.length > 0,
     garminConnected:
-      connected.some((r) => r.platform === "garmin" && r.status !== "disconnected") ||
-      recent.some((r) => r.garmin_activity_id != null),
+      garminConn.connected || recent.some((r) => r.garmin_activity_id != null),
     totalSynced: counts[0]?.total ?? 0,
     syncedThisWeek: counts[0]?.week ?? 0,
     markedSynced: counts[0]?.marked ?? 0,

--- a/web/app/setup/page.tsx
+++ b/web/app/setup/page.tsx
@@ -1,23 +1,19 @@
 import { getDb } from "@/lib/db";
+import { loadGarminConnection, loadHevyConnection, type Connection } from "@/lib/connections";
 import { ConnectHevy } from "@/components/connect-hevy";
 import { ConnectGarmin } from "@/components/connect-garmin";
 
 // Queries the live hevy2garmin Postgres per request — never at build time.
 export const dynamic = "force-dynamic";
 
-interface Conn {
-  platform: string;
-  status: string;
-  connected_at: string | null;
-}
-
 interface SetupData {
   dbConfigured: boolean;
-  hevy: Conn | null;
-  garmin: Conn | null;
+  hevy: Connection;
+  garmin: Connection;
 }
 
-const EMPTY: SetupData = { dbConfigured: false, hevy: null, garmin: null };
+const NONE: Connection = { connected: false, connectedAt: null };
+const EMPTY: SetupData = { dbConfigured: false, hevy: NONE, garmin: NONE };
 
 async function loadSetup(): Promise<SetupData> {
   let sql: ReturnType<typeof getDb>;
@@ -26,18 +22,11 @@ async function loadSetup(): Promise<SetupData> {
   } catch {
     return EMPTY;
   }
-  const rows = await sql`
-    SELECT platform, status, connected_at
-    FROM platform_credentials
-    WHERE platform IN ('hevy', 'garmin')
-  `.catch(() => [] as Conn[]);
-  const find = (p: string): Conn | null =>
-    rows.find((r) => r.platform === p) ?? null;
-  return { dbConfigured: true, hevy: find("hevy"), garmin: find("garmin") };
-}
-
-function isConnected(c: Conn | null): boolean {
-  return Boolean(c && c.status !== "disconnected");
+  const [hevy, garmin] = await Promise.all([
+    loadHevyConnection(sql),
+    loadGarminConnection(sql),
+  ]);
+  return { dbConfigured: true, hevy, garmin };
 }
 
 function fmtDate(value: string | null): string {
@@ -63,8 +52,8 @@ function StatusDot({ connected }: { connected: boolean }) {
 
 export default async function SetupPage() {
   const data = await loadSetup();
-  const hevyConnected = isConnected(data.hevy);
-  const garminConnected = isConnected(data.garmin);
+  const hevyConnected = data.hevy.connected;
+  const garminConnected = data.garmin.connected;
 
   return (
     <main className="mx-auto max-w-3xl px-4 py-8 md:px-6">
@@ -87,9 +76,9 @@ export default async function SetupPage() {
           <h2 className="text-lg font-semibold text-text">Hevy</h2>
           <StatusDot connected={hevyConnected} />
         </div>
-        {hevyConnected && data.hevy?.connected_at && (
+        {hevyConnected && data.hevy.connectedAt && (
           <p className="mb-3 text-xs text-text-muted">
-            Connected {fmtDate(data.hevy.connected_at)}.
+            Connected {fmtDate(data.hevy.connectedAt)}.
           </p>
         )}
         <ConnectHevy connected={hevyConnected} />
@@ -101,9 +90,9 @@ export default async function SetupPage() {
           <h2 className="text-lg font-semibold text-text">Garmin Connect</h2>
           <StatusDot connected={garminConnected} />
         </div>
-        {garminConnected && data.garmin?.connected_at && (
+        {garminConnected && data.garmin.connectedAt && (
           <p className="mb-3 text-xs text-text-muted">
-            Connected {fmtDate(data.garmin.connected_at)}.
+            Connected {fmtDate(data.garmin.connectedAt)}.
           </p>
         )}
         <ConnectGarmin connected={garminConnected} />

--- a/web/lib/connections.test.ts
+++ b/web/lib/connections.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { loadGarminConnection, loadHevyConnection } from "./connections";
+
+type Sql = Parameters<typeof loadGarminConnection>[0];
+
+/** A fake `sql` tag that records the query text and returns a canned result set. */
+function fakeSql(rows: unknown[], sink?: string[]): Sql {
+  const tag = (async (strings: TemplateStringsArray) => {
+    sink?.push(strings.join("?").replace(/\s+/g, " ").trim());
+    return rows;
+  }) as unknown as Sql;
+  return tag;
+}
+
+function throwingSql(): Sql {
+  return (async () => {
+    throw new Error("relation \"platform_credentials\" does not exist");
+  }) as unknown as Sql;
+}
+
+describe("loadGarminConnection (#495)", () => {
+  it("reads the garmin_tokens row, not the garmin email/password row", async () => {
+    const queries: string[] = [];
+    await loadGarminConnection(fakeSql([], queries));
+    expect(queries[0]).toContain("WHERE platform = 'garmin_tokens'");
+    expect(queries[0]).not.toContain("'garmin'");
+  });
+
+  it("is connected when a nested DI token is stored, ignoring the status column", async () => {
+    // has_token is what the SQL computes; status is deliberately absent from the projection
+    // because DBTokenStore's DO UPDATE never refreshes it.
+    const r = await loadGarminConnection(
+      fakeSql([{ connected_at: "2026-09-01T00:00:00Z", has_token: true }]),
+    );
+    expect(r).toEqual({ connected: true, connectedAt: "2026-09-01T00:00:00Z" });
+  });
+
+  it("accepts a token with no connected_at, which the token-store upsert never sets", async () => {
+    const r = await loadGarminConnection(fakeSql([{ connected_at: null, has_token: true }]));
+    expect(r).toEqual({ connected: true, connectedAt: null });
+  });
+
+  it("tests both the nested and the flat token shape", async () => {
+    const queries: string[] = [];
+    await loadGarminConnection(fakeSql([], queries));
+    expect(queries[0]).toContain("jsonb_exists(credentials -> 'garmin_tokens', 'di_token')");
+    expect(queries[0]).toContain("jsonb_exists(credentials, 'di_token')");
+  });
+
+  it("is disconnected when the row exists but holds no token", async () => {
+    const r = await loadGarminConnection(
+      fakeSql([{ connected_at: "2026-09-01T00:00:00Z", has_token: false }]),
+    );
+    expect(r).toEqual({ connected: false, connectedAt: null });
+  });
+
+  it("is disconnected when no row exists at all", async () => {
+    expect(await loadGarminConnection(fakeSql([]))).toEqual({
+      connected: false,
+      connectedAt: null,
+    });
+  });
+
+  it("degrades to disconnected when the table is missing", async () => {
+    expect(await loadGarminConnection(throwingSql())).toEqual({
+      connected: false,
+      connectedAt: null,
+    });
+  });
+});
+
+describe("loadHevyConnection", () => {
+  it("treats the status the setup form actually writes as connected", async () => {
+    const r = await loadHevyConnection(
+      fakeSql([{ status: "active", connected_at: "2026-09-01T00:00:00Z" }]),
+    );
+    expect(r).toEqual({ connected: true, connectedAt: "2026-09-01T00:00:00Z" });
+  });
+
+  it("treats an explicit disconnected status as disconnected", async () => {
+    const r = await loadHevyConnection(fakeSql([{ status: "disconnected", connected_at: null }]));
+    expect(r.connected).toBe(false);
+  });
+
+  it("is disconnected when no row exists", async () => {
+    expect((await loadHevyConnection(fakeSql([]))).connected).toBe(false);
+  });
+
+  it("degrades to disconnected when the table is missing", async () => {
+    expect((await loadHevyConnection(throwingSql())).connected).toBe(false);
+  });
+});

--- a/web/lib/connections.ts
+++ b/web/lib/connections.ts
@@ -1,0 +1,57 @@
+import type { getDb } from "./db";
+
+type Sql = ReturnType<typeof getDb>;
+
+export interface Connection {
+  connected: boolean;
+  connectedAt: string | null;
+}
+
+const DISCONNECTED: Connection = { connected: false, connectedAt: null };
+
+/**
+ * Which platform_credentials row means what:
+ *
+ *   platform='hevy'          the API key, written by the setup form
+ *   platform='garmin'        the Garmin email/password pair, written by the Python setup form only
+ *   platform='garmin_tokens' the DI tokens, written by every Garmin login (Python and web)
+ *
+ * Garmin connectivity has to come from `garmin_tokens`. A web login writes only that row, so
+ * pages that looked at `garmin` reported a working login as "Not connected" and stayed that way
+ * until the user hand-copied the row (hevy2garmin#495).
+ *
+ * It also has to come from the stored token rather than the `status` column. DBTokenStore's
+ * upsert sets status='active' on INSERT but not in its DO UPDATE branch, so a row first created
+ * by anything else keeps the schema default 'disconnected' through every later login. Reading the
+ * token itself is true whenever a sync would actually work, which is what the badge claims.
+ *
+ * Both token shapes count: 0.3+ nests the DI payload under `garmin_tokens`, older Python logins
+ * wrote it flat. healGarminTokenRow migrates a flat row, but only during a sync.
+ */
+export async function loadGarminConnection(sql: Sql): Promise<Connection> {
+  const rows = await sql`
+    SELECT connected_at,
+           (jsonb_exists(credentials -> 'garmin_tokens', 'di_token')
+            OR jsonb_exists(credentials, 'di_token')) AS has_token
+    FROM platform_credentials
+    WHERE platform = 'garmin_tokens'
+  `.catch(() => [] as Array<{ connected_at: string | null; has_token: boolean | null }>);
+  const row = rows[0];
+  if (!row?.has_token) return DISCONNECTED;
+  return { connected: true, connectedAt: row.connected_at ?? null };
+}
+
+/**
+ * Hevy is connected when its credential row exists and is not explicitly disconnected. The
+ * setup form writes status='active', so testing for the literal 'connected' never matches.
+ */
+export async function loadHevyConnection(sql: Sql): Promise<Connection> {
+  const rows = await sql`
+    SELECT status, connected_at
+    FROM platform_credentials
+    WHERE platform = 'hevy'
+  `.catch(() => [] as Array<{ status: string | null; connected_at: string | null }>);
+  const row = rows[0];
+  if (!row || row.status === "disconnected") return DISCONNECTED;
+  return { connected: true, connectedAt: row.connected_at ?? null };
+}


### PR DESCRIPTION
Follow-up to #496. That PR fixed the write side (the missing `pg` peer dependency meant the Garmin login silently saved nothing). ColinJennings007 then reported on #495 that the status still read "Not connected" until he manually added a second row under `platform='garmin'` holding a copy of his tokens. He was right, and this is why.

## The rows

| row | holds | written by |
| --- | --- | --- |
| `hevy` | the API key | the setup form |
| `garmin` | the Garmin email/password pair | the **Python** setup form only |
| `garmin_tokens` | the DI tokens | **every** Garmin login, Python and web |

## Three faults, same area

**1. The pages read the wrong row.** `/setup`, `/dashboard` and `/api/hevy/status` all queried `WHERE platform IN ('hevy', 'garmin')`. A web login writes only `garmin_tokens`, so `garmin` is absent and Garmin reported as disconnected no matter how well the login worked. Copying the row under `garmin`, as Colin did, satisfied the query, which is why his workaround worked.

**2. The `status` column is not a reliable signal.** `DBTokenStore`'s upsert sets `status='active'` in its INSERT branch but not in its `DO UPDATE` branch, so a row first created by anything else keeps the schema default `'disconnected'` through every later login. The reverse also happens: a row whose credentials have been emptied keeps `status='active'` and reports a false green.

**3. `/api/hevy/status` tested `status === 'connected'`.** Nothing writes that string. The setup form writes `'active'` and the token store writes `'active'`, so both flags in that endpoint were always false.

## The change

New `web/lib/connections.ts` gives all three call sites one definition of connected:

- Garmin comes from the `garmin_tokens` row and is true when a DI token is actually stored, which is the condition under which a sync would work. Both shapes count, since 0.3+ nests the payload under `garmin_tokens` and older Python logins wrote it flat.
- Hevy keeps the "row exists and is not explicitly disconnected" rule the dashboard already used.

Both helpers degrade to disconnected if the table is missing, matching the previous `.catch` guards.

## Verified

Ran the page against a Postgres seeded with each state:

| state | before | after |
| --- | --- | --- |
| nested token, `status='disconnected'` (the reported bug) | Not connected | **Connected** |
| flat token from an older Python login | Connected | **Connected** |
| `garmin_tokens` row present, credentials `{}` | Not connected | Not connected |
| credentials `{}` but `status='active'` (false green) | **Connected** | Not connected |
| only a `garmin` email/password row, no tokens | Connected | Not connected |

Screenshots of `/setup` and `/dashboard` confirm both dots green on the first state, with no synced workouts present, so the reading comes from the token and not from the `garmin_activity_id` fallback.

11 new tests in `web/lib/connections.test.ts`. Web suite 245 passed, `tsc --noEmit` clean.

Closes #495
