### PR TITLE
release: 0.11.0, the Python dashboard retirement and PyPI end-date notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-09-11
+
+### Deprecated
+- **The Python dashboard is retired in 0.12.0.** The Next.js dashboard in `web/` is the deploy for every fork: set **Root Directory** to `web` on your Vercel project (Settings > General) before updating past 0.11.x. In 0.12.0 `api/index.py`, `server.py`, the templates and the root `vercel.json` routing are removed, so a project with an empty Root Directory stops deploying. The demo at `hevy2garmin-demo.gkos.dev` already runs the Next.js dashboard; the Python one stays at `hevy2garmin-demo.vercel.app` until 0.12.0.
+- **The PyPI package is deprecated, with an end date of 2026-10-31.** The CLI and the Python sync core keep working until then; after that date the package receives no releases and is marked deprecated on PyPI. The replacements are the Next.js dashboard for the app and the npm package `hevy2garmin` for the sync engine (same FIT generation, same exercise map, same dedup rules, Python-parity goldens in its tests). `garmin-auth` on PyPI follows the same date.
+
 ### Changed
 - `hevy2garmin` 0.5.0 adds the exercise to muscle-group mapping and volume aggregation (`getExerciseMuscles`, `aggregateMuscleVolumes`, `MUSCLE_LABELS`, `MUSCLE_HEX`) that soma's web and app each kept a copy of (soma#841).
 - `hevy2garmin` 0.4.1 is 0.4.0 rebuilt from an empty `dist/`: 0.4.0 shipped stale compiled files that shadowed the sync engine's types. A `prepack` step now clears and rebuilds `dist/` before every publish ([#508](https://github.com/drkostas/hevy2garmin/issues/508)).

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@
   <a href="https://pypi.org/project/hevy2garmin/"><img src="https://img.shields.io/pypi/pyversions/hevy2garmin" alt="Python"></a>
 </p>
 
+> **Heads up (0.11.0):** the Python dashboard is retired in 0.12.0 and the PyPI package is deprecated with an end date of **2026-10-31**. Deploy the Next.js dashboard (Root Directory `web`) and use the npm package `hevy2garmin` for the sync engine. Details in the [CHANGELOG](CHANGELOG.md).
+
+
 <p align="center">
   Sync your <a href="https://hevyapp.com">Hevy</a> gym workouts to <a href="https://connect.garmin.com">Garmin Connect</a> with correct exercise names, sets, reps, weights, calorie estimation, and optional heart rate overlay from your Garmin watch.
 </p>
@@ -249,6 +252,8 @@ docker run --rm \
 ```bash
 pip install hevy2garmin
 ```
+
+> Deprecated: no releases after 2026-10-31. The npm package `hevy2garmin` and the `web/` dashboard replace it.
 
 Before using the API, make sure credentials are available via `~/.hevy2garmin/config.json` (run `hevy2garmin init`), environment variables, or pass them directly.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hevy2garmin"
-version = "0.10.1"
+version = "0.11.0"
 description = "Sync Hevy gym workouts to Garmin Connect — exercise mapping, FIT file generation, and automatic upload"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
The announcement release decided for #514 and #515: no code changes.

- CHANGELOG `0.11.0`: the Python dashboard is retired in 0.12.0 (forks set Root Directory `web` first; the Python demo stays at `hevy2garmin-demo.vercel.app` until then); the PyPI package is deprecated with an end date of **2026-10-31**, replaced by the Next.js dashboard and the npm package `hevy2garmin`; `garmin-auth` on PyPI follows the same date.
- README: a notice under the badges and one at `pip install` (the README is the PyPI description, so the notice reaches the package page with this release).
- `pyproject.toml` 0.11.0.

After merge: tag `v0.11.0` publishes to PyPI through `publish.yml`.

Part of #514, #515.
