### PR TITLE
web: bump garmin-auth to 0.6.0 (#517)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@garmin/fitsdk": "^21.212.0",
         "@types/libsodium-wrappers": "^0.7.14",
-        "garmin-auth": "^0.5.0",
+        "garmin-auth": "^0.6.0",
         "hash-wasm": "^4.12.0",
         "hevy2garmin": "^0.4.1",
         "libsodium-wrappers": "^0.8.4",
@@ -4073,9 +4073,9 @@
       }
     },
     "node_modules/garmin-auth": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/garmin-auth/-/garmin-auth-0.5.0.tgz",
-      "integrity": "sha512-YP3waRjxHIrXMz1/6vpTZDEsGU7bg5GUMidNmNK78Iod8q/VYX1kT+rKDNuHY5RTWwVP/kaTHopC+nRKz57BDA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/garmin-auth/-/garmin-auth-0.6.0.tgz",
+      "integrity": "sha512-mVRwBxkgmY+wojQfu85XQ5mUzVk3xbrq5mY0BrNWXt6TBiBz4TVGaNqk9l/HCj2Gz/QhGAmZZ+jDX2P/uHlzfg==",
       "license": "MIT",
       "dependencies": {
         "pg": "^8.0.0"

--- a/web/package.json
+++ b/web/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@garmin/fitsdk": "^21.212.0",
     "@types/libsodium-wrappers": "^0.7.14",
-    "garmin-auth": "^0.5.0",
+    "garmin-auth": "^0.6.0",
     "hash-wasm": "^4.12.0",
     "hevy2garmin": "^0.4.1",
     "libsodium-wrappers": "^0.8.4",


### PR DESCRIPTION
Bumps `web/` to `garmin-auth@^0.6.0`, the version soma resolves, so both consumers run the same published package. 0.6.0 adds the Garmin payload parsers as subpath exports; nothing the dashboard imports changed. Typecheck and the web suite are green.

Closes #517
