### PR TITLE
Move the sync engine into the hevy2garmin package (#500)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Changed
+- The sync engine now lives in the `hevy2garmin` npm package (0.3.0): `syncOneWorkout`, `listCandidates`, `reconcilePending`, `retryPending`, the pure dedup helpers and `generateDescription`, behind a `SyncStore` interface and a `GarminGateway`. The web dashboard imports it and keeps only a Postgres `SyncStore` adapter and route glue, so soma and any other consumer run the same dedup and dry-run logic ([#500](https://github.com/drkostas/hevy2garmin/issues/500)).
 - The Next.js web dashboard in `web/` is now the recommended Vercel deploy: set **Root Directory** to `web` when importing a fork, or change it in an existing project's settings and redeploy ([#456](https://github.com/drkostas/hevy2garmin/issues/456)). The Python dashboard keeps working for existing deployments (Root Directory empty) but no longer gets new features. Both read the same database and credential rows.
 
 ### Added

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -73,6 +73,34 @@ const { activityId } = await uploadFit(client, fit, hevyWorkout.start_time);
 if (activityId) await renameActivity(client, activityId, hevyWorkout.title);
 ```
 
+### Sync a workout (dedup, dry-run by default)
+
+The sync engine decides which Hevy workouts still need to reach Garmin and
+performs the upload. It never touches a database or the network directly: you
+hand it a `SyncStore` (the ledger of synced and in-flight workouts), a lazily
+built `GarminGateway`, and the Hevy fetch. `dryRun` defaults to `true`, so the
+call below computes the decision without writing anything.
+
+```ts
+import { garminGateway, syncOneWorkout, type SyncStore } from "hevy2garmin";
+
+const store: SyncStore = /* your ledger: Postgres, SQLite, a Map in tests */;
+const deps = {
+  store,
+  gateway: async () => garminGateway(await garminAuth.client()),
+  fetchWorkouts: () => hevy.getAllWorkouts(),
+};
+
+const preview = await syncOneWorkout(deps);                   // no writes
+if (preview.wouldUpload) await syncOneWorkout(deps, { dryRun: false });
+```
+
+Three layers keep a workout from being uploaded twice: a terminal row in the
+store, an activity already on Garmin at the same start time (matched, not
+re-uploaded), and an atomic claim on the in-flight row so two workers never
+race. `reconcilePending` and `retryPending` recover a stuck upload the same
+way, checking Garmin before ever re-uploading.
+
 ## API
 
 | Export | What it does |
@@ -83,6 +111,11 @@ if (activityId) await renameActivity(client, activityId, hevyWorkout.title);
 | `lookupExercise` | Map a Hevy exercise name to its Garmin FIT category. |
 | `uploadFit` / `renameActivity` / `setDescription` / `deleteActivity` | Manage the activity on Garmin Connect (needs a `garmin-auth` client). |
 | `HEVY_TO_GARMIN`, `TEMPLATE_TO_GARMIN` | The raw exercise mapping tables. |
+| `syncOneWorkout` / `listCandidates` | The sync engine: next unsynced workout, three-layer dedup, dry-run by default. |
+| `reconcilePending` / `retryPending` | Recover a stuck in-flight upload without ever double-uploading. |
+| `SyncStore` / `GarminGateway` / `garminGateway` | The two boundaries the engine talks through; `garminGateway` wraps a `garmin-auth` client. |
+| `isUnsynced` / `filterUnsynced` / `pickNextUnsynced` / `summarizeDedup` | Pure dedup decisions over a workout list. |
+| `generateDescription` | The activity description text every upload path attaches. |
 
 ## Develop
 

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hevy2garmin",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Sync Hevy workouts to Garmin Connect (TypeScript). FIT generation, exercise mapping, and upload. The TS twin of the Python hevy2garmin.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -3,3 +3,4 @@ export * from "./mapper";
 export * from "./fit";
 export * from "./hevy";
 export * from "./garmin";
+export * from "./sync";

--- a/typescript/src/sync/dedup.ts
+++ b/typescript/src/sync/dedup.ts
@@ -1,0 +1,92 @@
+/**
+ * Pure dedup decision logic — the SAFE half of the sync engine.
+ *
+ * These functions decide WHICH Hevy workouts still need syncing. They take
+ * plain data (a workout list + the sets of already-synced and pending hevy_ids)
+ * and return candidates / the next pick. They perform NO IO: no store, no Hevy,
+ * and crucially no Garmin upload.
+ *
+ * The three-layer never-duplicate concept maps onto the ledger as:
+ *   Layer 1 (already resolved): a terminal `synced_workouts` row exists
+ *            (status success/manual/skipped) → excluded via `syncedIds`.
+ *   Layer 2 (in flight): a `pending_uploads` row exists (an upload was claimed
+ *            or is mid-flight) → excluded via `pendingIds`, so we never
+ *            double-claim / double-upload the same workout.
+ *   Layer 3 (Garmin 409 on duplicate FIT) lives in the engine's upload path and
+ *            is out of scope here; the pure layer only encodes layers 1 and 2.
+ *
+ * "Skip if synced OR pending" is the single rule these functions enforce.
+ */
+import type { DedupWorkout } from "./types";
+
+export type { DedupWorkout };
+
+/** True when a workout is NOT yet resolved and NOT in flight. Pure predicate. */
+export function isUnsynced(
+  workout: DedupWorkout,
+  syncedIds: ReadonlySet<string>,
+  pendingIds: ReadonlySet<string>,
+): boolean {
+  const id = workout.id;
+  if (!id) return false;
+  return !syncedIds.has(id) && !pendingIds.has(id);
+}
+
+/** Filter to the workouts still needing a sync. Input order preserved. Pure. */
+export function filterUnsynced(
+  workouts: readonly DedupWorkout[],
+  syncedIds: ReadonlySet<string>,
+  pendingIds: ReadonlySet<string>,
+): DedupWorkout[] {
+  return workouts.filter((w) => isUnsynced(w, syncedIds, pendingIds));
+}
+
+/** The first unsynced workout in list order, or null. Pure. */
+export function pickNextUnsynced(
+  workouts: readonly DedupWorkout[],
+  syncedIds: ReadonlySet<string>,
+  pendingIds: ReadonlySet<string>,
+): DedupWorkout | null {
+  for (const w of workouts) {
+    if (isUnsynced(w, syncedIds, pendingIds)) return w;
+  }
+  return null;
+}
+
+/** A full preview of the dedup decision over a workout list. Pure. */
+export interface DedupSummary {
+  totalHevy: number;
+  syncedCount: number;
+  pendingCount: number;
+  remaining: number;
+  candidates: DedupWorkout[];
+  nextUnsynced: DedupWorkout | null;
+}
+
+/**
+ * Compute the full dedup decision in one pass. `syncedCount`/`pendingCount`
+ * reflect how many of THESE workouts are already resolved / in flight, so the
+ * numbers add up against `totalHevy`. Pure — feeds a preview route.
+ */
+export function summarizeDedup(
+  workouts: readonly DedupWorkout[],
+  syncedIds: ReadonlySet<string>,
+  pendingIds: ReadonlySet<string>,
+): DedupSummary {
+  const candidates = filterUnsynced(workouts, syncedIds, pendingIds);
+  let syncedCount = 0;
+  let pendingCount = 0;
+  for (const w of workouts) {
+    if (!w.id) continue;
+    if (syncedIds.has(w.id)) syncedCount++;
+    else if (pendingIds.has(w.id)) pendingCount++;
+  }
+  return {
+    totalHevy: workouts.length,
+    syncedCount,
+    pendingCount,
+    remaining: candidates.length,
+    candidates,
+    nextUnsynced: candidates[0] ?? null,
+  };
+}

--- a/typescript/src/sync/description.ts
+++ b/typescript/src/sync/description.ts
@@ -1,0 +1,67 @@
+/**
+ * Text description for a synced gym workout. Ported from garmin.py
+ * generate_description so every upload path produces the same body.
+ * Pure — builds a string, no network.
+ */
+export function generateDescription(
+  workout: Record<string, unknown>,
+  calories: number | null,
+  avgHr: number | null,
+): string {
+  const lines: string[] = [];
+  const title = (workout.title as string) || "Workout";
+  const start = (workout.start_time as string) || (workout.startTime as string) || "";
+  const end = (workout.end_time as string) || (workout.endTime as string) || "";
+  let durationS = 0;
+  if (start && end) {
+    const t0 = Date.parse(start.replace(" ", "T"));
+    const t1 = Date.parse(end.replace(" ", "T"));
+    if (!Number.isNaN(t0) && !Number.isNaN(t1)) durationS = Math.floor((t1 - t0) / 1000);
+  }
+
+  lines.push(`🏋️ ${title}`);
+  if (durationS > 0) lines.push(`⏱️ ${Math.floor(durationS / 60)} min`);
+  if (calories) lines.push(`🔥 ${calories} kcal`);
+  if (avgHr) lines.push(`❤️ avg ${avgHr} bpm`);
+
+  const exercises = (workout.exercises as Array<Record<string, unknown>>) || [];
+  if (exercises.length) {
+    lines.push("");
+    for (const ex of exercises) {
+      const name = (ex.title as string) || (ex.name as string) || "Unknown";
+      const allSets = (ex.sets as Array<Record<string, unknown>>) || [];
+      const normal = allSets.filter((s) => s.type === "normal");
+      const warmup = allSets.filter((s) => s.type === "warmup");
+      if (normal.length) {
+        const nLabel = normal.length === 1 ? "set" : "sets";
+        const hasDistance = normal.some((s) => s.distance_meters);
+        const hasDuration = normal.some((s) => s.duration_seconds);
+        const hasWeight = normal.some((s) => s.weight_kg || s.weight);
+        if (hasDistance || (hasDuration && !hasWeight)) {
+          const totalDist = normal.reduce((a, s) => a + (Number(s.distance_meters) || 0), 0);
+          const totalDur = normal.reduce((a, s) => a + (Number(s.duration_seconds) || 0), 0);
+          const parts = [`${normal.length} ${nLabel}`];
+          if (totalDist > 0) parts.push(`${(totalDist / 1000).toFixed(1)}km`);
+          if (totalDur > 0) parts.push(`${Math.floor(totalDur / 60)}min`);
+          lines.push(`• ${name}: ${parts.join(" · ")}`);
+        } else {
+          const weights = normal
+            .map((s) => (s.weight_kg ?? s.weight) as number | undefined)
+            .filter((w): w is number => w != null);
+          const reps = normal
+            .map((s) => s.reps as number | undefined)
+            .filter((r): r is number => r != null);
+          const topWeight = weights.length ? Math.max(...weights) : 0;
+          const topReps = reps.length ? Math.max(...reps) : 0;
+          lines.push(`• ${name}: ${normal.length} ${nLabel} · ${topWeight.toFixed(1)}kg × ${topReps}`);
+        }
+      } else if (warmup.length) {
+        const sLabel = warmup.length === 1 ? "set" : "sets";
+        lines.push(`• ${name}: ${warmup.length} warmup ${sLabel}`);
+      }
+    }
+  }
+
+  lines.push("\n— synced by hevy2garmin");
+  return lines.join("\n");
+}

--- a/typescript/src/sync/gateway.ts
+++ b/typescript/src/sync/gateway.ts
@@ -1,0 +1,42 @@
+/**
+ * The Garmin boundary of the sync engine — the ONLY way the engine reaches
+ * Garmin Connect. `findExistingActivity` is a READ (dedup layer 2, the
+ * 409-prevention lookup). `upload`, `rename` and `describe` are WRITES, reached
+ * only on the live path (dryRun === false). Nothing here decides WHETHER to
+ * upload; the engine does.
+ *
+ * `garminGateway(client)` is the default over this package's own Garmin ops. A
+ * test supplies spies instead.
+ */
+import type { GarminClient } from "garmin-auth";
+import { findActivityByStartTime, renameActivity, setDescription, uploadFit, type UploadResult } from "../garmin";
+
+export interface GarminGateway {
+  /** READ: the id of an activity already at this start time, or null. */
+  findExistingActivity(startTime: string): Promise<number | null>;
+  /** WRITE: upload a FIT (bytes); resolve the activity id. */
+  upload(fit: Uint8Array, workoutStart?: string): Promise<UploadResult>;
+  /** WRITE: rename an activity. */
+  rename(activityId: number, name: string): Promise<void>;
+  /** WRITE: set an activity's description. */
+  describe(activityId: number, description: string): Promise<void>;
+}
+
+/** The default gateway: thin passthroughs to the package's Garmin functions. */
+export function garminGateway(client: GarminClient): GarminGateway {
+  return {
+    findExistingActivity: (startTime) => findActivityByStartTime(client, startTime),
+    upload: (fit, workoutStart) => uploadFit(client, fit, workoutStart),
+    rename: (activityId, name) => renameActivity(client, activityId, name),
+    describe: (activityId, description) => setDescription(client, activityId, description),
+  };
+}
+
+/** What the engine needs from its host. All IO goes through these three. */
+export interface SyncDeps {
+  store: import("./store").SyncStore;
+  /** Lazily built: only called once a Garmin read/write is actually needed. */
+  gateway: () => Promise<GarminGateway>;
+  /** The Hevy workout list, newest first (the order the engine picks in). */
+  fetchWorkouts: () => Promise<import("./types").DedupWorkout[]>;
+}

--- a/typescript/src/sync/index.ts
+++ b/typescript/src/sync/index.ts
@@ -1,0 +1,7 @@
+export * from "./types";
+export * from "./store";
+export * from "./gateway";
+export * from "./dedup";
+export * from "./description";
+export * from "./sync-one";
+export * from "./recovery";

--- a/typescript/src/sync/recovery.ts
+++ b/typescript/src/sync/recovery.ts
@@ -1,0 +1,115 @@
+/**
+ * Recovery for stuck in-flight uploads — the counterpart to syncOneWorkout for
+ * a SPECIFIC pending workout rather than the next candidate.
+ *
+ *   reconcile — a Garmin READ: check whether Garmin already has an activity at
+ *     the workout's start time. If it does, the earlier attempt actually
+ *     landed, so complete the pending as a matched success (no re-upload).
+ *     Otherwise leave the pending in place and record that nothing was found.
+ *
+ *   retry — reconcile first (never double-upload), and only if Garmin still has
+ *     nothing, regenerate the FIT from the stored payload and re-upload, then
+ *     finalize. A Garmin WRITE — the host gates it behind auth + confirmation.
+ */
+import { generateFit, type HevyWorkout as FitWorkout } from "../fit";
+import { generateDescription } from "./description";
+import type { SyncDeps } from "./gateway";
+import type { PendingRecord, RecoveryOptions, RecoveryResult } from "./types";
+
+interface StoredPayload {
+  workout?: Record<string, unknown>;
+  title?: string;
+  calories?: number;
+  avg_hr?: number | null;
+}
+
+function payloadOf(pending: PendingRecord): StoredPayload {
+  const p = pending.payload;
+  return p && typeof p === "object" ? (p as StoredPayload) : {};
+}
+
+function startTimeOf(workout: Record<string, unknown> | undefined): string | null {
+  const s = workout?.start_time;
+  return typeof s === "string" && s ? s : null;
+}
+
+type RecoveryDeps = Pick<SyncDeps, "store" | "gateway">;
+
+/** Complete a pending as a matched Garmin activity (no upload). */
+async function completeMatched(deps: RecoveryDeps, hevyId: string, pl: StoredPayload, activityId: number): Promise<void> {
+  await deps.store.completePending(hevyId, {
+    garminActivityId: String(activityId),
+    title: pl.title ?? "",
+    calories: pl.calories ?? null,
+    avgHr: pl.avg_hr ?? null,
+    syncMethod: "match",
+  });
+}
+
+export async function reconcilePending(deps: RecoveryDeps, hevyId: string): Promise<RecoveryResult> {
+  const pending = await deps.store.getPending(hevyId);
+  if (!pending) return { status: "not_found", garminActivityId: null, error: null };
+  const pl = payloadOf(pending);
+  const startTime = startTimeOf(pl.workout);
+  if (!startTime) return { status: "no_payload", garminActivityId: null, error: null };
+
+  const gateway = await deps.gateway();
+  const existing = await gateway.findExistingActivity(startTime);
+  if (existing != null) {
+    await completeMatched(deps, hevyId, pl, existing);
+    return { status: "reconciled_synced", garminActivityId: existing, error: null };
+  }
+  await deps.store.updatePending(hevyId, { last_error: "reconcile: no matching Garmin activity" });
+  return { status: "no_activity", garminActivityId: null, error: null };
+}
+
+export async function retryPending(
+  deps: RecoveryDeps,
+  hevyId: string,
+  opts: RecoveryOptions = {},
+): Promise<RecoveryResult> {
+  const pending = await deps.store.getPending(hevyId);
+  if (!pending) return { status: "not_found", garminActivityId: null, error: null };
+  const pl = payloadOf(pending);
+  const workout = pl.workout;
+  const startTime = startTimeOf(workout);
+  if (!workout || !startTime) return { status: "no_payload", garminActivityId: null, error: null };
+
+  const gateway = await deps.gateway();
+
+  // Never double-upload: if Garmin already has it, complete as matched.
+  const existing = await gateway.findExistingActivity(startTime);
+  if (existing != null) {
+    await completeMatched(deps, hevyId, pl, existing);
+    return { status: "reconciled_synced", garminActivityId: existing, error: null };
+  }
+
+  try {
+    const fit = generateFit(workout as unknown as FitWorkout, null);
+    await deps.store.updatePending(hevyId, {
+      phase: "processing",
+      attempt_count: (pending.attempt_count ?? 0) + 1,
+      last_error: null,
+    });
+    const up = await gateway.upload(fit.fit, startTime);
+    const activityId = up.activityId;
+    if (activityId != null) {
+      await gateway.rename(activityId, pl.title ?? "");
+      if (opts.descriptionEnabled !== false) {
+        await gateway.describe(activityId, generateDescription(workout, fit.calories, fit.avg_hr));
+      }
+    }
+    await deps.store.completePending(hevyId, {
+      garminActivityId: activityId != null ? String(activityId) : null,
+      title: pl.title ?? "",
+      calories: fit.calories,
+      avgHr: fit.avg_hr,
+      syncMethod: "upload",
+    });
+    return { status: "synced", garminActivityId: activityId ?? null, error: null };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await deps.store.updatePending(hevyId, { phase: "processing", last_error: message });
+    return { status: "error", garminActivityId: null, error: message };
+  }
+}

--- a/typescript/src/sync/store.ts
+++ b/typescript/src/sync/store.ts
@@ -1,0 +1,34 @@
+/**
+ * The storage boundary of the sync engine. The engine never touches a database
+ * directly; it reads and writes its ledger (`synced_workouts` for terminal
+ * state, `pending_uploads` for in-flight durable checkpoints) through this
+ * interface. A consumer supplies an implementation — the web dashboard's is
+ * Postgres; a test's is a Map. Every method is local bookkeeping: NOTHING here
+ * calls Garmin, uploads a FIT, or mutates Hevy.
+ */
+import type { MarkSyncedOpts, PendingRecord, PendingUpdate } from "./types";
+
+export interface SyncStore {
+  /** True when the workout already has a terminal row (dedup layer 1). */
+  isSynced(hevyId: string): Promise<boolean>;
+  /** Every hevy_id with a terminal row. Batch read for dedup. */
+  loadSyncedIds(): Promise<Set<string>>;
+  /** Every hevy_id with an in-flight pending row. Batch read for dedup. */
+  loadPendingIds(): Promise<Set<string>>;
+  /** One pending row by id, or null. */
+  getPending(hevyId: string): Promise<PendingRecord | null>;
+  /**
+   * Atomically claim a workout (INSERT ... ON CONFLICT DO NOTHING). Returns true
+   * when THIS caller won the claim, false when a row already existed (dedup
+   * layer 3). Claiming is bookkeeping only — it does NOT begin an upload.
+   */
+  claimPending(hevyId: string, payload: Record<string, unknown>): Promise<boolean>;
+  /** Update a pending row's checkpoint fields. Never fires an upload. */
+  updatePending(hevyId: string, fields: PendingUpdate): Promise<void>;
+  /** Delete a pending row. Returns whether a row was removed. */
+  deletePending(hevyId: string): Promise<boolean>;
+  /** Write the terminal success row AND clear the pending row. */
+  completePending(hevyId: string, opts: MarkSyncedOpts): Promise<void>;
+  /** Record a workout as terminally synced (status='success'). Local ledger only. */
+  markSynced(hevyId: string, opts: MarkSyncedOpts): Promise<void>;
+}

--- a/typescript/src/sync/sync-one.ts
+++ b/typescript/src/sync/sync-one.ts
@@ -1,0 +1,301 @@
+/**
+ * syncOneWorkout — the Hevy→Garmin upload engine, host-agnostic.
+ *
+ * DRY-RUN BY DEFAULT. Because a bad upload creates a duplicate Garmin/Strava
+ * activity — a hard user constraint — the default is dryRun=true and NO Garmin
+ * write and NO store mutation happen unless the caller passes { dryRun: false }.
+ *
+ * The three-layer never-duplicate contract:
+ *
+ *   Layer 1 — already resolved: a terminal `synced_workouts` row exists for
+ *     the workout → SKIPPED. The pure dedup excludes these when picking the
+ *     next candidate; this module re-checks the picked workout against the live
+ *     ledger so a concurrent sync can't slip a just-synced id through.
+ *
+ *   Layer 2 — Garmin already has it: BEFORE uploading, the gateway asks Garmin
+ *     whether an activity already exists at the workout's start time. If one
+ *     does, we DO NOT upload (409 prevention) — we match it and rename/describe
+ *     the existing activity instead.
+ *
+ *   Layer 3 — in-flight ledger: claimPending atomically inserts a
+ *     pending_uploads row. If another process already claimed the workout, our
+ *     claim loses and we defer, so two workers never double-upload.
+ *
+ * ALL THREE gate the upload. In dryRun mode layers 1 and 2 run (reads only) to
+ * compute the decision, but NO claim, NO upload, NO finalize, NO ledger write.
+ *
+ * All IO goes through `SyncDeps`: the store, a lazily built Garmin gateway, and
+ * the Hevy fetch. The engine itself is pure orchestration.
+ */
+import { generateFit, type FitResult, type HevyWorkout as FitWorkout } from "../fit";
+import { filterUnsynced } from "./dedup";
+import { generateDescription } from "./description";
+import type { SyncDeps } from "./gateway";
+import type {
+  CandidateWorkout,
+  DedupDecision,
+  DedupWorkout,
+  FitStats,
+  SyncOneOptions,
+  SyncOneResult,
+} from "./types";
+
+function fitStatsOf(r: FitResult): FitStats {
+  return {
+    exercises: r.exercises,
+    totalSets: r.total_sets,
+    calories: r.calories,
+    avgHr: r.avg_hr,
+    durationS: r.duration_s,
+  };
+}
+
+function workoutView(w: DedupWorkout): SyncOneResult["workout"] {
+  return {
+    hevy_id: w.id,
+    title: (w.title as string | null) ?? null,
+    start_time: (w.start_time as string | null) ?? null,
+  };
+}
+
+/** Build the "nothing to do" result. */
+function emptyResult(dryRun: boolean, decision: DedupDecision, remaining: number): SyncOneResult {
+  return {
+    status: "none",
+    dryRun,
+    wouldUpload: false,
+    dedupDecision: decision,
+    workout: null,
+    fitStats: null,
+    existingGarminActivityId: null,
+    garminActivityId: null,
+    remaining,
+    syncMethod: null,
+    error: null,
+  };
+}
+
+/**
+ * The unsynced Hevy workouts (dedup layer 1) — everything that would be a sync
+ * candidate. READ-ONLY: no Garmin call, no store write.
+ */
+export async function listCandidates(deps: Pick<SyncDeps, "store" | "fetchWorkouts">): Promise<CandidateWorkout[]> {
+  const workouts = await deps.fetchWorkouts();
+  const [syncedIds, pendingIds] = await Promise.all([deps.store.loadSyncedIds(), deps.store.loadPendingIds()]);
+  const candidates = filterUnsynced(workouts, syncedIds, pendingIds);
+  return candidates.map((c) => ({
+    hevy_id: String(c.id),
+    title: (c.title as string | null) ?? null,
+    start_time: (c.start_time as string | null) ?? null,
+  }));
+}
+
+/**
+ * Sync the single next unsynced Hevy workout to Garmin.
+ *
+ * DEFAULT dryRun=true → computes the decision (next unsynced, FIT, layers 1 & 2)
+ * and returns it WITHOUT any Garmin write or store mutation. Only when
+ * dryRun=false does it claim → upload → finalize → mark synced.
+ */
+export async function syncOneWorkout(deps: SyncDeps, options: SyncOneOptions = {}): Promise<SyncOneResult> {
+  const dryRun = options.dryRun ?? true; // SAFE DEFAULT
+  const descriptionEnabled = options.descriptionEnabled ?? true;
+  const targetHevyId = options.targetHevyId;
+  const { store } = deps;
+
+  // 1) Fetch the Hevy list + the dedup id-sets, then pick the next unsynced
+  //    candidate (dedup layer 1, pure). Reads only.
+  const workouts = await deps.fetchWorkouts();
+  const [syncedIds, pendingIds] = await Promise.all([store.loadSyncedIds(), store.loadPendingIds()]);
+  const candidates = filterUnsynced(workouts, syncedIds, pendingIds);
+  const remaining = candidates.length;
+  const workout = targetHevyId
+    ? candidates.find((c) => String(c.id) === targetHevyId) ?? null
+    : candidates[0] ?? null;
+
+  if (!workout) {
+    return emptyResult(dryRun, "no_candidates", 0);
+  }
+
+  const wid = workout.id;
+  const title = (workout.title as string | null) ?? "Workout";
+  const startTime = (workout.start_time as string | null) ?? null;
+
+  // Re-confirm layer 1 against the live ledger for the picked id (guards a
+  // concurrent sync that resolved this id after the id-set snapshot).
+  if (await store.isSynced(wid)) {
+    return {
+      ...emptyResult(dryRun, "already_synced", remaining),
+      status: "skipped",
+      workout: workoutView(workout),
+    };
+  }
+
+  // Without a start_time we cannot run the layer-2 lookup, so we refuse to
+  // upload rather than risk a duplicate. Checked BEFORE generating the FIT:
+  // the encoder needs the same timestamps, and there is nothing to preview.
+  if (!startTime) {
+    return {
+      ...emptyResult(dryRun, "no_start_time", remaining),
+      status: dryRun ? "dry_run" : "deferred",
+      wouldUpload: false,
+      workout: workoutView(workout),
+    };
+  }
+
+  // 2) Generate the FIT (pure/in-memory). Runs in dry-run too, so a preview
+  //    shows real stats. No IO, no upload.
+  const fitResult = generateFit(workout as unknown as FitWorkout, null);
+  const fitStats = fitStatsOf(fitResult);
+
+  // 3) Layer 2 — ask Garmin whether an activity already exists at this start
+  //    time (409 prevention). A READ; runs in dry-run too so the preview
+  //    reflects the real decision. The gateway is built lazily, here.
+  const gateway = await deps.gateway();
+  const existingId = await gateway.findExistingActivity(startTime);
+
+  if (existingId) {
+    // Garmin already has this workout. NEVER upload — match it.
+    if (dryRun) {
+      return {
+        status: "dry_run",
+        dryRun: true,
+        wouldUpload: false,
+        dedupDecision: "existing_garmin_activity",
+        workout: workoutView(workout),
+        fitStats,
+        existingGarminActivityId: existingId,
+        garminActivityId: existingId,
+        remaining,
+        syncMethod: "match",
+        error: null,
+      };
+    }
+    await gateway.rename(existingId, title);
+    if (descriptionEnabled) {
+      await gateway.describe(existingId, generateDescription(workout, fitStats.calories, fitStats.avgHr));
+    }
+    await store.markSynced(wid, {
+      garminActivityId: String(existingId),
+      title,
+      calories: fitStats.calories,
+      avgHr: fitStats.avgHr,
+      hevyUpdatedAt: (workout.updated_at as string | null) ?? null,
+      syncMethod: "upload_fallback",
+    });
+    return {
+      status: "synced",
+      dryRun: false,
+      wouldUpload: false,
+      dedupDecision: "existing_garmin_activity",
+      workout: workoutView(workout),
+      fitStats,
+      existingGarminActivityId: existingId,
+      garminActivityId: existingId,
+      remaining,
+      syncMethod: "match",
+      error: null,
+    };
+  }
+
+  // 4) Fresh workout — a real upload WOULD happen. In dry-run STOP HERE.
+  if (dryRun) {
+    return {
+      status: "dry_run",
+      dryRun: true,
+      wouldUpload: true,
+      dedupDecision: "would_upload",
+      workout: workoutView(workout),
+      fitStats,
+      existingGarminActivityId: null,
+      garminActivityId: null,
+      remaining,
+      syncMethod: "upload",
+      error: null,
+    };
+  }
+
+  // ---- LIVE PATH (dryRun === false only) ----
+
+  // Layer 3 — atomically claim the workout. If we lose the race, another
+  // worker owns it; defer.
+  const payload = {
+    workout,
+    title,
+    calories: fitStats.calories,
+    avg_hr: fitStats.avgHr,
+    hevy_updated_at: (workout.updated_at as string | null) ?? null,
+    sync_method: "upload",
+  };
+  const claimed = await store.claimPending(wid, payload);
+  if (!claimed) {
+    return {
+      ...emptyResult(false, "claim_lost", remaining),
+      status: "deferred",
+      workout: workoutView(workout),
+      fitStats,
+    };
+  }
+
+  try {
+    await store.updatePending(wid, { phase: "processing", attempt_count: 1 });
+
+    const uploadResult = await gateway.upload(fitResult.fit, startTime);
+    const activityId = uploadResult.activityId;
+
+    // Finalize: rename + describe, then write the terminal row and clear the claim.
+    if (activityId) {
+      await gateway.rename(activityId, title);
+      if (descriptionEnabled) {
+        await gateway.describe(activityId, generateDescription(workout, fitStats.calories, fitStats.avgHr));
+      }
+    }
+    await store.completePending(wid, {
+      garminActivityId: activityId != null ? String(activityId) : null,
+      title,
+      calories: fitStats.calories,
+      avgHr: fitStats.avgHr,
+      hevyUpdatedAt: (workout.updated_at as string | null) ?? null,
+      syncMethod: "upload",
+    });
+
+    return {
+      status: "synced",
+      dryRun: false,
+      wouldUpload: true,
+      dedupDecision: "would_upload",
+      workout: workoutView(workout),
+      fitStats,
+      existingGarminActivityId: null,
+      garminActivityId: activityId,
+      remaining,
+      syncMethod: "upload",
+      error: null,
+    };
+  } catch (err) {
+    // The upload may or may not have reached Garmin. Park the pending row in
+    // 'processing' with the error rather than deleting it, so it is never
+    // blindly re-uploaded — reconciliation resolves it later.
+    const message = err instanceof Error ? err.message : String(err);
+    try {
+      await store.updatePending(wid, { phase: "processing", last_error: message.slice(0, 1000) });
+    } catch {
+      // If even the checkpoint write fails, drop the claim so the workout can
+      // be re-evaluated rather than being wedged in a bad state.
+      await store.deletePending(wid).catch(() => {});
+    }
+    return {
+      status: "error",
+      dryRun: false,
+      wouldUpload: true,
+      dedupDecision: "would_upload",
+      workout: workoutView(workout),
+      fitStats,
+      existingGarminActivityId: null,
+      garminActivityId: null,
+      remaining,
+      syncMethod: "upload",
+      error: message,
+    };
+  }
+}

--- a/typescript/src/sync/types.ts
+++ b/typescript/src/sync/types.ts
@@ -1,0 +1,142 @@
+/**
+ * Sync orchestration types — shared by every consumer of the engine (the web
+ * dashboard, soma, any fork). Field names are snake_case where they mirror a
+ * database row or a Hevy/Garmin payload, so the Postgres store and the Python
+ * pipeline read the same shapes without a mapping layer.
+ */
+
+/** Minimal shape a Hevy workout needs for dedup + upload. `id` is the Hevy id (PK). */
+export interface DedupWorkout {
+  id: string;
+  title?: string | null;
+  start_time?: string | null;
+  end_time?: string | null;
+  updated_at?: string | null;
+  [key: string]: unknown;
+}
+
+/** What the dedup gate decided for this workout. */
+export type DedupDecision =
+  | "would_upload" // fresh: no terminal row, no existing Garmin activity — a real upload
+  | "already_synced" // layer 1: terminal synced_workouts row exists — skip
+  | "existing_garmin_activity" // layer 2: Garmin already has an activity at this start time — match, do NOT upload
+  | "claim_lost" // layer 3: another worker holds the pending claim — deferred
+  | "no_candidates" // nothing left to sync
+  | "no_start_time"; // workout has no start_time; can't run the layer-2 lookup safely
+
+/** Compact FIT stats surfaced to the caller (no bytes). */
+export interface FitStats {
+  exercises: number;
+  totalSets: number;
+  calories: number;
+  avgHr: number | null;
+  durationS: number;
+}
+
+/** Result of syncing one workout, aligned with the Python status vocabulary. */
+export interface SyncOneResult {
+  status: "synced" | "skipped" | "deferred" | "dry_run" | "none" | "error";
+  dryRun: boolean;
+  /** In dry-run: true when a live run WOULD upload a fresh FIT. */
+  wouldUpload: boolean;
+  dedupDecision: DedupDecision;
+  workout: { hevy_id: string; title: string | null; start_time: string | null } | null;
+  fitStats: FitStats | null;
+  /** The matched/created Garmin activity id, when known. */
+  existingGarminActivityId: number | null;
+  garminActivityId: number | null;
+  /** How many candidates remained after dedup (context for the caller). */
+  remaining: number;
+  syncMethod: "upload" | "match" | null;
+  error: string | null;
+}
+
+/** A candidate workout surfaced to a candidates listing. */
+export interface CandidateWorkout {
+  hevy_id: string;
+  title: string | null;
+  start_time: string | null;
+}
+
+/** Terminal statuses stored in synced_workouts.status. */
+export type TerminalStatus = "success" | "manual" | "skipped";
+
+/** An in-flight durable checkpoint (a pending_uploads row). */
+export interface PendingRecord {
+  hevy_id: string;
+  phase: string;
+  next_step: string | null;
+  upload_id: string | null;
+  garmin_activity_id: string | null;
+  watch_activity_id: string | null;
+  pre_upload_ids: unknown[];
+  payload: Record<string, unknown>;
+  resolution_source: string | null;
+  attempt_count: number;
+  delete_attempt_count: number;
+  last_error: string | null;
+  locked_until: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+/** Fields a checkpoint update may change (mirrors the Python allow-list). */
+export interface PendingUpdate {
+  phase?: string;
+  next_step?: string | null;
+  upload_id?: string | null;
+  garmin_activity_id?: string | null;
+  watch_activity_id?: string | null;
+  pre_upload_ids?: unknown[];
+  payload?: Record<string, unknown>;
+  resolution_source?: string | null;
+  attempt_count?: number;
+  delete_attempt_count?: number;
+  last_error?: string | null;
+  locked_until?: string | null;
+}
+
+/** Fields written when recording a successful upload or match. */
+export interface MarkSyncedOpts {
+  garminActivityId?: string | null;
+  title?: string | null;
+  calories?: number | null;
+  avgHr?: number | null;
+  hevyUpdatedAt?: string | null;
+  syncMethod?: string;
+}
+
+/** Options controlling syncOneWorkout. dryRun defaults to TRUE (safe). */
+export interface SyncOneOptions {
+  /** DEFAULT true. When true: NO Garmin write and NO store mutation happen. */
+  dryRun?: boolean;
+  /** Whether to attach a text description on the activity. Default true. */
+  descriptionEnabled?: boolean;
+  /**
+   * Sync a SPECIFIC workout by its Hevy id instead of the next candidate. It
+   * must still be an unsynced candidate (all three dedup layers still gate the
+   * upload); if it is not among the candidates the result is `no_candidates`.
+   */
+  targetHevyId?: string;
+}
+
+/** Options for reconcile/retry. */
+export interface RecoveryOptions {
+  /** Attach a text description on a retried upload. Default true. */
+  descriptionEnabled?: boolean;
+}
+
+/** Result of reconcile/retry on a specific pending workout. */
+export interface RecoveryResult {
+  /**
+   * reconciled_synced — Garmin already had it, completed as matched.
+   * no_activity — reconcile found nothing on Garmin, pending left in place.
+   * synced — retry re-uploaded successfully.
+   * not_found — no pending row for this id.
+   * no_payload — the pending row has no usable stored workout.
+   * error — the retry upload failed (pending parked with the error).
+   */
+  status: "reconciled_synced" | "no_activity" | "synced" | "not_found" | "no_payload" | "error";
+  garminActivityId: number | null;
+  error: string | null;
+}

--- a/typescript/tests/sync/dedup.test.ts
+++ b/typescript/tests/sync/dedup.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { isUnsynced, filterUnsynced, pickNextUnsynced, summarizeDedup, type DedupWorkout } from "../../src/sync";
+
+const w = (id: string, title?: string): DedupWorkout => ({ id, title: title ?? id });
+
+describe("isUnsynced — the skip-if-synced-OR-pending rule", () => {
+  it("a fresh workout (neither synced nor pending) is a candidate", () => {
+    expect(isUnsynced(w("fresh"), new Set(), new Set())).toBe(true);
+  });
+  it("a workout with a terminal synced_workouts row is excluded (layer 1)", () => {
+    expect(isUnsynced(w("done"), new Set(["done"]), new Set())).toBe(false);
+  });
+  it("a workout with an in-flight pending_uploads row is excluded (layer 2)", () => {
+    expect(isUnsynced(w("mid"), new Set(), new Set(["mid"]))).toBe(false);
+  });
+  it("excluded when it is BOTH synced and pending", () => {
+    expect(isUnsynced(w("both"), new Set(["both"]), new Set(["both"]))).toBe(false);
+  });
+  it("a workout with no id is never a candidate", () => {
+    expect(isUnsynced({ id: "" }, new Set(), new Set())).toBe(false);
+  });
+});
+
+describe("filterUnsynced — combined dedup over a list", () => {
+  const workouts = [w("a"), w("b"), w("c"), w("d")];
+  it("keeps only fresh workouts, excluding synced and pending", () => {
+    expect(filterUnsynced(workouts, new Set(["a"]), new Set(["c"])).map((x) => x.id)).toEqual(["b", "d"]);
+  });
+  it("preserves input order of the survivors", () => {
+    expect(filterUnsynced([w("z"), w("y"), w("x")], new Set(["y"]), new Set()).map((x) => x.id)).toEqual(["z", "x"]);
+  });
+  it("returns empty when every workout is synced", () => {
+    expect(filterUnsynced(workouts, new Set(["a", "b", "c", "d"]), new Set())).toEqual([]);
+  });
+  it("returns empty when every workout is pending", () => {
+    expect(filterUnsynced(workouts, new Set(), new Set(["a", "b", "c", "d"]))).toEqual([]);
+  });
+  it("returns empty when synced and pending together cover everything", () => {
+    expect(filterUnsynced(workouts, new Set(["a", "b"]), new Set(["c", "d"]))).toEqual([]);
+  });
+  it("empty input → empty output", () => {
+    expect(filterUnsynced([], new Set(), new Set())).toEqual([]);
+  });
+});
+
+describe("pickNextUnsynced — the next workout to sync", () => {
+  const workouts = [w("first"), w("second"), w("third")];
+  it("picks the first unsynced workout in list order", () => {
+    expect(pickNextUnsynced(workouts, new Set(), new Set())?.id).toBe("first");
+  });
+  it("skips synced/pending and picks the next eligible one", () => {
+    expect(pickNextUnsynced(workouts, new Set(["first"]), new Set(["second"]))?.id).toBe("third");
+  });
+  it("returns null when all are synced", () => {
+    expect(pickNextUnsynced(workouts, new Set(["first", "second", "third"]), new Set())).toBeNull();
+  });
+  it("returns null when all are pending", () => {
+    expect(pickNextUnsynced(workouts, new Set(), new Set(["first", "second", "third"]))).toBeNull();
+  });
+  it("returns null on empty input", () => {
+    expect(pickNextUnsynced([], new Set(), new Set())).toBeNull();
+  });
+});
+
+describe("summarizeDedup — the preview shape", () => {
+  const workouts = [w("a"), w("b"), w("c"), w("d"), w("e")];
+  it("tallies synced, pending and remaining, and picks the next", () => {
+    const s = summarizeDedup(workouts, new Set(["a", "b"]), new Set(["c"]));
+    expect(s.totalHevy).toBe(5);
+    expect(s.syncedCount).toBe(2);
+    expect(s.pendingCount).toBe(1);
+    expect(s.remaining).toBe(2);
+    expect(s.candidates.map((x) => x.id)).toEqual(["d", "e"]);
+    expect(s.nextUnsynced?.id).toBe("d");
+  });
+  it("all synced → zero remaining, null next", () => {
+    const s = summarizeDedup(workouts, new Set(["a", "b", "c", "d", "e"]), new Set());
+    expect(s.syncedCount).toBe(5);
+    expect(s.remaining).toBe(0);
+    expect(s.candidates).toEqual([]);
+    expect(s.nextUnsynced).toBeNull();
+  });
+  it("all pending → zero remaining, counted as pending not synced", () => {
+    const s = summarizeDedup(workouts, new Set(), new Set(["a", "b", "c", "d", "e"]));
+    expect(s.syncedCount).toBe(0);
+    expect(s.pendingCount).toBe(5);
+    expect(s.remaining).toBe(0);
+  });
+  it("nothing synced or pending → everything remains", () => {
+    const s = summarizeDedup(workouts, new Set(), new Set());
+    expect(s.remaining).toBe(5);
+    expect(s.nextUnsynced?.id).toBe("a");
+  });
+  it("a workout that is both synced and pending counts once (synced wins)", () => {
+    const s = summarizeDedup([w("x")], new Set(["x"]), new Set(["x"]));
+    expect(s.syncedCount).toBe(1);
+    expect(s.pendingCount).toBe(0);
+  });
+  it("empty workout list → zeroed summary", () => {
+    expect(summarizeDedup([], new Set(["a"]), new Set(["b"]))).toEqual({
+      totalHevy: 0, syncedCount: 0, pendingCount: 0, remaining: 0, candidates: [], nextUnsynced: null,
+    });
+  });
+});

--- a/typescript/tests/sync/helpers.ts
+++ b/typescript/tests/sync/helpers.ts
@@ -1,0 +1,48 @@
+import { vi } from "vitest";
+import type { GarminGateway, MarkSyncedOpts, PendingRecord, PendingUpdate, SyncStore } from "../../src/sync";
+
+/**
+ * An in-memory SyncStore whose every method is a vi.fn, so tests assert on
+ * calls exactly as the web tests asserted on the mocked Postgres helpers.
+ * Reads are controllable (`syncedIds`, `pendingIds`, `pending`); writes record.
+ */
+export class MemoryStore implements SyncStore {
+  syncedIds = new Set<string>();
+  pendingIds = new Set<string>();
+  pending = new Map<string, PendingRecord>();
+  /** Force the live layer-1 re-check independently of the id-set snapshot. */
+  isSyncedOverride: boolean | null = null;
+  /** Force the claim outcome (dedup layer 3). Default: win. */
+  claimResult = true;
+
+  isSynced = vi.fn(async (hevyId: string) =>
+    this.isSyncedOverride ?? this.syncedIds.has(hevyId),
+  );
+  loadSyncedIds = vi.fn(async () => new Set(this.syncedIds));
+  loadPendingIds = vi.fn(async () => new Set(this.pendingIds));
+  getPending = vi.fn(async (hevyId: string) => this.pending.get(hevyId) ?? null);
+  claimPending = vi.fn(async (_hevyId: string, _payload: Record<string, unknown>) => this.claimResult);
+  updatePending = vi.fn(async (_hevyId: string, _fields: PendingUpdate) => {});
+  deletePending = vi.fn(async (_hevyId: string) => true);
+  completePending = vi.fn(async (_hevyId: string, _opts: MarkSyncedOpts) => {});
+  markSynced = vi.fn(async (_hevyId: string, _opts: MarkSyncedOpts) => {});
+}
+
+/** A GarminGateway of spies. Defaults: nothing at the timestamp; upload → 555. */
+export function mockGateway() {
+  return {
+    findExistingActivity: vi.fn(async (_startTime: string) => null as number | null),
+    upload: vi.fn(async (_fit: Uint8Array, _start?: string) => ({ uploadId: 99, activityId: 555 as number | null })),
+    rename: vi.fn(async (_id: number, _name: string) => {}),
+    describe: vi.fn(async (_id: number, _text: string) => {}),
+  } satisfies GarminGateway;
+}
+
+export const WORKOUT = {
+  id: "hevy-1",
+  title: "Push Day",
+  start_time: "2026-08-01T10:00:00Z",
+  end_time: "2026-08-01T11:00:00Z",
+  updated_at: "2026-08-01T11:05:00Z",
+  exercises: [{ title: "Bench Press", sets: [{ type: "normal", weight_kg: 80, reps: 5 }] }],
+};

--- a/typescript/tests/sync/recovery.test.ts
+++ b/typescript/tests/sync/recovery.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { reconcilePending, retryPending, type PendingRecord } from "../../src/sync";
+import { MemoryStore, mockGateway } from "./helpers";
+
+/**
+ * The "never double-upload" property: reconcile completes as matched; a retry
+ * that finds an existing activity does NOT upload. Plus the happy retry path.
+ */
+let store: MemoryStore;
+let gw: ReturnType<typeof mockGateway>;
+let gatewayFactory: ReturnType<typeof vi.fn<() => Promise<typeof gw>>>;
+const deps = () => ({ store, gateway: gatewayFactory });
+
+const PENDING: PendingRecord = {
+  hevy_id: "w1", phase: "processing", next_step: null, upload_id: null, garmin_activity_id: null,
+  watch_activity_id: null, pre_upload_ids: [], resolution_source: null, attempt_count: 1,
+  delete_attempt_count: 0, last_error: null, locked_until: null, created_at: null, updated_at: null,
+  payload: {
+    workout: { id: "w1", title: "Push Day", start_time: "2026-08-01T10:00:00Z", end_time: "2026-08-01T11:00:00Z",
+               exercises: [{ title: "Bench Press", sets: [{ type: "normal", weight_kg: 80, reps: 5 }] }] },
+    title: "Push Day", calories: 321, avg_hr: 110,
+  },
+};
+
+beforeEach(() => {
+  store = new MemoryStore();
+  gw = mockGateway();
+  gatewayFactory = vi.fn(async () => gw);
+  store.pending.set("w1", PENDING);
+});
+
+describe("reconcilePending", () => {
+  it("no pending row → not_found", async () => {
+    store.pending.clear();
+    const r = await reconcilePending(deps(), "w1");
+    expect(r.status).toBe("not_found");
+    expect(gw.findExistingActivity).not.toHaveBeenCalled();
+  });
+
+  it("no usable payload → no_payload, no Garmin call", async () => {
+    store.pending.set("w1", { ...PENDING, payload: {} });
+    const r = await reconcilePending(deps(), "w1");
+    expect(r.status).toBe("no_payload");
+    expect(gatewayFactory).not.toHaveBeenCalled();
+  });
+
+  it("Garmin already has it → completes as matched, no upload", async () => {
+    gw.findExistingActivity.mockResolvedValue(4242);
+    const r = await reconcilePending(deps(), "w1");
+    expect(r.status).toBe("reconciled_synced");
+    expect(r.garminActivityId).toBe(4242);
+    expect(store.completePending).toHaveBeenCalledWith(
+      "w1", expect.objectContaining({ garminActivityId: "4242", syncMethod: "match" }),
+    );
+    expect(gw.upload).not.toHaveBeenCalled();
+  });
+
+  it("Garmin has nothing → no_activity, pending left in place", async () => {
+    const r = await reconcilePending(deps(), "w1");
+    expect(r.status).toBe("no_activity");
+    expect(store.completePending).not.toHaveBeenCalled();
+    expect(store.updatePending).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("retryPending", () => {
+  it("Garmin already has it → matched, NEVER uploads", async () => {
+    gw.findExistingActivity.mockResolvedValue(4242);
+    const r = await retryPending(deps(), "w1");
+    expect(r.status).toBe("reconciled_synced");
+    expect(gw.upload).not.toHaveBeenCalled();
+  });
+
+  it("fresh → regenerates FIT, uploads, finalizes, completes", async () => {
+    const r = await retryPending(deps(), "w1");
+    expect(r.status).toBe("synced");
+    expect(r.garminActivityId).toBe(555);
+    expect(gw.upload).toHaveBeenCalledTimes(1);
+    expect(gw.rename).toHaveBeenCalledWith(555, "Push Day");
+    expect(gw.describe).toHaveBeenCalledTimes(1);
+    expect(store.completePending).toHaveBeenCalledWith(
+      "w1", expect.objectContaining({ garminActivityId: "555", syncMethod: "upload" }),
+    );
+  });
+
+  it("upload throws → parks pending with the error, no completion", async () => {
+    gw.upload.mockRejectedValue(new Error("Garmin upload failed (500)"));
+    const r = await retryPending(deps(), "w1");
+    expect(r.status).toBe("error");
+    expect(r.error).toContain("Garmin upload failed");
+    expect(store.completePending).not.toHaveBeenCalled();
+    expect(store.updatePending).toHaveBeenCalledWith(
+      "w1", expect.objectContaining({ phase: "processing", last_error: expect.stringContaining("failed") }),
+    );
+  });
+
+  it("no usable payload → no_payload", async () => {
+    store.pending.set("w1", { ...PENDING, payload: { title: "x" } });
+    const r = await retryPending(deps(), "w1");
+    expect(r.status).toBe("no_payload");
+    expect(gw.upload).not.toHaveBeenCalled();
+  });
+});

--- a/typescript/tests/sync/sync-one.test.ts
+++ b/typescript/tests/sync/sync-one.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { syncOneWorkout, listCandidates } from "../../src/sync";
+import { MemoryStore, mockGateway, WORKOUT } from "./helpers";
+
+/**
+ * The central safety property: in dryRun (the DEFAULT) NO Garmin write and NO
+ * store mutation are reachable. The gateway and the store are spies; we assert
+ * they are NEVER called on the dry-run path. FIT generation is real (pure).
+ */
+let store: MemoryStore;
+let gw: ReturnType<typeof mockGateway>;
+let gatewayFactory: ReturnType<typeof vi.fn<() => Promise<typeof gw>>>;
+
+const deps = () => ({ store, gateway: gatewayFactory, fetchWorkouts: async () => [WORKOUT] });
+
+function expectNoWrites() {
+  expect(gw.upload).not.toHaveBeenCalled();
+  expect(gw.rename).not.toHaveBeenCalled();
+  expect(gw.describe).not.toHaveBeenCalled();
+  expect(store.claimPending).not.toHaveBeenCalled();
+  expect(store.completePending).not.toHaveBeenCalled();
+  expect(store.markSynced).not.toHaveBeenCalled();
+  expect(store.updatePending).not.toHaveBeenCalled();
+  expect(store.deletePending).not.toHaveBeenCalled();
+}
+
+beforeEach(() => {
+  store = new MemoryStore();
+  gw = mockGateway();
+  gatewayFactory = vi.fn(async () => gw);
+});
+
+describe("syncOneWorkout — dry-run is the DEFAULT and never writes", () => {
+  it("defaults to dryRun when no option is passed (fresh → wouldUpload, no writes)", async () => {
+    const res = await syncOneWorkout(deps());
+    expect(res.dryRun).toBe(true);
+    expect(res.status).toBe("dry_run");
+    expect(res.wouldUpload).toBe(true);
+    expect(res.dedupDecision).toBe("would_upload");
+    expect(res.workout?.hevy_id).toBe("hevy-1");
+    expect(res.fitStats?.exercises).toBe(1);
+    expect(res.fitStats?.totalSets).toBe(1);
+    // The layer-2 read IS allowed (it's a read), but NO write happens.
+    expect(gw.findExistingActivity).toHaveBeenCalledTimes(1);
+    expectNoWrites();
+  });
+
+  it("explicit dryRun:true also performs zero writes", async () => {
+    const res = await syncOneWorkout(deps(), { dryRun: true });
+    expect(res.dryRun).toBe(true);
+    expect(res.wouldUpload).toBe(true);
+    expectNoWrites();
+  });
+});
+
+describe("dedup layer 1 — already-synced is skipped, never uploaded", () => {
+  it("id-set marks it synced → filtered out → no_candidates", async () => {
+    store.syncedIds.add("hevy-1");
+    const res = await syncOneWorkout(deps());
+    expect(res.status).toBe("none");
+    expect(res.dedupDecision).toBe("no_candidates");
+    expect(res.wouldUpload).toBe(false);
+    expect(gatewayFactory).not.toHaveBeenCalled();
+    expectNoWrites();
+  });
+
+  it("live re-check: isSynced true for the picked id → skipped, no upload", async () => {
+    store.isSyncedOverride = true; // passes the snapshot, fails the live ledger check
+    const res = await syncOneWorkout(deps(), { dryRun: false });
+    expect(res.status).toBe("skipped");
+    expect(res.dedupDecision).toBe("already_synced");
+    expectNoWrites();
+  });
+});
+
+describe("dedup layer 2 — existing Garmin activity → match, NOT upload", () => {
+  it("dry-run: reports the match, no writes", async () => {
+    gw.findExistingActivity.mockResolvedValue(4242);
+    const res = await syncOneWorkout(deps());
+    expect(res.dryRun).toBe(true);
+    expect(res.dedupDecision).toBe("existing_garmin_activity");
+    expect(res.wouldUpload).toBe(false);
+    expect(res.existingGarminActivityId).toBe(4242);
+    expect(res.syncMethod).toBe("match");
+    expectNoWrites();
+  });
+
+  it("live: matches + renames the existing activity, NEVER uploads a FIT", async () => {
+    gw.findExistingActivity.mockResolvedValue(4242);
+    const res = await syncOneWorkout(deps(), { dryRun: false });
+    expect(res.status).toBe("synced");
+    expect(res.dedupDecision).toBe("existing_garmin_activity");
+    expect(res.garminActivityId).toBe(4242);
+    expect(gw.upload).not.toHaveBeenCalled();
+    expect(gw.rename).toHaveBeenCalledWith(4242, "Push Day");
+    expect(gw.describe).toHaveBeenCalledTimes(1);
+    expect(store.markSynced).toHaveBeenCalledTimes(1);
+    expect(store.claimPending).not.toHaveBeenCalled();
+  });
+});
+
+describe("dedup layer 3 + live upload — fresh workout on the live path", () => {
+  it("claims, uploads, finalizes, and completes the pending row", async () => {
+    const res = await syncOneWorkout(deps(), { dryRun: false });
+    expect(res.status).toBe("synced");
+    expect(res.dedupDecision).toBe("would_upload");
+    expect(res.garminActivityId).toBe(555);
+    expect(store.claimPending).toHaveBeenCalledTimes(1);
+    expect(gw.upload).toHaveBeenCalledTimes(1);
+    expect(gw.rename).toHaveBeenCalledWith(555, "Push Day");
+    expect(gw.describe).toHaveBeenCalledTimes(1);
+    expect(store.completePending).toHaveBeenCalledTimes(1);
+  });
+
+  it("claim lost (another worker holds it) → deferred, NO upload", async () => {
+    store.claimResult = false;
+    const res = await syncOneWorkout(deps(), { dryRun: false });
+    expect(res.status).toBe("deferred");
+    expect(res.dedupDecision).toBe("claim_lost");
+    expect(gw.upload).not.toHaveBeenCalled();
+    expect(store.completePending).not.toHaveBeenCalled();
+    expect(store.markSynced).not.toHaveBeenCalled();
+  });
+
+  it("upload throws → parks pending as processing with the error, no completion", async () => {
+    gw.upload.mockRejectedValue(new Error("Garmin upload failed (500)"));
+    const res = await syncOneWorkout(deps(), { dryRun: false });
+    expect(res.status).toBe("error");
+    expect(res.error).toContain("Garmin upload failed");
+    expect(store.claimPending).toHaveBeenCalledTimes(1);
+    expect(store.updatePending).toHaveBeenCalledWith("hevy-1", expect.objectContaining({ phase: "processing" }));
+    expect(store.completePending).not.toHaveBeenCalled();
+  });
+});
+
+describe("empty + edge inputs", () => {
+  it("no workouts at all → none / no_candidates, no writes", async () => {
+    const res = await syncOneWorkout({ ...deps(), fetchWorkouts: async () => [] });
+    expect(res.status).toBe("none");
+    expect(res.dedupDecision).toBe("no_candidates");
+    expect(gatewayFactory).not.toHaveBeenCalled();
+    expectNoWrites();
+  });
+
+  it("workout without a start_time → refuses to upload (dry_run), no writes", async () => {
+    const res = await syncOneWorkout(
+      { ...deps(), fetchWorkouts: async () => [{ ...WORKOUT, start_time: null }] },
+      { dryRun: true },
+    );
+    expect(res.dedupDecision).toBe("no_start_time");
+    expect(res.wouldUpload).toBe(false);
+    expect(gatewayFactory).not.toHaveBeenCalled(); // never consulted Garmin
+    expectNoWrites();
+  });
+});
+
+describe("targetHevyId — sync a specific workout", () => {
+  it("targets the matching candidate (dry-run), not the first", async () => {
+    const res = await syncOneWorkout(deps(), { targetHevyId: "hevy-1" });
+    expect(res.dryRun).toBe(true);
+    expect(res.workout?.hevy_id).toBe("hevy-1");
+    expect(res.dedupDecision).toBe("would_upload");
+    expectNoWrites();
+  });
+
+  it("a target that is not a candidate → no_candidates", async () => {
+    const res = await syncOneWorkout(deps(), { targetHevyId: "does-not-exist" });
+    expect(res.status).toBe("none");
+    expect(res.dedupDecision).toBe("no_candidates");
+    expectNoWrites();
+  });
+});
+
+describe("listCandidates — the unsynced list", () => {
+  it("returns the unsynced workouts (dedup layer 1)", async () => {
+    const cands = await listCandidates(deps());
+    expect(cands).toHaveLength(1);
+    expect(cands[0].hevy_id).toBe("hevy-1");
+    expect(cands[0].title).toBe("Push Day");
+    expectNoWrites();
+  });
+
+  it("excludes already-synced ids", async () => {
+    store.syncedIds.add("hevy-1");
+    expect(await listCandidates(deps())).toHaveLength(0);
+  });
+});

--- a/web/lib/dedup.ts
+++ b/web/lib/dedup.ts
@@ -1,113 +1,12 @@
 /**
- * Pure dedup decision logic — the SAFE half of the sync engine.
- *
- * These functions decide WHICH Hevy workouts still need syncing. They take
- * plain data (a workout list + the sets of already-synced and pending hevy_ids)
- * and return candidates / the next pick. They perform NO IO: no DB, no Hevy, and
- * crucially no Garmin upload. They are the TS analogue of sync.py's per-workout
- * skip logic (`skip_existing and store.is_synced(wid)` + `pending_by_id.get(wid)`).
- *
- * The three-layer never-duplicate concept (from soma's hevy-upload.ts) maps onto
- * hevy2garmin's schema as:
- *   Layer 1 (already resolved): a terminal `synced_workouts` row exists
- *            (status success/manual/skipped) → excluded via `syncedIds`.
- *   Layer 2 (in flight): a `pending_uploads` row exists (an upload was claimed
- *            or is mid-flight) → excluded via `pendingIds`, so we never
- *            double-claim / double-upload the same workout.
- *   Layer 3 (Garmin 409 on duplicate FIT) lives in the UPLOAD half and is out of
- *            scope here; the pure layer only encodes layers 1 and 2.
- *
- * "Skip if synced OR pending" is the single rule these functions enforce.
+ * Pure dedup decisions live in the `hevy2garmin` package (shared with soma).
+ * Re-exported so routes keep importing from "@/lib/dedup".
  */
-
-/** Minimal shape a workout needs for dedup. `id` is the Hevy workout id (PK). */
-export interface DedupWorkout {
-  id: string;
-  title?: string | null;
-  start_time?: string | null;
-  [key: string]: unknown;
-}
-
-/**
- * True when a workout is NOT yet resolved and NOT in flight — i.e. a real sync
- * candidate. Pure predicate; mirrors the skip rule in sync.py's main loop.
- */
-export function isUnsynced(
-  workout: DedupWorkout,
-  syncedIds: ReadonlySet<string>,
-  pendingIds: ReadonlySet<string>,
-): boolean {
-  const id = workout.id;
-  if (!id) return false;
-  return !syncedIds.has(id) && !pendingIds.has(id);
-}
-
-/**
- * Filter a workout list to the ones still needing a sync: excludes anything with
- * a terminal `synced_workouts` row (layer 1) OR an in-flight `pending_uploads`
- * row (layer 2). Input order is preserved. Pure.
- */
-export function filterUnsynced(
-  workouts: readonly DedupWorkout[],
-  syncedIds: ReadonlySet<string>,
-  pendingIds: ReadonlySet<string>,
-): DedupWorkout[] {
-  return workouts.filter((w) => isUnsynced(w, syncedIds, pendingIds));
-}
-
-/**
- * Pick the next workout to sync from a list, applying the same skip rule.
- *
- * Ordering follows the Python pipeline: the first unsynced workout in the given
- * list order is the next one to process (`fetch_workouts` yields newest-first;
- * the loop takes them in that order). Returns null when nothing remains. Pure.
- */
-export function pickNextUnsynced(
-  workouts: readonly DedupWorkout[],
-  syncedIds: ReadonlySet<string>,
-  pendingIds: ReadonlySet<string>,
-): DedupWorkout | null {
-  for (const w of workouts) {
-    if (isUnsynced(w, syncedIds, pendingIds)) return w;
-  }
-  return null;
-}
-
-/** A full preview of the dedup decision over a workout list. Pure. */
-export interface DedupSummary {
-  totalHevy: number;
-  syncedCount: number;
-  pendingCount: number;
-  remaining: number;
-  candidates: DedupWorkout[];
-  nextUnsynced: DedupWorkout | null;
-}
-
-/**
- * Compute the full dedup decision in one pass: the candidate list and the next
- * pick, plus tallies. `syncedCount`/`pendingCount` reflect how many of THESE
- * workouts are already resolved / in flight (intersection with the id sets), so
- * the numbers add up against `totalHevy`. Pure — feeds the /preview route.
- */
-export function summarizeDedup(
-  workouts: readonly DedupWorkout[],
-  syncedIds: ReadonlySet<string>,
-  pendingIds: ReadonlySet<string>,
-): DedupSummary {
-  const candidates = filterUnsynced(workouts, syncedIds, pendingIds);
-  let syncedCount = 0;
-  let pendingCount = 0;
-  for (const w of workouts) {
-    if (!w.id) continue;
-    if (syncedIds.has(w.id)) syncedCount++;
-    else if (pendingIds.has(w.id)) pendingCount++;
-  }
-  return {
-    totalHevy: workouts.length,
-    syncedCount,
-    pendingCount,
-    remaining: candidates.length,
-    candidates,
-    nextUnsynced: candidates[0] ?? null,
-  };
-}
+export {
+  filterUnsynced,
+  isUnsynced,
+  pickNextUnsynced,
+  summarizeDedup,
+  type DedupSummary,
+  type DedupWorkout,
+} from "hevy2garmin";

--- a/web/lib/garmin-upload.ts
+++ b/web/lib/garmin-upload.ts
@@ -17,13 +17,6 @@
  */
 import { getDb } from "./db";
 import { GarminAuth, DBTokenStore, type GarminClient } from "garmin-auth";
-import {
-  uploadFit,
-  findActivityByStartTime,
-  renameActivity,
-  setDescription,
-  type UploadResult,
-} from "hevy2garmin";
 
 /** The DI tokens live in platform_credentials at this platform key. */
 export const GARMIN_TOKEN_PLATFORM = "garmin_tokens";
@@ -73,48 +66,4 @@ export async function getGarminClient(databaseUrl?: string): Promise<GarminClien
 /** Reset the cached client (test seam / after a token rotation). */
 export function resetGarminClient(): void {
   cachedClient = null;
-}
-
-/**
- * READ: is there already a Garmin activity at this start time? This is dedup
- * layer 2 — the pre-upload lookup that prevents a duplicate (409) upload. Thin
- * passthrough to the package's findActivityByStartTime. Returns the existing
- * activity id, or null when the timestamp is free. Never writes.
- */
-export async function findExistingActivity(
-  client: GarminClient,
-  startTime: string,
-): Promise<number | null> {
-  return findActivityByStartTime(client, startTime);
-}
-
-/**
- * WRITE: upload a FIT (bytes) to Garmin. Thin passthrough to the package's
- * uploadFit. Only ever reached on the live sync path (dryRun === false); the
- * dry-run path returns before any wrapper here is called.
- */
-export async function upload(
-  client: GarminClient,
-  fit: Uint8Array,
-  workoutStart?: string,
-): Promise<UploadResult> {
-  return uploadFit(client, fit, workoutStart);
-}
-
-/** WRITE: rename a Garmin activity. Thin passthrough to renameActivity. */
-export async function rename(
-  client: GarminClient,
-  activityId: number,
-  name: string,
-): Promise<void> {
-  return renameActivity(client, activityId, name);
-}
-
-/** WRITE: set a Garmin activity's description. Thin passthrough to setDescription. */
-export async function describe(
-  client: GarminClient,
-  activityId: number,
-  description: string,
-): Promise<void> {
-  return setDescription(client, activityId, description);
 }

--- a/web/lib/pending-recovery.test.ts
+++ b/web/lib/pending-recovery.test.ts
@@ -1,150 +1,45 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-/**
- * Unit tests for reconcile/retry (lib/pending-recovery). Every Garmin op, the
- * FIT generator, and the DB helpers are mocked, so no network/DB is touched. We
- * assert the "never double-upload" property (reconcile completes as matched; a
- * retry that finds an existing activity does NOT upload) and the happy retry
- * path.
- */
-
-const generateFit = vi.fn((..._a: unknown[]) => ({
-  fit: new Uint8Array([1, 2, 3]),
-  exercises: 2,
-  total_sets: 6,
-  calories: 321,
-  avg_hr: 110,
-  duration_s: 3600,
+/** Recovery logic is tested in the hevy2garmin package; this covers the wiring. */
+const h = vi.hoisted(() => ({
+  engine: {
+    reconcilePending: vi.fn(async (_deps: unknown, _id: string) => ({ status: "no_activity", garminActivityId: null, error: null })),
+    retryPending: vi.fn(async (_deps: unknown, _id: string, _opts: unknown) => ({ status: "synced", garminActivityId: 555, error: null })),
+  },
+  ps: { getPending: vi.fn(async (_id: string, _sql: unknown) => null) },
 }));
-vi.mock("hevy2garmin", () => ({ generateFit: (...a: unknown[]) => generateFit(...a) }));
-
-const getGarminClient = vi.fn(async (..._a: unknown[]) => ({ domain: "garmin.com" }));
-const findExistingActivity = vi.fn();
-const upload = vi.fn();
-const rename = vi.fn();
-const describe_ = vi.fn();
-vi.mock("./garmin-upload", () => ({
-  getGarminClient: (...a: unknown[]) => getGarminClient(...a),
-  findExistingActivity: (...a: unknown[]) => findExistingActivity(...a),
-  upload: (...a: unknown[]) => upload(...a),
-  rename: (...a: unknown[]) => rename(...a),
-  describe: (...a: unknown[]) => describe_(...a),
-}));
-
-const getPending = vi.fn();
-const completePending = vi.fn();
-const updatePending = vi.fn();
-vi.mock("./pending-store", () => ({
-  getPending: (...a: unknown[]) => getPending(...a),
-  completePending: (...a: unknown[]) => completePending(...a),
-  updatePending: (...a: unknown[]) => updatePending(...a),
-}));
-
-vi.mock("./sync-one", () => ({ generateDescription: () => "desc" }));
+vi.mock("hevy2garmin", async (importOriginal) => ({ ...(await importOriginal<object>()), ...h.engine }));
+vi.mock("./pending-store", () => h.ps);
 vi.mock("./db", () => ({ getDb: () => ({}) }));
+vi.mock("./garmin-upload", () => ({ getGarminClient: async () => ({}) }));
+vi.mock("./hevy-sync", () => ({ fetchAllWorkouts: async () => [] }));
 
 import { reconcilePending, retryPending } from "./pending-recovery";
+import type { buildSyncDeps } from "./sync-one";
 
-const sql = {} as ReturnType<typeof import("./db").getDb>;
-const client = { domain: "garmin.com" };
-const garminClientFactory = vi.fn(async () => client as never);
+type Deps = ReturnType<typeof buildSyncDeps>;
+const SQL = { tag: "sql" } as never;
+beforeEach(() => { h.engine.reconcilePending.mockClear(); h.engine.retryPending.mockClear(); h.ps.getPending.mockClear(); });
 
-const PENDING = {
-  hevy_id: "w1",
-  phase: "processing",
-  attempt_count: 1,
-  payload: {
-    workout: { id: "w1", title: "Push Day", start_time: "2026-08-01T10:00:00Z" },
-    title: "Push Day",
-    calories: 321,
-    avg_hr: 110,
-  },
-};
-
-beforeEach(() => {
-  vi.clearAllMocks();
-  getPending.mockResolvedValue(PENDING);
-  findExistingActivity.mockResolvedValue(null);
-  upload.mockResolvedValue({ uploadId: 9, activityId: 555 });
-});
-
-describe("reconcilePending", () => {
-  it("no pending row → not_found", async () => {
-    getPending.mockResolvedValue(null);
-    const r = await reconcilePending("w1", { garminClientFactory }, sql);
-    expect(r.status).toBe("not_found");
-    expect(findExistingActivity).not.toHaveBeenCalled();
-  });
-
-  it("no usable payload → no_payload, no Garmin call", async () => {
-    getPending.mockResolvedValue({ ...PENDING, payload: {} });
-    const r = await reconcilePending("w1", { garminClientFactory }, sql);
-    expect(r.status).toBe("no_payload");
-    expect(garminClientFactory).not.toHaveBeenCalled();
-  });
-
-  it("Garmin already has it → completes as matched, no upload", async () => {
-    findExistingActivity.mockResolvedValue(4242);
-    const r = await reconcilePending("w1", { garminClientFactory }, sql);
-    expect(r.status).toBe("reconciled_synced");
-    expect(r.garminActivityId).toBe(4242);
-    expect(completePending).toHaveBeenCalledWith(
-      "w1",
-      expect.objectContaining({ garminActivityId: "4242", syncMethod: "match" }),
-      sql,
-    );
-    expect(upload).not.toHaveBeenCalled();
-  });
-
-  it("Garmin has nothing → no_activity, pending left in place", async () => {
-    const r = await reconcilePending("w1", { garminClientFactory }, sql);
+describe("pending-recovery (route shim)", () => {
+  it("reconcilePending forwards the id with sql-bound deps", async () => {
+    const r = await reconcilePending("w1", {}, SQL);
     expect(r.status).toBe("no_activity");
-    expect(completePending).not.toHaveBeenCalled();
-    expect(updatePending).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe("retryPending", () => {
-  it("Garmin already has it → matched, NEVER uploads", async () => {
-    findExistingActivity.mockResolvedValue(4242);
-    const r = await retryPending("w1", { garminClientFactory }, sql);
-    expect(r.status).toBe("reconciled_synced");
-    expect(upload).not.toHaveBeenCalled();
-    expect(generateFit).not.toHaveBeenCalled();
+    const [deps, id] = h.engine.reconcilePending.mock.calls[0];
+    expect(id).toBe("w1");
+    await (deps as Deps).store.getPending("w1");
+    expect(h.ps.getPending).toHaveBeenCalledWith("w1", SQL);
   });
 
-  it("fresh → regenerates FIT, uploads, finalizes, completes", async () => {
-    const r = await retryPending("w1", { garminClientFactory }, sql);
+  it("retryPending forwards id + options", async () => {
+    const r = await retryPending("w1", { descriptionEnabled: false }, SQL);
     expect(r.status).toBe("synced");
-    expect(r.garminActivityId).toBe(555);
-    expect(generateFit).toHaveBeenCalledTimes(1);
-    expect(upload).toHaveBeenCalledTimes(1);
-    expect(rename).toHaveBeenCalledWith(client, 555, "Push Day");
-    expect(describe_).toHaveBeenCalledTimes(1);
-    expect(completePending).toHaveBeenCalledWith(
-      "w1",
-      expect.objectContaining({ garminActivityId: "555", syncMethod: "upload" }),
-      sql,
-    );
+    expect(h.engine.retryPending.mock.calls[0][1]).toBe("w1");
+    expect(h.engine.retryPending.mock.calls[0][2]).toEqual({ descriptionEnabled: false });
   });
 
-  it("upload throws → parks pending with the error, no completion", async () => {
-    upload.mockRejectedValue(new Error("Garmin upload failed (500)"));
-    const r = await retryPending("w1", { garminClientFactory }, sql);
-    expect(r.status).toBe("error");
-    expect(r.error).toContain("Garmin upload failed");
-    expect(completePending).not.toHaveBeenCalled();
-    expect(updatePending).toHaveBeenCalledWith(
-      "w1",
-      expect.objectContaining({ phase: "processing", last_error: expect.stringContaining("failed") }),
-      sql,
-    );
-  });
-
-  it("no usable payload → no_payload", async () => {
-    getPending.mockResolvedValue({ ...PENDING, payload: { title: "x" } });
-    const r = await retryPending("w1", { garminClientFactory }, sql);
-    expect(r.status).toBe("no_payload");
-    expect(upload).not.toHaveBeenCalled();
+  it("retryPending defaults options to {}", async () => {
+    await retryPending("w2", undefined, SQL);
+    expect(h.engine.retryPending.mock.calls[0][2]).toEqual({});
   });
 });

--- a/web/lib/pending-recovery.ts
+++ b/web/lib/pending-recovery.ts
@@ -1,170 +1,24 @@
 /**
- * Recovery for stuck in-flight uploads — the counterpart to lib/sync-one for a
- * SPECIFIC pending workout rather than the next candidate.
- *
- *   reconcile — a Garmin READ: check whether Garmin already has an activity at
- *     the workout's start time. If it does, the earlier attempt actually landed,
- *     so complete the pending as a matched success (no re-upload). Otherwise
- *     leave the pending in place and record that nothing was found.
- *
- *   retry — reconcile first (never double-upload), and only if Garmin still has
- *     nothing, regenerate the FIT from the stored payload and re-upload, then
- *     finalize. A Garmin WRITE — the route gates it behind auth + confirmation.
- *
- * Both reuse the same helpers as sync-one and take an injectable Garmin client
- * factory so they can be unit-tested with no network.
+ * Route-facing recovery for a stuck pending upload. The logic (reconcile →
+ * match, never double-upload; retry → reconcile first, then re-upload) lives in
+ * the `hevy2garmin` package; this binds it to the app's store and Garmin client
+ * and keeps the `(hevyId, opts, sql)` signature the routes call.
  */
-import { generateFit, type HevyWorkout as FitWorkout } from "hevy2garmin";
 import {
-  getGarminClient,
-  findExistingActivity,
-  upload,
-  rename,
-  describe,
-} from "./garmin-upload";
-import { getPending, completePending, updatePending, type PendingRow } from "./pending-store";
-import { generateDescription } from "./sync-one";
-import type { GarminClient } from "garmin-auth";
+  reconcilePending as engineReconcilePending,
+  retryPending as engineRetryPending,
+  type RecoveryOptions,
+} from "hevy2garmin";
 import { getDb } from "./db";
+import type { Sql } from "./pending-store";
+import { buildSyncDeps } from "./sync-one";
 
-type Sql = ReturnType<typeof getDb>;
+export type { RecoveryOptions, RecoveryResult } from "hevy2garmin";
 
-export interface RecoveryOptions {
-  /** Injectable Garmin client factory (tests). Defaults to the live client. */
-  garminClientFactory?: () => Promise<GarminClient>;
-  /** Attach a text description on a retried upload. Default true. */
-  descriptionEnabled?: boolean;
+export function reconcilePending(hevyId: string, _opts: RecoveryOptions = {}, sql: Sql = getDb()) {
+  return engineReconcilePending(buildSyncDeps(sql), hevyId);
 }
 
-export interface RecoveryResult {
-  /**
-   * reconciled_synced — Garmin already had it, completed as matched.
-   * no_activity — reconcile found nothing on Garmin, pending left in place.
-   * synced — retry re-uploaded successfully.
-   * not_found — no pending row for this id.
-   * no_payload — the pending row has no usable stored workout.
-   * error — the retry upload failed (pending parked with the error).
-   */
-  status: "reconciled_synced" | "no_activity" | "synced" | "not_found" | "no_payload" | "error";
-  garminActivityId: number | null;
-  error: string | null;
-}
-
-interface StoredPayload {
-  workout?: Record<string, unknown>;
-  title?: string;
-  calories?: number;
-  avg_hr?: number | null;
-}
-
-function payloadOf(pending: PendingRow): StoredPayload {
-  const p = pending.payload;
-  return p && typeof p === "object" ? (p as StoredPayload) : {};
-}
-
-function startTimeOf(workout: Record<string, unknown> | undefined): string | null {
-  const s = workout?.start_time;
-  return typeof s === "string" && s ? s : null;
-}
-
-/** Complete a pending as a matched Garmin activity (no upload). */
-async function completeMatched(
-  hevyId: string,
-  pl: StoredPayload,
-  activityId: number,
-  sql: Sql,
-): Promise<void> {
-  await completePending(
-    hevyId,
-    {
-      garminActivityId: String(activityId),
-      title: pl.title ?? "",
-      calories: pl.calories ?? null,
-      avgHr: pl.avg_hr ?? null,
-      syncMethod: "match",
-    },
-    sql,
-  );
-}
-
-export async function reconcilePending(
-  hevyId: string,
-  opts: RecoveryOptions = {},
-  sql: Sql = getDb(),
-): Promise<RecoveryResult> {
-  const pending = await getPending(hevyId, sql);
-  if (!pending) return { status: "not_found", garminActivityId: null, error: null };
-  const pl = payloadOf(pending);
-  const startTime = startTimeOf(pl.workout);
-  if (!startTime) return { status: "no_payload", garminActivityId: null, error: null };
-
-  const factory = opts.garminClientFactory ?? (() => getGarminClient());
-  const client = await factory();
-  const existing = await findExistingActivity(client, startTime);
-  if (existing != null) {
-    await completeMatched(hevyId, pl, existing, sql);
-    return { status: "reconciled_synced", garminActivityId: existing, error: null };
-  }
-  await updatePending(hevyId, { last_error: "reconcile: no matching Garmin activity" }, sql);
-  return { status: "no_activity", garminActivityId: null, error: null };
-}
-
-export async function retryPending(
-  hevyId: string,
-  opts: RecoveryOptions = {},
-  sql: Sql = getDb(),
-): Promise<RecoveryResult> {
-  const pending = await getPending(hevyId, sql);
-  if (!pending) return { status: "not_found", garminActivityId: null, error: null };
-  const pl = payloadOf(pending);
-  const workout = pl.workout;
-  const startTime = startTimeOf(workout);
-  if (!workout || !startTime) return { status: "no_payload", garminActivityId: null, error: null };
-
-  const factory = opts.garminClientFactory ?? (() => getGarminClient());
-  const client = await factory();
-
-  // Never double-upload: if Garmin already has it, complete as matched.
-  const existing = await findExistingActivity(client, startTime);
-  if (existing != null) {
-    await completeMatched(hevyId, pl, existing, sql);
-    return { status: "reconciled_synced", garminActivityId: existing, error: null };
-  }
-
-  try {
-    const fit = generateFit(workout as unknown as FitWorkout, null);
-    await updatePending(
-      hevyId,
-      { phase: "processing", attempt_count: (pending.attempt_count ?? 0) + 1, last_error: null },
-      sql,
-    );
-    const up = await upload(client, fit.fit, startTime);
-    const activityId = up.activityId;
-    if (activityId != null) {
-      await rename(client, activityId, pl.title ?? "");
-      if (opts.descriptionEnabled !== false) {
-        await describe(
-          client,
-          activityId,
-          generateDescription(workout, fit.calories, fit.avg_hr),
-        );
-      }
-    }
-    await completePending(
-      hevyId,
-      {
-        garminActivityId: activityId != null ? String(activityId) : null,
-        title: pl.title ?? "",
-        calories: fit.calories,
-        avgHr: fit.avg_hr,
-        syncMethod: "upload",
-      },
-      sql,
-    );
-    return { status: "synced", garminActivityId: activityId ?? null, error: null };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    await updatePending(hevyId, { phase: "processing", last_error: message }, sql);
-    return { status: "error", garminActivityId: null, error: message };
-  }
+export function retryPending(hevyId: string, opts: RecoveryOptions = {}, sql: Sql = getDb()) {
+  return engineRetryPending(buildSyncDeps(sql), hevyId, opts);
 }

--- a/web/lib/pending-store.ts
+++ b/web/lib/pending-store.ts
@@ -14,7 +14,7 @@
  */
 import { getDb } from "./db";
 
-type Sql = ReturnType<typeof getDb>;
+export type Sql = ReturnType<typeof getDb>;
 
 /** Terminal statuses stored in synced_workouts.status. */
 export type TerminalStatus = "success" | "manual" | "skipped";

--- a/web/lib/sync-one.test.ts
+++ b/web/lib/sync-one.test.ts
@@ -1,332 +1,95 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-
-/**
- * Unit tests for the LIVE Hevy→Garmin upload engine (lib/sync-one).
- *
- * The central safety property under test: in dryRun (the DEFAULT) NO Garmin
- * write and NO DB mutation are reachable. We mock every DB helper and the FIT
- * generator, and inject the Hevy fetch + Garmin client so no network is
- * touched. The Garmin write wrappers (upload/rename/describe) and the mutating
- * ledger helpers (claimPending/completePending/markSynced/updatePending) are
- * spies, and we assert they are NEVER called on the dry-run path.
- */
-
-// --- Mock the package: generateFit is deterministic; the Garmin ops are spies. ---
-const uploadFit = vi.fn();
-const findActivityByStartTime = vi.fn();
-const renameActivity = vi.fn();
-const setDescription = vi.fn();
-vi.mock("hevy2garmin", () => ({
-  generateFit: vi.fn(() => ({
-    fit: new Uint8Array([1, 2, 3]),
-    exercises: 2,
-    total_sets: 6,
-    hr_samples: 0,
-    calories: 321,
-    avg_hr: null,
-    duration_s: 3600,
-  })),
-  uploadFit: (...a: unknown[]) => uploadFit(...a),
-  findActivityByStartTime: (...a: unknown[]) => findActivityByStartTime(...a),
-  renameActivity: (...a: unknown[]) => renameActivity(...a),
-  setDescription: (...a: unknown[]) => setDescription(...a),
-}));
-
-// --- Mock garmin-auth so importing garmin-upload never builds a real client. ---
-vi.mock("garmin-auth", () => ({
-  GarminAuth: class {
-    async client() {
-      return { domain: "garmin.com", di_token: "x" };
-    }
-  },
-  DBTokenStore: class {
-    constructor(..._a: unknown[]) {}
-  },
-}));
-
-// --- Mock the DB ledger helpers. Reads return controllable sets; writes are spies. ---
-const isSynced = vi.fn();
-const claimPending = vi.fn();
-const updatePending = vi.fn();
-const deletePending = vi.fn();
-const completePending = vi.fn();
-const markSynced = vi.fn();
-const loadSyncedIds = vi.fn();
-const loadPendingIds = vi.fn();
-vi.mock("./pending-store", () => ({
-  isSynced: (...a: unknown[]) => isSynced(...a),
-  claimPending: (...a: unknown[]) => claimPending(...a),
-  updatePending: (...a: unknown[]) => updatePending(...a),
-  deletePending: (...a: unknown[]) => deletePending(...a),
-  completePending: (...a: unknown[]) => completePending(...a),
-  markSynced: (...a: unknown[]) => markSynced(...a),
-  loadSyncedIds: (...a: unknown[]) => loadSyncedIds(...a),
-  loadPendingIds: (...a: unknown[]) => loadPendingIds(...a),
-}));
-
-// getDb is imported for the Sql type; give it a harmless stub.
-vi.mock("./db", () => ({ getDb: () => ({}) }));
-
-import { syncOneWorkout, listCandidates } from "./sync-one";
 import type { GarminClient } from "garmin-auth";
 
-const sql = {} as ReturnType<typeof import("./db").getDb>;
+/**
+ * The engine (dedup layers, dry-run default, claim→upload→finalize) is tested
+ * in the hevy2garmin package. These tests cover THIS app's wiring of it: the
+ * store is bound to the route's `sql`, the Garmin client is built lazily and
+ * once, the Hevy fetch is the app's, and options reach the engine untouched.
+ */
+const h = vi.hoisted(() => ({
+  engine: {
+    syncOneWorkout: vi.fn(async (_deps: unknown, _opts: unknown) => ({ status: "dry_run" })),
+    listCandidates: vi.fn(async (_deps: unknown) => [] as unknown[]),
+    garminGateway: vi.fn((client: unknown) => ({ client, kind: "gateway" })),
+  },
+  ps: { isSynced: vi.fn(async (_id: string, _sql: unknown) => false) },
+  getGarminClient: vi.fn(async () => ({ name: "healed-client" }) as unknown as GarminClient),
+  fetchAllWorkouts: vi.fn(async () => [{ id: "hevy-1" }]),
+}));
+vi.mock("hevy2garmin", async (importOriginal) => ({ ...(await importOriginal<object>()), ...h.engine }));
+vi.mock("./pending-store", () => h.ps);
+vi.mock("./db", () => ({ getDb: () => ({}) }));
+vi.mock("./garmin-upload", () => ({ getGarminClient: () => h.getGarminClient() }));
+vi.mock("./hevy-sync", () => ({ fetchAllWorkouts: () => h.fetchAllWorkouts() }));
 
-// A fake Garmin client — findExistingActivity/upload/etc. are the mocked
-// package fns above, so this object only needs to exist.
-const fakeClient = { domain: "garmin.com", di_token: "x" } as unknown as GarminClient;
-const garminClientFactory = vi.fn(async () => fakeClient);
+import { syncOneWorkout, listCandidates, type buildSyncDeps } from "./sync-one";
 
-const WORKOUT = {
-  id: "hevy-1",
-  title: "Push Day",
-  start_time: "2026-08-01T10:00:00Z",
-  end_time: "2026-08-01T11:00:00Z",
-  updated_at: "2026-08-01T11:05:00Z",
-  exercises: [
-    { title: "Bench Press", sets: [{ type: "normal", weight_kg: 80, reps: 5 }] },
-  ],
-};
-
-function fetchOne() {
-  return async () => [WORKOUT];
-}
-
-/** Assert that NOTHING wrote to Garmin or mutated the DB ledger. */
-function expectNoWrites() {
-  expect(uploadFit).not.toHaveBeenCalled();
-  expect(renameActivity).not.toHaveBeenCalled();
-  expect(setDescription).not.toHaveBeenCalled();
-  expect(claimPending).not.toHaveBeenCalled();
-  expect(completePending).not.toHaveBeenCalled();
-  expect(markSynced).not.toHaveBeenCalled();
-  expect(updatePending).not.toHaveBeenCalled();
-  expect(deletePending).not.toHaveBeenCalled();
-}
+type Deps = ReturnType<typeof buildSyncDeps>;
+const SQL = { tag: "sql" } as never;
+const lastDeps = () => h.engine.syncOneWorkout.mock.calls.at(-1)![0] as Deps;
 
 beforeEach(() => {
-  vi.clearAllMocks();
-  // Default: empty ledgers (fresh workout), Garmin has nothing at the timestamp.
-  loadSyncedIds.mockResolvedValue(new Set<string>());
-  loadPendingIds.mockResolvedValue(new Set<string>());
-  isSynced.mockResolvedValue(false);
-  findActivityByStartTime.mockResolvedValue(null);
-  claimPending.mockResolvedValue(true);
-  uploadFit.mockResolvedValue({ uploadId: 99, activityId: 555 });
+  h.engine.syncOneWorkout.mockClear();
+  h.engine.listCandidates.mockClear();
+  h.engine.garminGateway.mockClear();
+  h.getGarminClient.mockClear();
+  h.fetchAllWorkouts.mockClear();
+  h.ps.isSynced.mockClear();
 });
 
-describe("syncOneWorkout — dry-run is the DEFAULT and never writes", () => {
-  it("defaults to dryRun when no option is passed (fresh → wouldUpload, no writes)", async () => {
-    const res = await syncOneWorkout(sql, {
-      fetchWorkouts: fetchOne(),
-      garminClientFactory,
-    });
-    expect(res.dryRun).toBe(true);
-    expect(res.status).toBe("dry_run");
-    expect(res.wouldUpload).toBe(true);
-    expect(res.dedupDecision).toBe("would_upload");
-    expect(res.workout?.hevy_id).toBe("hevy-1");
-    expect(res.fitStats?.calories).toBe(321);
-    // The layer-2 read IS allowed (it's a read), but NO write happens.
-    expect(findActivityByStartTime).toHaveBeenCalledTimes(1);
-    expectNoWrites();
+describe("syncOneWorkout (route shim)", () => {
+  it("forwards options to the engine untouched — no dryRun is injected", async () => {
+    await syncOneWorkout(SQL);
+    expect(h.engine.syncOneWorkout).toHaveBeenCalledTimes(1);
+    expect(h.engine.syncOneWorkout.mock.calls[0][1]).toEqual({});
+    await syncOneWorkout(SQL, { dryRun: false, targetHevyId: "hevy-1", descriptionEnabled: false });
+    expect(h.engine.syncOneWorkout.mock.calls[1][1]).toEqual({ dryRun: false, targetHevyId: "hevy-1", descriptionEnabled: false });
   });
 
-  it("explicit dryRun:true also performs zero writes", async () => {
-    const res = await syncOneWorkout(sql, {
-      dryRun: true,
-      fetchWorkouts: fetchOne(),
-      garminClientFactory,
-    });
-    expect(res.dryRun).toBe(true);
-    expect(res.wouldUpload).toBe(true);
-    expectNoWrites();
-  });
-});
-
-describe("dedup layer 1 — already-synced is skipped, never uploaded", () => {
-  it("id-set marks it synced → filtered out → no_candidates", async () => {
-    loadSyncedIds.mockResolvedValue(new Set(["hevy-1"]));
-    const res = await syncOneWorkout(sql, {
-      fetchWorkouts: fetchOne(),
-      garminClientFactory,
-    });
-    expect(res.status).toBe("none");
-    expect(res.dedupDecision).toBe("no_candidates");
-    expect(res.wouldUpload).toBe(false);
-    // Garmin was never even consulted.
-    expect(findActivityByStartTime).not.toHaveBeenCalled();
-    expectNoWrites();
+  it("binds the store to the route's sql", async () => {
+    await syncOneWorkout(SQL);
+    await lastDeps().store.isSynced("w1");
+    expect(h.ps.isSynced).toHaveBeenCalledWith("w1", SQL);
   });
 
-  it("live re-check: isSynced true for the picked id → skipped, no upload", async () => {
-    // Passes the id-set filter but the live ledger says it's already synced
-    // (a concurrent sync resolved it). Must skip, not upload.
-    isSynced.mockResolvedValue(true);
-    const res = await syncOneWorkout(sql, {
-      dryRun: false,
-      fetchWorkouts: fetchOne(),
-      garminClientFactory,
-    });
-    expect(res.status).toBe("skipped");
-    expect(res.dedupDecision).toBe("already_synced");
-    expectNoWrites();
+  it("the Hevy fetch is the app's fetchAllWorkouts", async () => {
+    await syncOneWorkout(SQL);
+    expect(await lastDeps().fetchWorkouts()).toEqual([{ id: "hevy-1" }]);
+    expect(h.fetchAllWorkouts).toHaveBeenCalledTimes(1);
+  });
+
+  it("the Garmin gateway is LAZY and built once from the healed client", async () => {
+    await syncOneWorkout(SQL);
+    expect(h.getGarminClient).not.toHaveBeenCalled(); // nothing logged in yet
+    const deps = lastDeps();
+    const [g1, g2] = await Promise.all([deps.gateway(), deps.gateway()]);
+    expect(h.getGarminClient).toHaveBeenCalledTimes(1);
+    expect(h.engine.garminGateway).toHaveBeenCalledWith({ name: "healed-client" });
+    expect(g1).toBe(g2);
+  });
+
+  it("test seams: fetchWorkouts and garminClientFactory override the defaults and are NOT forwarded", async () => {
+    const fetchWorkouts = vi.fn(async () => []);
+    const garminClientFactory = vi.fn(async () => ({ name: "injected" }) as unknown as GarminClient);
+    await syncOneWorkout(SQL, { dryRun: true, fetchWorkouts, garminClientFactory });
+    const deps = lastDeps();
+    await deps.fetchWorkouts();
+    await deps.gateway();
+    expect(fetchWorkouts).toHaveBeenCalledTimes(1);
+    expect(h.fetchAllWorkouts).not.toHaveBeenCalled();
+    expect(garminClientFactory).toHaveBeenCalledTimes(1);
+    expect(h.getGarminClient).not.toHaveBeenCalled();
+    expect(h.engine.syncOneWorkout.mock.calls[0][1]).toEqual({ dryRun: true });
   });
 });
 
-describe("dedup layer 2 — existing Garmin activity → match, NOT upload", () => {
-  it("dry-run: reports the match, no writes", async () => {
-    findActivityByStartTime.mockResolvedValue(4242);
-    const res = await syncOneWorkout(sql, {
-      fetchWorkouts: fetchOne(),
-      garminClientFactory,
-    });
-    expect(res.dryRun).toBe(true);
-    expect(res.dedupDecision).toBe("existing_garmin_activity");
-    expect(res.wouldUpload).toBe(false);
-    expect(res.existingGarminActivityId).toBe(4242);
-    expect(res.syncMethod).toBe("match");
-    expect(uploadFit).not.toHaveBeenCalled();
-    expectNoWrites();
-  });
-
-  it("live: matches + renames the existing activity, NEVER uploads a FIT", async () => {
-    findActivityByStartTime.mockResolvedValue(4242);
-    const res = await syncOneWorkout(sql, {
-      dryRun: false,
-      fetchWorkouts: fetchOne(),
-      garminClientFactory,
-    });
-    expect(res.status).toBe("synced");
-    expect(res.dedupDecision).toBe("existing_garmin_activity");
-    expect(res.garminActivityId).toBe(4242);
-    // The upload path is unreachable — the whole point of layer 2.
-    expect(uploadFit).not.toHaveBeenCalled();
-    // It DID rename/describe the existing activity and record a terminal row.
-    expect(renameActivity).toHaveBeenCalledWith(fakeClient, 4242, "Push Day");
-    expect(setDescription).toHaveBeenCalledTimes(1);
-    expect(markSynced).toHaveBeenCalledTimes(1);
-    // No fresh claim/upload was made.
-    expect(claimPending).not.toHaveBeenCalled();
-  });
-});
-
-describe("dedup layer 3 + live upload — fresh workout on the live path", () => {
-  it("claims, uploads, finalizes, and completes the pending row", async () => {
-    const res = await syncOneWorkout(sql, {
-      dryRun: false,
-      fetchWorkouts: fetchOne(),
-      garminClientFactory,
-    });
-    expect(res.status).toBe("synced");
-    expect(res.dedupDecision).toBe("would_upload");
-    expect(res.garminActivityId).toBe(555);
-    // Layer 3 claim happened before the upload.
-    expect(claimPending).toHaveBeenCalledTimes(1);
-    expect(uploadFit).toHaveBeenCalledTimes(1);
-    expect(renameActivity).toHaveBeenCalledWith(fakeClient, 555, "Push Day");
-    expect(setDescription).toHaveBeenCalledTimes(1);
-    expect(completePending).toHaveBeenCalledTimes(1);
-  });
-
-  it("claim lost (another worker holds it) → deferred, NO upload", async () => {
-    claimPending.mockResolvedValue(false);
-    const res = await syncOneWorkout(sql, {
-      dryRun: false,
-      fetchWorkouts: fetchOne(),
-      garminClientFactory,
-    });
-    expect(res.status).toBe("deferred");
-    expect(res.dedupDecision).toBe("claim_lost");
-    expect(uploadFit).not.toHaveBeenCalled();
-    expect(completePending).not.toHaveBeenCalled();
-    expect(markSynced).not.toHaveBeenCalled();
-  });
-
-  it("upload throws → parks pending as processing with the error, no completion", async () => {
-    uploadFit.mockRejectedValue(new Error("Garmin upload failed (500)"));
-    const res = await syncOneWorkout(sql, {
-      dryRun: false,
-      fetchWorkouts: fetchOne(),
-      garminClientFactory,
-    });
-    expect(res.status).toBe("error");
-    expect(res.error).toContain("Garmin upload failed");
-    expect(claimPending).toHaveBeenCalledTimes(1);
-    // Parked, not completed — never blindly re-uploaded.
-    expect(updatePending).toHaveBeenCalledWith(
-      "hevy-1",
-      expect.objectContaining({ phase: "processing" }),
-      sql,
-    );
-    expect(completePending).not.toHaveBeenCalled();
-  });
-});
-
-describe("empty + edge inputs", () => {
-  it("no workouts at all → none / no_candidates, no writes", async () => {
-    const res = await syncOneWorkout(sql, {
-      fetchWorkouts: async () => [],
-      garminClientFactory,
-    });
-    expect(res.status).toBe("none");
-    expect(res.dedupDecision).toBe("no_candidates");
-    expect(garminClientFactory).not.toHaveBeenCalled();
-    expectNoWrites();
-  });
-
-  it("workout without a start_time → refuses to upload (dry_run), no writes", async () => {
-    const noStart = { ...WORKOUT, start_time: null };
-    const res = await syncOneWorkout(sql, {
-      dryRun: true,
-      fetchWorkouts: async () => [noStart],
-      garminClientFactory,
-    });
-    expect(res.dedupDecision).toBe("no_start_time");
-    expect(res.wouldUpload).toBe(false);
-    // Never consulted Garmin (no start time to look up).
-    expect(garminClientFactory).not.toHaveBeenCalled();
-    expectNoWrites();
-  });
-});
-
-describe("targetHevyId — sync a specific workout", () => {
-  it("targets the matching candidate (dry-run), not the first", async () => {
-    const res = await syncOneWorkout(sql, {
-      targetHevyId: "hevy-1",
-      fetchWorkouts: fetchOne(),
-      garminClientFactory,
-    });
-    expect(res.dryRun).toBe(true);
-    expect(res.workout?.hevy_id).toBe("hevy-1");
-    expect(res.dedupDecision).toBe("would_upload");
-    expectNoWrites();
-  });
-
-  it("a target that is not a candidate → no_candidates", async () => {
-    const res = await syncOneWorkout(sql, {
-      targetHevyId: "does-not-exist",
-      fetchWorkouts: fetchOne(),
-      garminClientFactory,
-    });
-    expect(res.status).toBe("none");
-    expect(res.dedupDecision).toBe("no_candidates");
-    expectNoWrites();
-  });
-});
-
-describe("listCandidates — the unsynced list", () => {
-  it("returns the unsynced workouts (dedup layer 1)", async () => {
-    const cands = await listCandidates(sql, { fetchWorkouts: fetchOne() });
-    expect(cands).toHaveLength(1);
-    expect(cands[0].hevy_id).toBe("hevy-1");
-    expect(cands[0].title).toBe("Push Day");
-    expectNoWrites();
-  });
-
-  it("excludes already-synced ids", async () => {
-    loadSyncedIds.mockResolvedValue(new Set(["hevy-1"]));
-    const cands = await listCandidates(sql, { fetchWorkouts: fetchOne() });
-    expect(cands).toHaveLength(0);
+describe("listCandidates (route shim)", () => {
+  it("forwards sql-bound deps to the engine", async () => {
+    await listCandidates(SQL);
+    expect(h.engine.listCandidates).toHaveBeenCalledTimes(1);
+    const deps = h.engine.listCandidates.mock.calls[0][0] as Deps;
+    await deps.store.isSynced("w9");
+    expect(h.ps.isSynced).toHaveBeenCalledWith("w9", SQL);
   });
 });

--- a/web/lib/sync-one.ts
+++ b/web/lib/sync-one.ts
@@ -1,480 +1,66 @@
 /**
- * syncOneWorkout — the LIVE Hevy→Garmin upload engine for the web app.
+ * Route-facing sync entry points. The engine itself — dedup layers, dry-run
+ * default, claim → upload → finalize — lives in the `hevy2garmin` package and
+ * is shared with soma. This module only binds it to this app's IO:
  *
- * DRY-RUN BY DEFAULT. This is the piece that makes the modern web capable of
- * actually syncing (the rest of the web app only reads). Because a bad upload
- * creates a duplicate Garmin/Strava activity — a hard user constraint — the
- * default is dryRun=true and NO Garmin write and NO DB mutation happen unless
- * the caller explicitly passes { dryRun: false }.
+ *   store        → Postgres, via ./pending-store (postgresSyncStore)
+ *   gateway      → the app's healed Garmin client (getGarminClient), lazily
+ *   fetchWorkouts→ the app's Hevy key resolution (fetchAllWorkouts)
  *
- * The three-layer never-duplicate contract (ported from sync.py):
- *
- *   Layer 1 — already resolved: if a terminal `synced_workouts` row exists for
- *     the workout (isSynced / the dedup id-set), it is SKIPPED. The pure dedup
- *     in lib/dedup already excludes these when picking the next candidate; this
- *     module re-checks the picked workout so a concurrent sync can't slip a
- *     just-synced id through.
- *
- *   Layer 2 — Garmin already has it: BEFORE uploading, findActivityByStartTime
- *     asks Garmin whether an activity already exists at the workout's start
- *     time. If one does, we DO NOT upload (409 prevention) — we match it and
- *     rename/describe the existing activity instead.
- *
- *   Layer 3 — in-flight ledger: claimPending atomically inserts a
- *     pending_uploads row (INSERT ... ON CONFLICT DO NOTHING). If another
- *     process already claimed the workout, our claim loses and we defer, so two
- *     workers never double-upload the same workout.
- *
- * ALL THREE gate the upload. In dryRun mode we run layers 1 and 2 (reads only)
- * to compute the decision, but perform NO claim, NO upload, NO finalize, and NO
- * ledger write.
+ * Signatures keep the `(sql, options)` shape every route already calls.
+ * dryRun still defaults to TRUE inside the engine; nothing here overrides it.
  */
 import {
-  isSynced,
-  claimPending,
-  updatePending,
-  deletePending,
-  completePending,
-  markSynced,
-} from "./pending-store";
-import { getHevyClient, type HevyWorkout } from "./hevy-sync";
-import { filterUnsynced, type DedupWorkout } from "./dedup";
-import { loadSyncedIds, loadPendingIds } from "./pending-store";
-import {
-  getGarminClient,
-  findExistingActivity,
-  upload,
-  rename,
-  describe,
-} from "./garmin-upload";
-import { generateFit, type HevyWorkout as FitWorkout, type FitResult } from "hevy2garmin";
+  garminGateway,
+  listCandidates as engineListCandidates,
+  syncOneWorkout as engineSyncOneWorkout,
+  type GarminGateway,
+  type SyncDeps,
+  type SyncOneOptions as EngineSyncOneOptions,
+} from "hevy2garmin";
 import type { GarminClient } from "garmin-auth";
-import { getDb } from "./db";
+import { getGarminClient } from "./garmin-upload";
+import { fetchAllWorkouts, type HevyWorkout } from "./hevy-sync";
+import { postgresSyncStore } from "./sync-store";
+import type { Sql } from "./pending-store";
 
-type Sql = ReturnType<typeof getDb>;
+export type {
+  CandidateWorkout,
+  DedupDecision,
+  FitStats,
+  SyncOneResult,
+} from "hevy2garmin";
+export { generateDescription } from "hevy2garmin";
 
-/** What the dedup gate decided for this workout. */
-export type DedupDecision =
-  | "would_upload" // fresh: no terminal row, no existing Garmin activity — a real upload
-  | "already_synced" // layer 1: terminal synced_workouts row exists — skip
-  | "existing_garmin_activity" // layer 2: Garmin already has an activity at this start time — match, do NOT upload
-  | "claim_lost" // layer 3: another worker holds the pending claim — deferred
-  | "no_candidates" // nothing left to sync
-  | "no_start_time"; // workout has no start_time; can't run the layer-2 lookup safely
-
-/** Compact FIT stats surfaced to the caller (no bytes). */
-export interface FitStats {
-  exercises: number;
-  totalSets: number;
-  calories: number;
-  avgHr: number | null;
-  durationS: number;
-}
-
-/** Result shape, aligned with the Python sync-one status vocabulary. */
-export interface SyncOneResult {
-  /** synced | skipped | deferred | dry_run | none | error */
-  status: "synced" | "skipped" | "deferred" | "dry_run" | "none" | "error";
-  dryRun: boolean;
-  /** In dry-run: true when a live run WOULD upload a fresh FIT. */
-  wouldUpload: boolean;
-  dedupDecision: DedupDecision;
-  workout: { hevy_id: string; title: string | null; start_time: string | null } | null;
-  fitStats: FitStats | null;
-  /** The matched/created Garmin activity id, when known. */
-  existingGarminActivityId: number | null;
-  garminActivityId: number | null;
-  /** How many candidates remained after dedup (context for the caller). */
-  remaining: number;
-  syncMethod: "upload" | "match" | null;
-  error: string | null;
-}
-
-/** Options controlling syncOneWorkout. dryRun defaults to TRUE (safe). */
-export interface SyncOneOptions {
-  /** DEFAULT true. When true: NO Garmin write and NO DB mutation happen. */
-  dryRun?: boolean;
-  /** Injectable Hevy fetch (tests). Defaults to the live Hevy read. */
+export interface SyncOneOptions extends EngineSyncOneOptions {
+  /** Test seam: replace the Hevy fetch. Default: fetchAllWorkouts(). */
   fetchWorkouts?: () => Promise<HevyWorkout[]>;
-  /** Injectable Garmin client factory (tests). Defaults to getGarminClient. */
+  /** Test seam: replace the Garmin client. Default: getGarminClient(). */
   garminClientFactory?: () => Promise<GarminClient>;
-  /** Whether to attach a text description on the activity. Default true. */
-  descriptionEnabled?: boolean;
-  /**
-   * Sync a SPECIFIC workout by its Hevy id instead of the next candidate. When
-   * set, the workout must still be an unsynced candidate (all three dedup layers
-   * still gate the upload); if it is not among the candidates the result is
-   * `no_candidates`.
-   */
-  targetHevyId?: string;
 }
 
-function fitStatsOf(r: FitResult): FitStats {
+/** Bind the engine to this app's store, Garmin client and Hevy fetch. */
+export function buildSyncDeps(sql: Sql, options: SyncOneOptions = {}): SyncDeps {
+  const clientFactory = options.garminClientFactory ?? (() => getGarminClient());
+  let gateway: Promise<GarminGateway> | null = null;
   return {
-    exercises: r.exercises,
-    totalSets: r.total_sets,
-    calories: r.calories,
-    avgHr: r.avg_hr,
-    durationS: r.duration_s,
+    store: postgresSyncStore(sql),
+    // Built once, lazily: the dry-run/no-candidate paths never log in to Garmin.
+    gateway: () => (gateway ??= clientFactory().then(garminGateway)),
+    fetchWorkouts: options.fetchWorkouts ?? (() => fetchAllWorkouts()),
   };
 }
 
-function workoutView(w: DedupWorkout): SyncOneResult["workout"] {
-  return {
-    hevy_id: w.id,
-    title: (w.title as string | null) ?? null,
-    start_time: (w.start_time as string | null) ?? null,
-  };
-}
-
-/** The live Hevy workout fetch used by default (all workouts). */
-async function defaultFetchWorkouts(): Promise<HevyWorkout[]> {
-  const client = await getHevyClient();
-  return (await client.getAllWorkouts()) as HevyWorkout[];
-}
-
-/** A candidate workout surfaced to the /api/candidates route. */
-export interface CandidateWorkout {
-  hevy_id: string;
-  title: string | null;
-  start_time: string | null;
+/** READ-only: the unsynced Hevy workouts. */
+export function listCandidates(sql: Sql, options: SyncOneOptions = {}) {
+  return engineListCandidates(buildSyncDeps(sql, options));
 }
 
 /**
- * The unsynced Hevy workouts (dedup layer 1) — everything that would be a sync
- * candidate. READ-ONLY: no Garmin call, no DB write. Injectable Hevy fetch for
- * tests.
+ * Sync the next unsynced workout (or `options.targetHevyId`). dryRun defaults
+ * to true in the engine; pass `{ dryRun: false }` for a real upload.
  */
-export async function listCandidates(
-  sql: Sql,
-  opts: { fetchWorkouts?: () => Promise<HevyWorkout[]> } = {},
-): Promise<CandidateWorkout[]> {
-  const fetchWorkouts = opts.fetchWorkouts ?? defaultFetchWorkouts;
-  const workouts = (await fetchWorkouts()) as DedupWorkout[];
-  const [syncedIds, pendingIds] = await Promise.all([loadSyncedIds(sql), loadPendingIds(sql)]);
-  const candidates = filterUnsynced(workouts, syncedIds, pendingIds);
-  return candidates.map((c) => ({
-    hevy_id: String(c.id),
-    title: (c.title as string | null) ?? null,
-    start_time: (c.start_time as string | null) ?? null,
-  }));
-}
-
-/**
- * Text description for a synced gym workout. Ported from garmin.py
- * generate_description so the web upload and the Python pipeline produce the
- * same body. Pure/local — builds a string, no network.
- */
-export function generateDescription(
-  workout: Record<string, unknown>,
-  calories: number | null,
-  avgHr: number | null,
-): string {
-  const lines: string[] = [];
-  const title = (workout.title as string) || "Workout";
-  const start = (workout.start_time as string) || (workout.startTime as string) || "";
-  const end = (workout.end_time as string) || (workout.endTime as string) || "";
-  let durationS = 0;
-  if (start && end) {
-    const t0 = Date.parse(start.replace(" ", "T"));
-    const t1 = Date.parse(end.replace(" ", "T"));
-    if (!Number.isNaN(t0) && !Number.isNaN(t1)) durationS = Math.floor((t1 - t0) / 1000);
-  }
-
-  lines.push(`🏋️ ${title}`);
-  if (durationS > 0) lines.push(`⏱️ ${Math.floor(durationS / 60)} min`);
-  if (calories) lines.push(`🔥 ${calories} kcal`);
-  if (avgHr) lines.push(`❤️ avg ${avgHr} bpm`);
-
-  const exercises = (workout.exercises as Array<Record<string, unknown>>) || [];
-  if (exercises.length) {
-    lines.push("");
-    for (const ex of exercises) {
-      const name = (ex.title as string) || (ex.name as string) || "Unknown";
-      const allSets = (ex.sets as Array<Record<string, unknown>>) || [];
-      const normal = allSets.filter((s) => s.type === "normal");
-      const warmup = allSets.filter((s) => s.type === "warmup");
-      if (normal.length) {
-        const nLabel = normal.length === 1 ? "set" : "sets";
-        const hasDistance = normal.some((s) => s.distance_meters);
-        const hasDuration = normal.some((s) => s.duration_seconds);
-        const hasWeight = normal.some((s) => s.weight_kg || s.weight);
-        if (hasDistance || (hasDuration && !hasWeight)) {
-          const totalDist = normal.reduce((a, s) => a + (Number(s.distance_meters) || 0), 0);
-          const totalDur = normal.reduce((a, s) => a + (Number(s.duration_seconds) || 0), 0);
-          const parts = [`${normal.length} ${nLabel}`];
-          if (totalDist > 0) parts.push(`${(totalDist / 1000).toFixed(1)}km`);
-          if (totalDur > 0) parts.push(`${Math.floor(totalDur / 60)}min`);
-          lines.push(`• ${name}: ${parts.join(" · ")}`);
-        } else {
-          const weights = normal
-            .map((s) => (s.weight_kg ?? s.weight) as number | undefined)
-            .filter((w): w is number => w != null);
-          const reps = normal
-            .map((s) => s.reps as number | undefined)
-            .filter((r): r is number => r != null);
-          const topWeight = weights.length ? Math.max(...weights) : 0;
-          const topReps = reps.length ? Math.max(...reps) : 0;
-          lines.push(`• ${name}: ${normal.length} ${nLabel} · ${topWeight.toFixed(1)}kg × ${topReps}`);
-        }
-      } else if (warmup.length) {
-        const sLabel = warmup.length === 1 ? "set" : "sets";
-        lines.push(`• ${name}: ${warmup.length} warmup ${sLabel}`);
-      }
-    }
-  }
-
-  lines.push("\n— synced by hevy2garmin");
-  return lines.join("\n");
-}
-
-/** Build the "nothing to do" result. */
-function emptyResult(dryRun: boolean, decision: DedupDecision, remaining: number): SyncOneResult {
-  return {
-    status: "none",
-    dryRun,
-    wouldUpload: false,
-    dedupDecision: decision,
-    workout: null,
-    fitStats: null,
-    existingGarminActivityId: null,
-    garminActivityId: null,
-    remaining,
-    syncMethod: null,
-    error: null,
-  };
-}
-
-/**
- * Sync the single next unsynced Hevy workout to Garmin.
- *
- * DEFAULT dryRun=true → computes the decision (fetch next unsynced, generate the
- * FIT, run layers 1 & 2) and returns { wouldUpload, workout, fitStats,
- * dedupDecision, existingGarminActivityId } WITHOUT any Garmin write or DB
- * mutation. Only when dryRun=false does it claim → upload → finalize → mark
- * synced.
- */
-export async function syncOneWorkout(
-  sql: Sql,
-  options: SyncOneOptions = {},
-): Promise<SyncOneResult> {
-  const dryRun = options.dryRun ?? true; // SAFE DEFAULT
-  const descriptionEnabled = options.descriptionEnabled ?? true;
-  const targetHevyId = options.targetHevyId;
-
-  // 1) Fetch the Hevy workout list + the dedup id-sets, then pick the next
-  //    unsynced candidate (dedup layer 1, pure). Reads only.
-  const fetchWorkouts = options.fetchWorkouts ?? defaultFetchWorkouts;
-
-  const workouts = (await fetchWorkouts()) as DedupWorkout[];
-  const [syncedIds, pendingIds] = await Promise.all([
-    loadSyncedIds(sql),
-    loadPendingIds(sql),
-  ]);
-  const candidates = filterUnsynced(workouts, syncedIds, pendingIds);
-  const remaining = candidates.length;
-  // Target a specific workout when asked; otherwise take the next candidate.
-  const workout = targetHevyId
-    ? candidates.find((c) => String(c.id) === targetHevyId) ?? null
-    : candidates[0] ?? null;
-
-  if (!workout) {
-    return emptyResult(dryRun, "no_candidates", 0);
-  }
-
-  const wid = workout.id;
-  const title = (workout.title as string | null) ?? "Workout";
-  const startTime = (workout.start_time as string | null) ?? null;
-
-  // Re-confirm layer 1 against the live ledger for the picked id (guards a
-  // concurrent sync that resolved this id after the id-set snapshot).
-  if (await isSynced(wid, sql)) {
-    return {
-      ...emptyResult(dryRun, "already_synced", remaining),
-      status: "skipped",
-      workout: workoutView(workout),
-    };
-  }
-
-  // 2) Generate the FIT (pure/in-memory; the package returns bytes + stats).
-  //    No IO, no upload. Runs in dry-run too, so the preview shows real stats.
-  const fitResult = generateFit(workout as unknown as FitWorkout, null);
-  const fitStats = fitStatsOf(fitResult);
-
-  // Without a start_time we cannot run the layer-2 lookup, so we refuse to
-  // upload rather than risk a duplicate. (The Python path also keys dedup on
-  // start_time.)
-  if (!startTime) {
-    return {
-      ...emptyResult(dryRun, "no_start_time", remaining),
-      status: dryRun ? "dry_run" : "deferred",
-      wouldUpload: false,
-      workout: workoutView(workout),
-      fitStats,
-    };
-  }
-
-  // 3) Layer 2 — ask Garmin whether an activity already exists at this start
-  //    time (409 prevention). This is a READ; it runs in dry-run too so the
-  //    preview reflects the real decision.
-  const garminClientFactory = options.garminClientFactory ?? (() => getGarminClient());
-  const client = await garminClientFactory();
-  const existingId = await findExistingActivity(client, startTime);
-
-  if (existingId) {
-    // Garmin already has this workout. NEVER upload — match it. In a live run
-    // we rename/describe the existing activity and record a terminal row; in
-    // dry-run we report the match and touch nothing.
-    if (dryRun) {
-      return {
-        status: "dry_run",
-        dryRun: true,
-        wouldUpload: false,
-        dedupDecision: "existing_garmin_activity",
-        workout: workoutView(workout),
-        fitStats,
-        existingGarminActivityId: existingId,
-        garminActivityId: existingId,
-        remaining,
-        syncMethod: "match",
-        error: null,
-      };
-    }
-    await rename(client, existingId, title);
-    if (descriptionEnabled) {
-      await describe(
-        client,
-        existingId,
-        generateDescription(workout, fitStats.calories, fitStats.avgHr),
-      );
-    }
-    await markSynced(wid, {
-      garminActivityId: String(existingId),
-      title,
-      calories: fitStats.calories,
-      avgHr: fitStats.avgHr,
-      hevyUpdatedAt: (workout.updated_at as string | null) ?? null,
-      syncMethod: "upload_fallback",
-    }, sql);
-    return {
-      status: "synced",
-      dryRun: false,
-      wouldUpload: false,
-      dedupDecision: "existing_garmin_activity",
-      workout: workoutView(workout),
-      fitStats,
-      existingGarminActivityId: existingId,
-      garminActivityId: existingId,
-      remaining,
-      syncMethod: "match",
-      error: null,
-    };
-  }
-
-  // 4) Fresh workout — a real upload WOULD happen. In dry-run STOP HERE: no
-  //    claim, no upload, no finalize, no ledger write.
-  if (dryRun) {
-    return {
-      status: "dry_run",
-      dryRun: true,
-      wouldUpload: true,
-      dedupDecision: "would_upload",
-      workout: workoutView(workout),
-      fitStats,
-      existingGarminActivityId: null,
-      garminActivityId: null,
-      remaining,
-      syncMethod: "upload",
-      error: null,
-    };
-  }
-
-  // ---- LIVE PATH (dryRun === false only) ----
-
-  // Layer 3 — atomically claim the workout in pending_uploads. If we lose the
-  // race, another worker owns it; defer.
-  const payload = {
-    workout,
-    title,
-    calories: fitStats.calories,
-    avg_hr: fitStats.avgHr,
-    hevy_updated_at: (workout.updated_at as string | null) ?? null,
-    sync_method: "upload",
-  };
-  const claimed = await claimPending(wid, payload, sql);
-  if (!claimed) {
-    return {
-      ...emptyResult(false, "claim_lost", remaining),
-      status: "deferred",
-      workout: workoutView(workout),
-      fitStats,
-    };
-  }
-
-  try {
-    await updatePending(wid, { phase: "processing", attempt_count: 1 }, sql);
-
-    const uploadResult = await upload(client, fitResult.fit, startTime);
-    const activityId = uploadResult.activityId;
-
-    // Finalize: rename + describe, then write the terminal success row and
-    // clear the pending claim.
-    if (activityId) {
-      await rename(client, activityId, title);
-      if (descriptionEnabled) {
-        await describe(
-          client,
-          activityId,
-          generateDescription(workout, fitStats.calories, fitStats.avgHr),
-        );
-      }
-    }
-    await completePending(wid, {
-      garminActivityId: activityId != null ? String(activityId) : null,
-      title,
-      calories: fitStats.calories,
-      avgHr: fitStats.avgHr,
-      hevyUpdatedAt: (workout.updated_at as string | null) ?? null,
-      syncMethod: "upload",
-    }, sql);
-
-    return {
-      status: "synced",
-      dryRun: false,
-      wouldUpload: true,
-      dedupDecision: "would_upload",
-      workout: workoutView(workout),
-      fitStats,
-      existingGarminActivityId: null,
-      garminActivityId: activityId,
-      remaining,
-      syncMethod: "upload",
-      error: null,
-    };
-  } catch (err) {
-    // The upload may or may not have reached Garmin. Park the pending row in
-    // 'processing' with the error (mirrors sync.py) rather than deleting it, so
-    // it is never blindly re-uploaded — reconciliation resolves it later.
-    const message = err instanceof Error ? err.message : String(err);
-    try {
-      await updatePending(wid, { phase: "processing", last_error: message.slice(0, 1000) }, sql);
-    } catch {
-      // If even the checkpoint write fails, drop the claim so the workout can
-      // be re-evaluated rather than being wedged in a bad state.
-      await deletePending(wid, sql).catch(() => {});
-    }
-    return {
-      status: "error",
-      dryRun: false,
-      wouldUpload: true,
-      dedupDecision: "would_upload",
-      workout: workoutView(workout),
-      fitStats,
-      existingGarminActivityId: null,
-      garminActivityId: null,
-      remaining,
-      syncMethod: "upload",
-      error: message,
-    };
-  }
+export function syncOneWorkout(sql: Sql, options: SyncOneOptions = {}) {
+  const { fetchWorkouts: _f, garminClientFactory: _g, ...engineOptions } = options;
+  return engineSyncOneWorkout(buildSyncDeps(sql, options), engineOptions);
 }

--- a/web/lib/sync-store.test.ts
+++ b/web/lib/sync-store.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const ps = vi.hoisted(() => ({
+  isSynced: vi.fn(async (_id: string, _sql: unknown) => true),
+  loadSyncedIds: vi.fn(async (_sql: unknown) => new Set(["a"])),
+  loadPendingIds: vi.fn(async (_sql: unknown) => new Set(["b"])),
+  getPending: vi.fn(async (_id: string, _sql: unknown) => null),
+  claimPending: vi.fn(async (_id: string, _payload: unknown, _sql: unknown) => true),
+  updatePending: vi.fn(async (_id: string, _fields: unknown, _sql: unknown) => {}),
+  deletePending: vi.fn(async (_id: string, _sql: unknown) => true),
+  completePending: vi.fn(async (_id: string, _opts: unknown, _sql: unknown) => {}),
+  markSynced: vi.fn(async (_id: string, _opts: unknown, _sql: unknown) => {}),
+}));
+vi.mock("./pending-store", () => ps);
+vi.mock("./db", () => ({ getDb: () => ({}) }));
+
+import { postgresSyncStore } from "./sync-store";
+
+/** Every SyncStore method must reach its pending-store twin with `sql` LAST. */
+const SQL = { tag: "the-sql-connection" } as never;
+
+beforeEach(() => Object.values(ps).forEach((f) => f.mockClear()));
+
+describe("postgresSyncStore binds the engine's SyncStore to pending-store for one connection", () => {
+  const store = postgresSyncStore(SQL);
+
+  it("isSynced", async () => {
+    expect(await store.isSynced("w1")).toBe(true);
+    expect(ps.isSynced).toHaveBeenCalledWith("w1", SQL);
+  });
+  it("loadSyncedIds / loadPendingIds", async () => {
+    expect(await store.loadSyncedIds()).toEqual(new Set(["a"]));
+    expect(await store.loadPendingIds()).toEqual(new Set(["b"]));
+    expect(ps.loadSyncedIds).toHaveBeenCalledWith(SQL);
+    expect(ps.loadPendingIds).toHaveBeenCalledWith(SQL);
+  });
+  it("getPending", async () => {
+    await store.getPending("w1");
+    expect(ps.getPending).toHaveBeenCalledWith("w1", SQL);
+  });
+  it("claimPending passes the payload through", async () => {
+    const payload = { workout: { id: "w1" } };
+    expect(await store.claimPending("w1", payload)).toBe(true);
+    expect(ps.claimPending).toHaveBeenCalledWith("w1", payload, SQL);
+  });
+  it("updatePending passes the fields through", async () => {
+    await store.updatePending("w1", { phase: "processing", last_error: "x" });
+    expect(ps.updatePending).toHaveBeenCalledWith("w1", { phase: "processing", last_error: "x" }, SQL);
+  });
+  it("deletePending", async () => {
+    expect(await store.deletePending("w1")).toBe(true);
+    expect(ps.deletePending).toHaveBeenCalledWith("w1", SQL);
+  });
+  it("completePending / markSynced pass the opts through", async () => {
+    const opts = { garminActivityId: "555", title: "Push Day", syncMethod: "upload" };
+    await store.completePending("w1", opts);
+    await store.markSynced("w2", opts);
+    expect(ps.completePending).toHaveBeenCalledWith("w1", opts, SQL);
+    expect(ps.markSynced).toHaveBeenCalledWith("w2", opts, SQL);
+  });
+  it("exposes exactly the SyncStore surface (bookkeeping only, no Garmin/Hevy)", () => {
+    expect(Object.keys(store).sort()).toEqual([
+      "claimPending", "completePending", "deletePending", "getPending", "isSynced",
+      "loadPendingIds", "loadSyncedIds", "markSynced", "updatePending",
+    ]);
+  });
+});

--- a/web/lib/sync-store.ts
+++ b/web/lib/sync-store.ts
@@ -1,0 +1,36 @@
+/**
+ * The Postgres implementation of the engine's `SyncStore` boundary.
+ *
+ * The sync engine (`hevy2garmin` package) never touches a database; it reads
+ * and writes its ledger through `SyncStore`. This adapter binds that interface
+ * to the raw SQL helpers in `./pending-store` for one `sql` connection, so a
+ * route builds a store from its `getDb()` tag and hands it to the engine.
+ * Everything here is local bookkeeping: NOTHING calls Garmin or Hevy.
+ */
+import type { MarkSyncedOpts, PendingUpdate, SyncStore } from "hevy2garmin";
+import {
+  claimPending,
+  completePending,
+  deletePending,
+  getPending,
+  isSynced,
+  loadPendingIds,
+  loadSyncedIds,
+  markSynced,
+  updatePending,
+  type Sql,
+} from "./pending-store";
+
+export function postgresSyncStore(sql: Sql): SyncStore {
+  return {
+    isSynced: (hevyId) => isSynced(hevyId, sql),
+    loadSyncedIds: () => loadSyncedIds(sql),
+    loadPendingIds: () => loadPendingIds(sql),
+    getPending: (hevyId) => getPending(hevyId, sql),
+    claimPending: (hevyId, payload) => claimPending(hevyId, payload, sql),
+    updatePending: (hevyId, fields: PendingUpdate) => updatePending(hevyId, fields, sql),
+    deletePending: (hevyId) => deletePending(hevyId, sql),
+    completePending: (hevyId, opts: MarkSyncedOpts) => completePending(hevyId, opts, sql),
+    markSynced: (hevyId, opts: MarkSyncedOpts) => markSynced(hevyId, opts, sql),
+  };
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,7 +12,7 @@
         "@types/libsodium-wrappers": "^0.7.14",
         "garmin-auth": "^0.5.0",
         "hash-wasm": "^4.12.0",
-        "hevy2garmin": "^0.1.4",
+        "hevy2garmin": "^0.3.0",
         "libsodium-wrappers": "^0.8.4",
         "next": "^16.1.0",
         "pg": "^8.23.0",
@@ -4161,9 +4161,9 @@
       }
     },
     "node_modules/hevy2garmin": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/hevy2garmin/-/hevy2garmin-0.1.4.tgz",
-      "integrity": "sha512-1UMUbUjH0gacHPa7XfRpYIHWYsPvmcOpKkivLo6qDrLLkD3DET06/1iYlkWCIyCMvDu4E+0A/VZ8c6MrGyYEcQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/hevy2garmin/-/hevy2garmin-0.3.0.tgz",
+      "integrity": "sha512-YO6LX6yoHfmLXgVYoIGwOOsZdKPKGGXo2ZVvKY9xiIB5mVs1Qj/X9K/OYd8TxQ4u46qlhQ2wdLuTg5S40UJ1Ww==",
       "license": "MIT",
       "dependencies": {
         "@garmin/fitsdk": "^21.0.0"

--- a/web/package.json
+++ b/web/package.json
@@ -21,7 +21,7 @@
     "@types/libsodium-wrappers": "^0.7.14",
     "garmin-auth": "^0.5.0",
     "hash-wasm": "^4.12.0",
-    "hevy2garmin": "^0.1.4",
+    "hevy2garmin": "^0.3.0",
     "libsodium-wrappers": "^0.8.4",
     "next": "^16.1.0",
     "pg": "^8.23.0",


### PR DESCRIPTION
Moves the Hevy to Garmin sync orchestration out of `web/lib` and into the `hevy2garmin` npm package, so the web dashboard and soma run the same engine instead of two copies.

## Package (`typescript/`, 0.3.0)

New `src/sync/`:

- `types.ts`: the shared shapes (`SyncOneResult`, `PendingRecord`, `SyncOneOptions`, ...), snake_case where they mirror a row so the Postgres store and the Python pipeline read the same fields.
- `store.ts`: the `SyncStore` interface. The engine never touches a database; a consumer supplies the ledger (synced rows, in-flight claims).
- `gateway.ts`: the `GarminGateway` interface and `garminGateway(client)`, the only way the engine reaches Garmin. `SyncDeps` bundles store, lazy gateway and the Hevy fetch.
- `dedup.ts`: the pure helpers (`isUnsynced`, `filterUnsynced`, `pickNextUnsynced`, `summarizeDedup`), unchanged from the web copy.
- `sync-one.ts`: `syncOneWorkout` and `listCandidates`. Dry-run by default. The three dedup layers are the ones shipped in the web: terminal row, existing Garmin activity at the same start time (matched, never re-uploaded), atomic claim on the pending row. A workout without a start time is refused before a FIT is generated.
- `recovery.ts`: `reconcilePending` and `retryPending`, reconcile before any re-upload.
- `description.ts`: `generateDescription`, moved from the web.

The storage-agnostic shape follows the `SyncStore` design from #467; the behaviour is the tested web engine.

Tests: `tests/sync/` ports the 45 web engine tests (dedup 22, sync-one 15, recovery 8) onto an in-memory store and a spy gateway, plus the dry-run no-write property. Package suite: 56 passing (was 11).

## Web (`web/`)

- `lib/sync-store.ts`: `postgresSyncStore(sql)`, the `SyncStore` over the existing `pending-store` helpers. The raw SQL layer is untouched.
- `lib/sync-one.ts`, `lib/pending-recovery.ts`, `lib/dedup.ts`: thin bindings that keep the `(sql, options)` and `(hevyId, opts, sql)` signatures every route calls, build the deps (store bound to the route's `sql`, Garmin client built lazily and once, the app's Hevy key resolution) and forward to the package. No route changed.
- `lib/garmin-upload.ts`: the four passthroughs the gateway replaced are gone; token healing and `getGarminClient` stay.
- Tests: the engine tests moved to the package; the web now tests its wiring (store binding, lazy gateway, option forwarding, signature order). Web suite: 239 passing across 45 files, `tsc --noEmit` clean, `next build` clean.

`hevy2garmin` bumped to `^0.3.0` in `web/package.json`; the same version goes into soma's `web/package.json` in a follow-up.

## Verification

- `typescript/`: `npm run build` and `npm test` (56/56).
- `web/`: `npx tsc --noEmit`, `npx vitest run` (239/239), `npm run build`.
- Every route import of `@/lib/sync-one`, `@/lib/pending-recovery`, `@/lib/dedup` and `@/lib/pending-store` resolves to the same exported names as before.

Closes #500
