### PR TITLE
ci: watch the Hevy spec for media fields

### DIFF
--- a/.github/workflows/hevy-spec-watch.yml
+++ b/.github/workflows/hevy-spec-watch.yml
@@ -1,0 +1,52 @@
+name: Hevy spec watch
+
+# hevy2garmin#237 asks for Hevy workout photos on Garmin. The Hevy public API exposes none, and
+# the promise on that issue is to revisit when it does. This job keeps the promise: once a week
+# it reads the spec and, the first time a media-shaped field appears, says so on the issue.
+# A spec that cannot be fetched fails the run instead of passing quietly (#524).
+
+on:
+  schedule:
+    - cron: "17 6 * * 1"   # Mondays 06:17 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Print instead of commenting on the issue"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Read the spec
+        id: spec
+        run: |
+          python3 scripts/hevy_spec_media_check.py | tee result.txt
+          if [ "$(sed -n 2p result.txt)" = "none" ]; then echo "found=false" >> "$GITHUB_OUTPUT"; else echo "found=true" >> "$GITHUB_OUTPUT"; fi
+      - name: Comment on the issue
+        if: steps.spec.outputs.found == 'true' && (github.event_name == 'schedule' || inputs.dry_run == false)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          {
+            echo "The Hevy public API spec now carries media-shaped fields (found by the weekly spec watch, #524):"
+            echo
+            echo '```'
+            tail -n +2 result.txt
+            echo '```'
+            echo
+            echo "Time to revisit this: see #525 for the Garmin side."
+          } > comment.md
+          gh issue comment 237 --repo "$GITHUB_REPOSITORY" --body-file comment.md
+      - name: Dry run summary
+        if: steps.spec.outputs.found == 'true' && github.event_name == 'workflow_dispatch' && inputs.dry_run != false
+        run: echo "media fields found; dry run, not commenting"

--- a/scripts/hevy_spec_media_check.py
+++ b/scripts/hevy_spec_media_check.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Does the Hevy public API spec expose workout photos yet? (hevy2garmin#237, #524)
+
+Fetches the OpenAPI document and lists every property name that looks like media. Exit 0 and
+print "none" when there is nothing; exit 0 and print the names when there is; exit 2 when the
+spec cannot be fetched or parsed, so a moved document shows up as a failed run rather than as
+silence.
+
+    python3 scripts/hevy_spec_media_check.py                 # live spec
+    python3 scripts/hevy_spec_media_check.py path/to.json    # a saved spec, for tests
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+import urllib.request
+
+SPEC_URL = "https://api.hevyapp.com/docs.json"
+MEDIA = re.compile(r"^[a-z_]*(image|photo|media|picture|attachment)[a-z_]*$", re.I)
+
+
+def load(source: str | None) -> dict:
+    if source:
+        with open(source, encoding="utf-8") as f:
+            return json.load(f)
+    req = urllib.request.Request(SPEC_URL, headers={"User-Agent": "hevy2garmin-spec-watch/1"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.load(resp)
+
+
+def media_keys(node, path: str = "", found: set[str] | None = None) -> set[str]:
+    """Every object key under the document whose name looks like media, with its JSON path."""
+    if found is None:
+        found = set()
+    if isinstance(node, dict):
+        for k, v in node.items():
+            if MEDIA.match(k):
+                found.add(f"{path}/{k}")
+            media_keys(v, f"{path}/{k}", found)
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            media_keys(v, f"{path}[{i}]", found)
+    return found
+
+
+def main() -> int:
+    try:
+        spec = load(sys.argv[1] if len(sys.argv) > 1 else None)
+    except Exception as e:  # noqa: BLE001 - the whole point is to report any failure
+        print(f"spec unavailable: {e}", file=sys.stderr)
+        return 2
+    keys = sorted(media_keys(spec))
+    title = spec.get("info", {}).get("title", "?")
+    print(f"spec: {title} {spec.get('openapi', '?')} paths={len(spec.get('paths', {}))}")
+    print("none" if not keys else "\n".join(keys))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
#237 (sync Hevy photos to Garmin) is blocked on the Hevy public API, which exposes no media field on `/v1/workouts`. The promise on that issue is to revisit when it does; this job keeps the promise instead of relying on someone remembering.

## What changed

- `scripts/hevy_spec_media_check.py` fetches `https://api.hevyapp.com/docs.json` (OpenAPI 3.0, 14 paths today) and prints every property whose name looks like media (`image`, `photo`, `media`, `picture`, `attachment`), or `none`. A spec that cannot be fetched or parsed exits 2.
- `.github/workflows/hevy-spec-watch.yml` runs it every Monday and on demand. When a media field appears on a scheduled run (or a manual run with dry_run off) it comments on #237 with the field paths and points at #525 for the Garmin side. A failed fetch fails the run, so a moved spec shows up red rather than as silence.

## Verified

- Live spec today: `none`. A fixture with `Set.properties.photo_url` added: the path is listed. A missing file: exit 2.
- Workflow YAML parses; the check script passes the repo's ruff format and lint.

Closes #524
