### PR TITLE
typescript: rebuild from an empty dist and clean before publish, 0.4.1 (#508)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Changed
+- `hevy2garmin` 0.4.1 is 0.4.0 rebuilt from an empty `dist/`: 0.4.0 shipped stale compiled files that shadowed the sync engine's types. A `prepack` step now clears and rebuilds `dist/` before every publish ([#508](https://github.com/drkostas/hevy2garmin/issues/508)).
 - `hevy2garmin` 0.4.0 adds `matchHevyToGarmin` and `toUtcDate`, the timestamp matcher soma used to keep as a local copy (soma#835).
 - The `hevy2garmin-web` Vercel project is now connected to this repository with Root Directory `web`, so every pull request builds a preview of the Next.js dashboard next to the Python one, and merges to `main` deploy it ([#478](https://github.com/drkostas/hevy2garmin/issues/478)). Until now the green Vercel check on a PR had only ever built the Python dashboard.
 - Coming next: `hevy2garmin-demo.gkos.dev` moves to the Next.js dashboard. The Python demo stays reachable for one more release at `hevy2garmin-demo.vercel.app` ([#456](https://github.com/drkostas/hevy2garmin/issues/456)).

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hevy2garmin",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Sync Hevy workouts to Garmin Connect (TypeScript). FIT generation, exercise mapping, and upload. The TS twin of the Python hevy2garmin.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -15,7 +15,9 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "test": "vitest run"
+    "test": "vitest run",
+    "clean": "rm -rf dist",
+    "prepack": "npm run clean && npm run build"
   },
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
0.4.0 on npm carries 44 files against 0.3.0's 30: compiled leftovers of removed sources (`sync.js`, `sync-types`, `cooldown`, `hr-fusion`, `routine-sync`, `exercise-mapper`) were still in the publishing checkout's gitignored `dist/`, and `dist/sync.d.ts` shadows `dist/sync/index.d.ts`, so 0.4.0 exports the old orchestrator's types instead of the engine's (`SyncOneOptions` without `dryRun`; the web dashboard's typecheck fails against it).

This PR bumps to 0.4.1 and adds `clean` + `prepack` scripts so every publish rebuilds from an empty `dist/`. Built clean here: the pack list has no stale file; suite 63 passing. After merge: publish 0.4.1 and deprecate 0.4.0.

Closes #508
