### PR TITLE
fix(web): bump garmin-auth to 0.5.0 so a failed token write is reported

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@garmin/fitsdk": "^21.212.0",
         "@types/libsodium-wrappers": "^0.7.14",
-        "garmin-auth": "^0.4.1",
+        "garmin-auth": "^0.5.0",
         "hash-wasm": "^4.12.0",
         "hevy2garmin": "^0.1.4",
         "libsodium-wrappers": "^0.8.4",
@@ -4073,17 +4073,12 @@
       }
     },
     "node_modules/garmin-auth": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/garmin-auth/-/garmin-auth-0.4.1.tgz",
-      "integrity": "sha512-Z3Nlh3UpoilqWpjrY4jfgQ8DImzD5vJ4yOdi5Gui3m0w7mc8ReoNESUp6GoKZD9RDzuwsekZuuqAeImTtI7ytw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/garmin-auth/-/garmin-auth-0.5.0.tgz",
+      "integrity": "sha512-YP3waRjxHIrXMz1/6vpTZDEsGU7bg5GUMidNmNK78Iod8q/VYX1kT+rKDNuHY5RTWwVP/kaTHopC+nRKz57BDA==",
       "license": "MIT",
-      "peerDependencies": {
+      "dependencies": {
         "pg": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "pg": {
-          "optional": true
-        }
       }
     },
     "node_modules/gensync": {

--- a/web/package.json
+++ b/web/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@garmin/fitsdk": "^21.212.0",
     "@types/libsodium-wrappers": "^0.7.14",
-    "garmin-auth": "^0.4.1",
+    "garmin-auth": "^0.5.0",
     "hash-wasm": "^4.12.0",
     "hevy2garmin": "^0.1.4",
     "libsodium-wrappers": "^0.8.4",


### PR DESCRIPTION
garmin-auth 0.5.0 fixes the defect behind #495 at the source, so hevy2garmin can stop relying on the workaround being enough.

The one that mattered: `DBTokenStore.save()` ended in a bare catch, and the store opens its own client through `pg`, which garmin-auth declared as an optional peer dependency that npm does not install. So in a fresh fork the driver never loaded, the catch discarded the error, and the login route answered "connected" having written nothing at all. That is why #495 took three root causes to close: the missing dependency (#496), then the pages reading the wrong row (#497), and underneath both, a store that could not tell anyone it had failed.

0.5.0 also raises on an unreachable database instead of answering "no tokens", restores `status`, `auth_type` and `connected_at` when a re-login updates the row, and depends on `pg` directly.

A caret on a 0.x version does not accept 0.5.0, so the pin needed moving by hand.

## No route changes needed

Both `save()` callers already wrap the call and return the real error with a 500, so they go from reporting a success that never happened to reporting the actual failure:

- `app/api/garmin-login/route.ts` catches around `persist()`
- `app/api/garmin-ticket/route.ts` has its own try/catch

`getGarminClient()` will surface a database error rather than `Login needs MFA / fresh SSO`. That is the honest reading, and it already throws for a missing `DATABASE_URL`, so callers expect it.

The explicit `pg` entry stays. garmin-auth brings its own now, but that entry is what #496 added after this exact dependency went missing, and keeping it costs nothing.

## Verified

245 tests pass and `tsc --noEmit` is clean against the real 0.5.0, not just the lockfile: the first `npm install` left 0.4.1 on disk while the lockfile said 0.5.0, so the installed `dist/storage.js` was checked directly for the new upsert and the absence of the old bare catch.

End to end against the installed dependency, a save to an unreachable database now rejects with `connect ECONNREFUSED` instead of resolving. Before this bump the same call resolved successfully having written nothing, which is the behaviour that hid #495.

Closes #498
