### PR TITLE
web: bump hevy2garmin to 0.4.1 (#507)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,7 +12,7 @@
         "@types/libsodium-wrappers": "^0.7.14",
         "garmin-auth": "^0.5.0",
         "hash-wasm": "^4.12.0",
-        "hevy2garmin": "^0.3.0",
+        "hevy2garmin": "^0.4.1",
         "libsodium-wrappers": "^0.8.4",
         "next": "^16.1.0",
         "pg": "^8.23.0",
@@ -4161,9 +4161,9 @@
       }
     },
     "node_modules/hevy2garmin": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/hevy2garmin/-/hevy2garmin-0.3.0.tgz",
-      "integrity": "sha512-YO6LX6yoHfmLXgVYoIGwOOsZdKPKGGXo2ZVvKY9xiIB5mVs1Qj/X9K/OYd8TxQ4u46qlhQ2wdLuTg5S40UJ1Ww==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/hevy2garmin/-/hevy2garmin-0.4.1.tgz",
+      "integrity": "sha512-37NpiiJh9ka9s89CuDb9Eb/FoSfA0EmHDShvtfLkUomW8syP2T+PdgvvIKBr6ucpCNTCZz3KTca4nimG0XYLAQ==",
       "license": "MIT",
       "dependencies": {
         "@garmin/fitsdk": "^21.0.0"

--- a/web/package.json
+++ b/web/package.json
@@ -21,7 +21,7 @@
     "@types/libsodium-wrappers": "^0.7.14",
     "garmin-auth": "^0.5.0",
     "hash-wasm": "^4.12.0",
-    "hevy2garmin": "^0.3.0",
+    "hevy2garmin": "^0.4.1",
     "libsodium-wrappers": "^0.8.4",
     "next": "^16.1.0",
     "pg": "^8.23.0",


### PR DESCRIPTION
Bumps `web/` to `hevy2garmin@^0.4.1`, the version soma resolves, so both consumers run the same published package. The first attempt at `^0.4.0` is what exposed #508: 0.4.0 shipped stale compiled files that shadowed the sync engine types and this typecheck failed against it. 0.4.1 is the clean rebuild; typecheck and the 239 web tests are green against it.

Closes #507
