### PR TITLE
typescript: exercise to muscle-group mapping (0.5.0) (#513)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Changed
+- `hevy2garmin` 0.5.0 adds the exercise to muscle-group mapping and volume aggregation (`getExerciseMuscles`, `aggregateMuscleVolumes`, `MUSCLE_LABELS`, `MUSCLE_HEX`) that soma's web and app each kept a copy of (soma#841).
 - `hevy2garmin` 0.4.1 is 0.4.0 rebuilt from an empty `dist/`: 0.4.0 shipped stale compiled files that shadowed the sync engine's types. A `prepack` step now clears and rebuilds `dist/` before every publish ([#508](https://github.com/drkostas/hevy2garmin/issues/508)).
 - `hevy2garmin` 0.4.0 adds `matchHevyToGarmin` and `toUtcDate`, the timestamp matcher soma used to keep as a local copy (soma#835).
 - The `hevy2garmin-web` Vercel project is now connected to this repository with Root Directory `web`, so every pull request builds a preview of the Next.js dashboard next to the Python one, and merges to `main` deploy it ([#478](https://github.com/drkostas/hevy2garmin/issues/478)). Until now the green Vercel check on a PR had only ever built the Python dashboard.

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -103,6 +103,9 @@ way, checking Garmin before ever re-uploading.
 
 ## API
 
+Every module is also a subpath (`hevy2garmin/muscle-groups`, `hevy2garmin/match`, `hevy2garmin/fit`, `hevy2garmin/sync`, ...), so a consumer that only needs a table does not load the Garmin client and its `garmin-auth` peer.
+
+
 | Export | What it does |
 | --- | --- |
 | `HevyClient` | Read the Hevy API (`getWorkoutCount`, `getWorkouts`, `getWorkout`, `getAllWorkouts`). |

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -117,6 +117,7 @@ way, checking Garmin before ever re-uploading.
 | `isUnsynced` / `filterUnsynced` / `pickNextUnsynced` / `summarizeDedup` | Pure dedup decisions over a workout list. |
 | `generateDescription` | The activity description text every upload path attaches. |
 | `matchHevyToGarmin` / `toUtcDate` | Pair Hevy workouts with activities Garmin already holds, by timestamp (exact, ±60 s, then closest within ±6 h), so they are never uploaded twice. |
+| `getExerciseMuscles` / `aggregateMuscleVolumes` / `MUSCLE_LABELS` / `MUSCLE_HEX` | Exercise to muscle-group mapping (primary and secondary targets) and the per-workout volume every body map draws from. |
 
 ## Develop
 

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hevy2garmin",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Sync Hevy workouts to Garmin Connect (TypeScript). FIT generation, exercise mapping, and upload. The TS twin of the Python hevy2garmin.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -8,7 +8,40 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
-    }
+    },
+    "./exercise-map": {
+      "types": "./dist/exercise-map.d.ts",
+      "default": "./dist/exercise-map.js"
+    },
+    "./mapper": {
+      "types": "./dist/mapper.d.ts",
+      "default": "./dist/mapper.js"
+    },
+    "./fit": {
+      "types": "./dist/fit.d.ts",
+      "default": "./dist/fit.js"
+    },
+    "./hevy": {
+      "types": "./dist/hevy.d.ts",
+      "default": "./dist/hevy.js"
+    },
+    "./garmin": {
+      "types": "./dist/garmin.d.ts",
+      "default": "./dist/garmin.js"
+    },
+    "./match": {
+      "types": "./dist/match.d.ts",
+      "default": "./dist/match.js"
+    },
+    "./muscle-groups": {
+      "types": "./dist/muscle-groups.d.ts",
+      "default": "./dist/muscle-groups.js"
+    },
+    "./sync": {
+      "types": "./dist/sync/index.d.ts",
+      "default": "./dist/sync/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist"

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -5,3 +5,4 @@ export * from "./hevy";
 export * from "./garmin";
 export * from "./sync";
 export * from "./match";
+export * from "./muscle-groups";

--- a/typescript/src/muscle-groups.ts
+++ b/typescript/src/muscle-groups.ts
@@ -1,0 +1,215 @@
+/**
+ * Exercise to muscle-group mapping, with primary and secondary targets, plus
+ * the per-group labels, hex colours and the volume aggregation every body map
+ * draws from. One table for the web dashboard and the app; the surfaces keep
+ * only their own presentation extras (Tailwind classes, SVG slugs).
+ * Based on standard exercise-science / Hevy / Garmin classifications.
+ */
+
+export type MuscleGroup =
+  | "chest"
+  | "back"
+  | "shoulders"
+  | "biceps"
+  | "triceps"
+  | "forearms"
+  | "quads"
+  | "hamstrings"
+  | "glutes"
+  | "calves"
+  | "core";
+
+export const ALL_MUSCLE_GROUPS: MuscleGroup[] = [
+  "chest", "back", "shoulders", "biceps", "triceps", "forearms",
+  "quads", "hamstrings", "glutes", "calves", "core",
+];
+
+/**
+ * Aggregate muscle volumes from exercises.
+ * Returns a map of muscle group → { primary: number, secondary: number }
+ * weight = 1.0 for primary muscles, 0.33 for secondary (proportional contribution)
+ */
+
+export const MUSCLE_LABELS: Record<MuscleGroup, string> = {
+  chest: "Chest",
+  back: "Back",
+  shoulders: "Shoulders",
+  biceps: "Biceps",
+  triceps: "Triceps",
+  forearms: "Forearms",
+  quads: "Quads",
+  hamstrings: "Hamstrings",
+  glutes: "Glutes",
+  calves: "Calves",
+  core: "Core",
+};
+
+/**
+ * Colors for each muscle group (hex for SVG, Tailwind class for UI)
+ */
+
+export const MUSCLE_HEX: Record<MuscleGroup, string> = {
+  chest: "#ef4444", back: "#22c55e", shoulders: "#f97316", biceps: "#06b6d4",
+  triceps: "#a855f7", forearms: "#ec4899", quads: "#3b82f6", hamstrings: "#8b5cf6",
+  glutes: "#f59e0b", calves: "#10b981", core: "#eab308",
+};
+
+export interface MuscleMapping {
+  primary: MuscleGroup[];
+  secondary: MuscleGroup[];
+}
+
+// Exact match mapping for all known exercises
+const EXERCISE_MAP: Record<string, MuscleMapping> = {
+  // --- CHEST ---
+  "Bench Press (Barbell)":          { primary: ["chest"], secondary: ["triceps", "shoulders"] },
+  "Incline Bench Press (Barbell)":  { primary: ["chest"], secondary: ["shoulders", "triceps"] },
+  "Chest Dip":                      { primary: ["chest"], secondary: ["triceps", "shoulders"] },
+  "Chest Dip (Weighted)":           { primary: ["chest"], secondary: ["triceps", "shoulders"] },
+  "Chest Dip (Assisted)":           { primary: ["chest"], secondary: ["triceps", "shoulders"] },
+  "Chest Fly (Machine)":            { primary: ["chest"], secondary: [] },
+  "Chest Fly (Band)":               { primary: ["chest"], secondary: [] },
+  "Push Up (Weighted)":             { primary: ["chest"], secondary: ["triceps", "shoulders"] },
+
+  // --- BACK ---
+  "Iso-Lateral Row (Machine)":      { primary: ["back"], secondary: ["biceps"] },
+  "Iso-Lateral Low Row":            { primary: ["back"], secondary: ["biceps"] },
+  "Pull Up":                        { primary: ["back"], secondary: ["biceps"] },
+  "Pull Up (Assisted)":             { primary: ["back"], secondary: ["biceps"] },
+  "Pull Up (Weighted)":             { primary: ["back"], secondary: ["biceps"] },
+  "Bent Over Row (Barbell)":        { primary: ["back"], secondary: ["biceps", "core"] },
+  "Chest Supported Incline Row (Dumbbell)": { primary: ["back"], secondary: ["biceps"] },
+  "Lat Pulldown (Cable)":           { primary: ["back"], secondary: ["biceps"] },
+  "Lat Pulldown (Machine)":         { primary: ["back"], secondary: ["biceps"] },
+  "Reverse Grip Lat Pulldown (Cable)": { primary: ["back"], secondary: ["biceps"] },
+  "Seated Cable Row - V Grip (Cable)": { primary: ["back"], secondary: ["biceps"] },
+  "Straight Arm Lat Pulldown (Cable)": { primary: ["back"], secondary: [] },
+  "Deadlift (Barbell)":             { primary: ["back", "hamstrings"], secondary: ["glutes", "core", "forearms"] },
+  "Back Extension (Weighted Hyperextension)": { primary: ["back"], secondary: ["glutes", "hamstrings"] },
+  "Back Extension (Hyperextension)": { primary: ["back"], secondary: ["glutes", "hamstrings"] },
+
+  // --- SHOULDERS ---
+  "Overhead Press (Barbell)":       { primary: ["shoulders"], secondary: ["triceps", "core"] },
+  "Seated Overhead Press (Barbell)": { primary: ["shoulders"], secondary: ["triceps"] },
+  "Seated Shoulder Press (Machine)": { primary: ["shoulders"], secondary: ["triceps"] },
+  "Shoulder Press (Dumbbell)":      { primary: ["shoulders"], secondary: ["triceps"] },
+  "Arnold Press (Dumbbell)":        { primary: ["shoulders"], secondary: ["triceps"] },
+  "Lateral Raise (Dumbbell)":       { primary: ["shoulders"], secondary: [] },
+  "Lateral Raise (Machine)":        { primary: ["shoulders"], secondary: [] },
+  "Lateral Raise (Cable)":          { primary: ["shoulders"], secondary: [] },
+  "Front Raise (Dumbbell)":         { primary: ["shoulders"], secondary: [] },
+  "Front Raise (Barbell)":          { primary: ["shoulders"], secondary: [] },
+  "Face Pull":                      { primary: ["shoulders"], secondary: ["back"] },
+  "Rear Deltoid":                   { primary: ["shoulders"], secondary: ["back"] },
+  "Rear Delt Reverse Fly (Machine)": { primary: ["shoulders"], secondary: ["back"] },
+  "Rear Delt Reverse Fly (Cable)":  { primary: ["shoulders"], secondary: ["back"] },
+  "Chest Supported Reverse Fly (Dumbbell)": { primary: ["shoulders"], secondary: ["back"] },
+  "Shoulder Extension":             { primary: ["shoulders"], secondary: [] },
+  "Shrug (Dumbbell)":               { primary: ["shoulders"], secondary: [] },
+
+  // --- BICEPS ---
+  "Hammer Curl (Dumbbell)":         { primary: ["biceps"], secondary: ["forearms"] },
+  "Preacher Curl (Barbell)":        { primary: ["biceps"], secondary: [] },
+  "Concentration Curl":             { primary: ["biceps"], secondary: [] },
+  "Bicep Curl (Barbell)":           { primary: ["biceps"], secondary: [] },
+  "Bicep Curl (Dumbbell)":          { primary: ["biceps"], secondary: [] },
+  "Bicep Curl (Cable)":             { primary: ["biceps"], secondary: [] },
+  "Reverse EZ-Bar Curl":            { primary: ["biceps"], secondary: ["forearms"] },
+
+  // --- TRICEPS ---
+  "Triceps Pushdown":               { primary: ["triceps"], secondary: [] },
+  "Triceps Extension (Cable)":      { primary: ["triceps"], secondary: [] },
+  "One-Arm Cable Cross Body Triceps Extension": { primary: ["triceps"], secondary: [] },
+  "Overhead Triceps Extension (Cable)": { primary: ["triceps"], secondary: [] },
+
+  // --- FOREARMS ---
+  "Seated Palms Up Wrist Curl":     { primary: ["forearms"], secondary: [] },
+
+  // --- QUADS ---
+  "Leg Extension (Machine)":        { primary: ["quads"], secondary: [] },
+  "Leg Press (Machine)":            { primary: ["quads", "glutes"], secondary: ["hamstrings", "calves"] },
+
+  // --- HAMSTRINGS ---
+  "Seated Leg Curl (Machine)":      { primary: ["hamstrings"], secondary: [] },
+  "Lying Leg Curl (Machine)":       { primary: ["hamstrings"], secondary: [] },
+  "Romanian Deadlift (Barbell)":    { primary: ["hamstrings"], secondary: ["glutes", "back"] },
+
+  // --- GLUTES ---
+  "Hip Abduction (Machine)":        { primary: ["glutes"], secondary: [] },
+  "Hip Adduction (Machine)":        { primary: ["glutes"], secondary: [] },
+
+  // --- CALVES ---
+  "Calf Press (Machine)":           { primary: ["calves"], secondary: [] },
+  "Seated Calf Raise":              { primary: ["calves"], secondary: [] },
+
+  // --- CORE ---
+  "Crunch (Weighted)":              { primary: ["core"], secondary: [] },
+  "Crunch":                         { primary: ["core"], secondary: [] },
+  "Crunch (Machine)":               { primary: ["core"], secondary: [] },
+  "Hanging Leg Raise":              { primary: ["core"], secondary: [] },
+  "Leg Raise Parallel Bars":        { primary: ["core"], secondary: [] },
+  "Lying Leg Raise":                { primary: ["core"], secondary: [] },
+  "Side Bend (Dumbbell)":           { primary: ["core"], secondary: [] },
+  "Plank":                          { primary: ["core"], secondary: ["shoulders"] },
+  "Russian Twist (Bodyweight)":     { primary: ["core"], secondary: [] },
+  "Superman":                       { primary: ["core"], secondary: ["back", "glutes"] },
+  "Torso Rotation":                 { primary: ["core"], secondary: [] },
+};
+
+/**
+ * Get primary and secondary muscle groups for an exercise.
+ * Falls back to ILIKE-style pattern matching for unknown exercises.
+ */
+export function getExerciseMuscles(exerciseName: string): MuscleMapping {
+  // Exact match
+  const exact = EXERCISE_MAP[exerciseName];
+  if (exact) return exact;
+
+  // Pattern fallback for unknown exercises
+  const lower = exerciseName.toLowerCase();
+  if (lower.includes("bench") || lower.includes("chest") || lower.includes("push up"))
+    return { primary: ["chest"], secondary: ["triceps"] };
+  if (lower.includes("row") || lower.includes("pull up") || lower.includes("lat ") || lower.includes("pulldown"))
+    return { primary: ["back"], secondary: ["biceps"] };
+  if (lower.includes("shoulder") || lower.includes("overhead press") || lower.includes("lateral raise") || lower.includes("front raise") || lower.includes("face pull") || lower.includes("rear delt") || lower.includes("reverse fly") || lower.includes("shrug"))
+    return { primary: ["shoulders"], secondary: [] };
+  if (lower.includes("curl") || lower.includes("hammer") || lower.includes("preacher") || lower.includes("concentration"))
+    return { primary: ["biceps"], secondary: [] };
+  if (lower.includes("tricep") || lower.includes("pushdown"))
+    return { primary: ["triceps"], secondary: [] };
+  if (lower.includes("deadlift") || lower.includes("back extension"))
+    return { primary: ["back"], secondary: ["hamstrings"] };
+  if (lower.includes("leg press") || lower.includes("leg extension") || lower.includes("squat"))
+    return { primary: ["quads"], secondary: ["glutes"] };
+  if (lower.includes("leg curl") || lower.includes("romanian"))
+    return { primary: ["hamstrings"], secondary: ["glutes"] };
+  if (lower.includes("hip"))
+    return { primary: ["glutes"], secondary: [] };
+  if (lower.includes("calf"))
+    return { primary: ["calves"], secondary: [] };
+  if (lower.includes("crunch") || lower.includes("plank") || lower.includes("leg raise") || lower.includes("twist") || lower.includes("superman") || lower.includes("torso"))
+    return { primary: ["core"], secondary: [] };
+  if (lower.includes("wrist"))
+    return { primary: ["forearms"], secondary: [] };
+  if (lower.includes("dip"))
+    return { primary: ["chest"], secondary: ["triceps", "shoulders"] };
+
+  return { primary: [], secondary: [] };
+}
+
+/** Per-workout muscle volumes for the body map, exactly as web's workout dialog computes
+ *  them: working sets only (weight × reps), primary ×1, secondary ×0.33, bodyweight
+ *  exercises count as 1 so they still light up (soma#761). */
+export function aggregateMuscleVolumes(exercises: { title?: string | null; sets?: { weight_kg?: number | null; reps?: number | null; type?: string | null }[] | null }[]): Record<string, { primary: number; secondary: number; total: number }> {
+  const out: Record<string, { primary: number; secondary: number; total: number }> = {};
+  for (const mg of ALL_MUSCLE_GROUPS) out[mg] = { primary: 0, secondary: 0, total: 0 };
+  for (const ex of exercises) {
+    const mapping = getExerciseMuscles(ex.title || "");
+    let exVol = 0;
+    for (const st of ex.sets ?? []) if ((st.type ?? "normal") === "normal" && (st.weight_kg ?? 0) > 0 && (st.reps ?? 0) > 0) exVol += (st.weight_kg as number) * (st.reps as number);
+    if (exVol === 0) exVol = 1;
+    for (const mg of mapping.primary) { out[mg].primary += exVol; out[mg].total += exVol; }
+    for (const mg of mapping.secondary) { const c = exVol * 0.33; out[mg].secondary += c; out[mg].total += c; }
+  }
+  return out;
+}

--- a/typescript/tests/muscle-groups.test.ts
+++ b/typescript/tests/muscle-groups.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { ALL_MUSCLE_GROUPS, MUSCLE_LABELS, MUSCLE_HEX, getExerciseMuscles, aggregateMuscleVolumes } from "../src/muscle-groups";
+
+describe("groups, labels, colours", () => {
+  it("every group has a label and a hex colour", () => {
+    for (const g of ALL_MUSCLE_GROUPS) { expect(MUSCLE_LABELS[g]).toBeTruthy(); expect(MUSCLE_HEX[g]).toMatch(/^#[0-9a-f]{6}$/i); }
+    expect(ALL_MUSCLE_GROUPS).toHaveLength(11);
+  });
+});
+
+describe("getExerciseMuscles", () => {
+  it("known exercises come from the table", () => {
+    expect(getExerciseMuscles("Bench Press (Barbell)")).toEqual({ primary: ["chest"], secondary: ["triceps", "shoulders"] });
+  });
+  it("unknown names fall back to keyword heuristics", () => {
+    expect(getExerciseMuscles("Weird Cable Pushdown Variation").primary).toEqual(["triceps"]);
+    expect(getExerciseMuscles("Bulgarian Squat Thing").primary).toEqual(["quads"]);
+    expect(getExerciseMuscles("Seated Row Machine XL").primary).toEqual(["back"]);
+  });
+  it("nothing recognisable maps to no muscle", () => {
+    const m = getExerciseMuscles("Stretching");
+    expect(m.primary.length + m.secondary.length).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("aggregateMuscleVolumes", () => {
+  const ex = (title: string, sets: { weight_kg?: number | null; reps?: number | null; type?: string | null }[]) => ({ title, sets });
+  it("working sets only, weight × reps, primary ×1, secondary ×0.33", () => {
+    const v = aggregateMuscleVolumes([ex("Bench Press (Barbell)", [{ weight_kg: 100, reps: 5, type: "normal" }, { weight_kg: 60, reps: 10, type: "warmup" }])]);
+    expect(v.chest.primary).toBe(500); expect(v.chest.total).toBe(500);
+    expect(v.triceps.secondary).toBeCloseTo(165, 6); expect(v.triceps.total).toBeCloseTo(165, 6);
+    expect(v.back.total).toBe(0);
+  });
+  it("bodyweight exercises count as 1 so they still light up", () => {
+    const v = aggregateMuscleVolumes([ex("Pull Up", [{ reps: 8, type: "normal" }])]);
+    expect(v.back.primary).toBe(1);
+  });
+  it("tolerates missing fields and an empty list", () => {
+    expect(aggregateMuscleVolumes([{ title: null, sets: null }]).chest.total).toBe(0);
+    expect(Object.keys(aggregateMuscleVolumes([]))).toEqual([...ALL_MUSCLE_GROUPS]);
+  });
+});


### PR DESCRIPTION
Adds `src/muscle-groups.ts` to the package (drkostas/hevy2garmin#513, part of drkostas/soma#841): the `MuscleGroup` type, `ALL_MUSCLE_GROUPS`, `MUSCLE_LABELS`, `MUSCLE_HEX`, the 72-exercise mapping with primary and secondary targets plus the keyword fallback (`getExerciseMuscles`), and `aggregateMuscleVolumes` (working sets only, weight × reps, primary ×1, secondary ×0.33, bodyweight exercises count as 1 so they still light up).

soma's web and app each carried this table; the mapping and `getExerciseMuscles` were byte-identical, the app's aggregator was the tolerant superset, so that one is the package's. What stays per surface: the web's Tailwind class per colour and the app's mapping to react-native-body-highlighter slugs.

Tests: 70 passing (was 63). Version 0.5.0.

Closes #513

Also: every module is now a subpath export (`hevy2garmin/muscle-groups`, `hevy2garmin/match`, `hevy2garmin/sync`, ...). The app only needs the muscle table and has no `garmin-auth`; importing the index would load the Garmin client and fail on the peer.
