### PR TITLE
fix(web): move Garmin login toResponse out of the route module (from #356)

### DIFF
--- a/web/app/api/garmin-login-mfa/route.ts
+++ b/web/app/api/garmin-login-mfa/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { workerLoginMfa } from "@/lib/garmin-login-worker";
-import { toResponse } from "@/app/api/garmin-login/route";
+import { toResponse } from "@/lib/garmin-login-response";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";

--- a/web/app/api/garmin-login/route.ts
+++ b/web/app/api/garmin-login/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
-import { DBTokenStore } from "garmin-auth";
-import { GARMIN_TOKEN_PLATFORM, resetGarminClient } from "@/lib/garmin-upload";
-import { workerLogin, tokensFromResult, type WorkerLoginResult } from "@/lib/garmin-login-worker";
+import { workerLogin } from "@/lib/garmin-login-worker";
+import { toResponse } from "@/lib/garmin-login-response";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -20,73 +19,6 @@ export const runtime = "nodejs";
  * When the account has two-factor enabled the Worker returns needs_mfa with a
  * session_id; the client then posts the code to /api/garmin-login-mfa.
  */
-
-/** Persist the DI tokens (nested {garmin_tokens:{...}}) for the sync engine. */
-async function persist(url: string, result: WorkerLoginResult): Promise<void> {
-  const tokens = tokensFromResult(result);
-  if (!tokens) throw new Error("Login succeeded but no DI tokens were returned.");
-  const store = new DBTokenStore(url, GARMIN_TOKEN_PLATFORM);
-  await store.save(tokens);
-  resetGarminClient();
-}
-
-/** Map a Worker result to the HTTP response the client consumes. */
-export function toResponse(url: string | undefined, result: WorkerLoginResult): Promise<NextResponse> | NextResponse {
-  switch (result.status) {
-    case "success": {
-      if (!url) {
-        return NextResponse.json(
-          { status: "error", error: "DATABASE_URL is not configured; cannot store the session." },
-          { status: 503 },
-        );
-      }
-      return persist(url, result)
-        .then(() => NextResponse.json({ status: "connected" }))
-        .catch((err) =>
-          NextResponse.json(
-            { status: "error", error: err instanceof Error ? err.message : String(err) },
-            { status: 500 },
-          ),
-        );
-    }
-    case "needs_mfa":
-      return NextResponse.json({
-        status: "needs_mfa",
-        session_id: result.session_id ?? "",
-        mfa_method: result.mfa_method ?? "",
-      });
-    case "needs_captcha":
-      return NextResponse.json(
-        {
-          status: "needs_captcha",
-          error:
-            "Garmin asked for a captcha. Automated sign-in can't clear it — sign in on Garmin's site and use the manual token flow.",
-        },
-        { status: 409 },
-      );
-    case "invalid_credentials":
-      return NextResponse.json(
-        { status: "invalid_credentials", error: "Incorrect Garmin email or password." },
-        { status: 401 },
-      );
-    case "rate_limited":
-      return NextResponse.json(
-        {
-          status: "rate_limited",
-          retry_after_seconds: result.retry_after_seconds ?? null,
-          error: result.retry_after_seconds
-            ? `Garmin is rate-limiting sign-ins. Try again in about ${Math.ceil(result.retry_after_seconds / 60)} min.`
-            : "Garmin is rate-limiting sign-ins. Try again later.",
-        },
-        { status: 429 },
-      );
-    default:
-      return NextResponse.json(
-        { status: "error", error: result.message ?? "Garmin login failed." },
-        { status: 502 },
-      );
-  }
-}
 
 export async function POST(request: Request) {
   let body: { email?: unknown; password?: unknown } = {};

--- a/web/lib/garmin-login-response.ts
+++ b/web/lib/garmin-login-response.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server";
+import { DBTokenStore } from "garmin-auth";
+import { GARMIN_TOKEN_PLATFORM, resetGarminClient } from "@/lib/garmin-upload";
+import { tokensFromResult, type WorkerLoginResult } from "@/lib/garmin-login-worker";
+
+/** Persist the DI tokens (nested {garmin_tokens:{...}}) for the sync engine. */
+async function persist(url: string, result: WorkerLoginResult): Promise<void> {
+  const tokens = tokensFromResult(result);
+  if (!tokens) throw new Error("Login succeeded but no DI tokens were returned.");
+  const store = new DBTokenStore(url, GARMIN_TOKEN_PLATFORM);
+  await store.save(tokens);
+  resetGarminClient();
+}
+
+/** Map a Worker result to the HTTP response both Garmin login steps consume. */
+export function toResponse(
+  url: string | undefined,
+  result: WorkerLoginResult,
+): Promise<NextResponse> | NextResponse {
+  switch (result.status) {
+    case "success": {
+      if (!url) {
+        return NextResponse.json(
+          { status: "error", error: "DATABASE_URL is not configured; cannot store the session." },
+          { status: 503 },
+        );
+      }
+      return persist(url, result)
+        .then(() => NextResponse.json({ status: "connected" }))
+        .catch((err) =>
+          NextResponse.json(
+            { status: "error", error: err instanceof Error ? err.message : String(err) },
+            { status: 500 },
+          ),
+        );
+    }
+    case "needs_mfa":
+      return NextResponse.json({
+        status: "needs_mfa",
+        session_id: result.session_id ?? "",
+        mfa_method: result.mfa_method ?? "",
+      });
+    case "needs_captcha":
+      return NextResponse.json(
+        {
+          status: "needs_captcha",
+          error:
+            "Garmin asked for a captcha. Automated sign-in can't clear it — sign in on Garmin's site and use the manual token flow.",
+        },
+        { status: 409 },
+      );
+    case "invalid_credentials":
+      return NextResponse.json(
+        { status: "invalid_credentials", error: "Incorrect Garmin email or password." },
+        { status: 401 },
+      );
+    case "rate_limited":
+      return NextResponse.json(
+        {
+          status: "rate_limited",
+          retry_after_seconds: result.retry_after_seconds ?? null,
+          error: result.retry_after_seconds
+            ? `Garmin is rate-limiting sign-ins. Try again in about ${Math.ceil(result.retry_after_seconds / 60)} min.`
+            : "Garmin is rate-limiting sign-ins. Try again later.",
+        },
+        { status: 429 },
+      );
+    default:
+      return NextResponse.json(
+        { status: "error", error: result.message ?? "Garmin login failed." },
+        { status: 502 },
+      );
+  }
+}


### PR DESCRIPTION
`web/app/api/garmin-login-mfa/route.ts` imported `toResponse` from `web/app/api/garmin-login/route.ts`. A route module importing from another route module is a Next.js footgun: it drags the first route's module scope into the second and can break the build. This moves `toResponse` and the token-persist helper into `web/lib/garmin-login-response.ts` and has both routes import from there.

Extracted from #356 by @diogormendes and cherry-picked with his authorship. His branch also touched `auth.test.ts`, but main had already rewritten that test block, so the test file here is main's. Typecheck and vitest (245/245) green on this branch.

Part of #500.
