### PR TITLE
typescript: matchHevyToGarmin + toUtcDate (0.4.0) (#505)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Changed
+- `hevy2garmin` 0.4.0 adds `matchHevyToGarmin` and `toUtcDate`, the timestamp matcher soma used to keep as a local copy (soma#835).
 - The `hevy2garmin-web` Vercel project is now connected to this repository with Root Directory `web`, so every pull request builds a preview of the Next.js dashboard next to the Python one, and merges to `main` deploy it ([#478](https://github.com/drkostas/hevy2garmin/issues/478)). Until now the green Vercel check on a PR had only ever built the Python dashboard.
 - Coming next: `hevy2garmin-demo.gkos.dev` moves to the Next.js dashboard. The Python demo stays reachable for one more release at `hevy2garmin-demo.vercel.app` ([#456](https://github.com/drkostas/hevy2garmin/issues/456)).
 - The sync engine now lives in the `hevy2garmin` npm package (0.3.0): `syncOneWorkout`, `listCandidates`, `reconcilePending`, `retryPending`, the pure dedup helpers and `generateDescription`, behind a `SyncStore` interface and a `GarminGateway`. The web dashboard imports it and keeps only a Postgres `SyncStore` adapter and route glue, so soma and any other consumer run the same dedup and dry-run logic ([#500](https://github.com/drkostas/hevy2garmin/issues/500)).

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -116,6 +116,7 @@ way, checking Garmin before ever re-uploading.
 | `SyncStore` / `GarminGateway` / `garminGateway` | The two boundaries the engine talks through; `garminGateway` wraps a `garmin-auth` client. |
 | `isUnsynced` / `filterUnsynced` / `pickNextUnsynced` / `summarizeDedup` | Pure dedup decisions over a workout list. |
 | `generateDescription` | The activity description text every upload path attaches. |
+| `matchHevyToGarmin` / `toUtcDate` | Pair Hevy workouts with activities Garmin already holds, by timestamp (exact, ±60 s, then closest within ±6 h), so they are never uploaded twice. |
 
 ## Develop
 

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hevy2garmin",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Sync Hevy workouts to Garmin Connect (TypeScript). FIT generation, exercise mapping, and upload. The TS twin of the Python hevy2garmin.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -4,3 +4,4 @@ export * from "./fit";
 export * from "./hevy";
 export * from "./garmin";
 export * from "./sync";
+export * from "./match";

--- a/typescript/src/match.ts
+++ b/typescript/src/match.ts
@@ -1,0 +1,64 @@
+/**
+ * Match Hevy workouts to EXISTING Garmin strength activities by timestamp.
+ *
+ * A dedup layer for a consumer that already has both lists: a Hevy workout that
+ * matches an activity Garmin already holds must not be uploaded again. Pure:
+ * takes the two lists, returns the (hevyId → activityId) pairs. Reading the
+ * lists and recording the match belong to the application that owns the rows.
+ */
+
+export interface HevyDt { hevyId: string; date: Date; }
+export interface GarminAct { gmt: string; aid: number; } // gmt = "YYYY-MM-DD HH:MM:SS"
+
+/** Format a Date as Garmin's naive-UTC "YYYY-MM-DD HH:MM:SS". */
+function gmtStr(d: Date): string {
+  return d.toISOString().slice(0, 19).replace("T", " ");
+}
+
+const SIX_HOURS_MS = 6 * 3600 * 1000;
+
+/**
+ * Two-pass match, faithful to the Python:
+ *  1. exact GMT-string match, else scan offsets -60..+60s (first hit wins),
+ *  2. else the closest Garmin activity within ±6h (Hevy local-time-as-UTC offset).
+ * Returns the hevyId → garmin activity_id pairs that matched.
+ */
+export function matchHevyToGarmin(hevyDts: HevyDt[], garminActs: GarminAct[]): Array<{ hevyId: string; aid: number }> {
+  const byTime = new Map<string, number>();
+  for (const g of garminActs) byTime.set(g.gmt, g.aid);
+  const acts = garminActs.map((g) => ({ ms: Date.parse(g.gmt + "Z"), aid: g.aid }));
+
+  const out: Array<{ hevyId: string; aid: number }> = [];
+  for (const { hevyId, date } of hevyDts) {
+    let aid: number | undefined = byTime.get(gmtStr(date));
+
+    if (aid === undefined) { // pass 1: ±60s, first hit scanning from -60
+      for (let off = -60; off <= 60; off++) {
+        const cand = byTime.get(gmtStr(new Date(date.getTime() + off * 1000)));
+        if (cand !== undefined) { aid = cand; break; }
+      }
+    }
+
+    if (aid === undefined) { // pass 2: closest within ±6h
+      const hms = date.getTime();
+      let best: { d: number; aid: number } | null = null;
+      for (const a of acts) {
+        const d = Math.abs(a.ms - hms);
+        if (d <= SIX_HOURS_MS && (best === null || d < best.d)) best = { d, aid: a.aid };
+      }
+      if (best) aid = best.aid;
+    }
+
+    if (aid !== undefined) out.push({ hevyId, aid });
+  }
+  return out;
+}
+
+/** Parse a Hevy/Garmin start into a UTC Date (naive strings treated as UTC). */
+export function toUtcDate(s: string): Date | null {
+  if (!s) return null;
+  const iso = s.includes("T") ? s : s.replace(" ", "T");
+  const withZone = /[Z+]|[-]\d\d:\d\d$/.test(iso) ? iso : iso + "Z";
+  const d = new Date(withZone);
+  return isNaN(d.getTime()) ? null : d;
+}

--- a/typescript/tests/match.test.ts
+++ b/typescript/tests/match.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { matchHevyToGarmin, toUtcDate, type HevyDt, type GarminAct } from "../src/match";
+
+const D = (s: string) => new Date(s);
+
+describe("matchHevyToGarmin — two-pass timestamp match (dedup)", () => {
+  const garmin: GarminAct[] = [
+    { gmt: "2026-07-13 10:00:00", aid: 111 },
+    { gmt: "2026-07-13 18:30:00", aid: 222 }, // ~6h off a 12:30 workout (local-time offset)
+  ];
+
+  it("exact GMT match", () => {
+    const hevy: HevyDt[] = [{ hevyId: "w1", date: D("2026-07-13T10:00:00Z") }];
+    expect(matchHevyToGarmin(hevy, garmin)).toEqual([{ hevyId: "w1", aid: 111 }]);
+  });
+
+  it("matches within ±60s", () => {
+    const hevy: HevyDt[] = [{ hevyId: "w1", date: D("2026-07-13T10:00:45Z") }];
+    expect(matchHevyToGarmin(hevy, garmin)).toEqual([{ hevyId: "w1", aid: 111 }]);
+  });
+
+  it("fuzzy-matches the closest activity within ±6h", () => {
+    // workout at 12:30 UTC → 111 is 2.5h away, 222 is 6h away → picks 111 (closest)
+    const hevy: HevyDt[] = [{ hevyId: "w1", date: D("2026-07-13T12:30:00Z") }];
+    expect(matchHevyToGarmin(hevy, garmin)).toEqual([{ hevyId: "w1", aid: 111 }]);
+  });
+
+  it("no match when beyond ±6h", () => {
+    const hevy: HevyDt[] = [{ hevyId: "w1", date: D("2026-07-14T02:00:00Z") }];
+    expect(matchHevyToGarmin(hevy, garmin)).toEqual([]);
+  });
+
+  it("matches multiple workouts independently", () => {
+    const hevy: HevyDt[] = [
+      { hevyId: "a", date: D("2026-07-13T10:00:00Z") },
+      { hevyId: "b", date: D("2026-07-13T18:30:20Z") }, // within 60s of 222
+    ];
+    expect(matchHevyToGarmin(hevy, garmin)).toEqual([
+      { hevyId: "a", aid: 111 },
+      { hevyId: "b", aid: 222 },
+    ]);
+  });
+});
+
+describe("toUtcDate", () => {
+  it("treats naive strings as UTC, respects explicit zones", () => {
+    expect(toUtcDate("2026-07-13 10:00:00")!.toISOString()).toBe("2026-07-13T10:00:00.000Z");
+    expect(toUtcDate("2026-07-13T10:00:00Z")!.toISOString()).toBe("2026-07-13T10:00:00.000Z");
+    expect(toUtcDate("2026-07-13T12:00:00+02:00")!.toISOString()).toBe("2026-07-13T10:00:00.000Z");
+  });
+  it("returns null on empty/garbage", () => {
+    expect(toUtcDate("")).toBeNull();
+    expect(toUtcDate("nonsense")).toBeNull();
+  });
+});


### PR DESCRIPTION
Adds `src/match.ts` to the package: `matchHevyToGarmin` (exact GMT match, then ±60 s, then the closest activity within ±6 h) and `toUtcDate`, with the matcher tests. This is the pure half of soma's `web/lib/hevy-match.ts`; the database step that records a match stays in soma (drkostas/soma#835).

Package suite 63 passing. Version 0.4.0. README row and CHANGELOG entry included.

Closes #505
