### PR TITLE
feat(fit): opt-in training load in the session

### DIFF
--- a/typescript/src/fit.ts
+++ b/typescript/src/fit.ts
@@ -94,7 +94,14 @@ export function calcCalories(hrBpm: number[], durationS: number, workoutYear: nu
 export function generateFit(
   workout: HevyWorkout,
   hrSamples: HrSample[] | null,
-  opts: { profile?: Partial<FitProfile>; custom?: CustomMappings } = {},
+  opts: {
+    profile?: Partial<FitProfile>;
+    custom?: CustomMappings;
+    /** Garmin Connect keeps session.training_load_peak from an upload and shows it as the
+     *  activity's Training Load (verified 2026-09-11, hevy2garmin#522). Off unless given, because
+     *  a written load feeds Garmin's acute load and training status. */
+    trainingLoad?: number;
+  } = {},
 ): FitResult {
   const p: FitProfile = { ...DEFAULT_PROFILE, ...opts.profile };
 
@@ -228,6 +235,7 @@ export function generateFit(
   };
   if (avgHr != null) { lap.avgHeartRate = avgHr; lap.maxHeartRate = maxHr; session.avgHeartRate = avgHr; session.maxHeartRate = maxHr; }
   if (totalDistanceM > 0) { lap.totalDistance = totalDistanceM; session.totalDistance = totalDistanceM; }
+  if (opts.trainingLoad != null && opts.trainingLoad > 0) session.trainingLoadPeak = opts.trainingLoad;
   wm(lap);
   wm(session);
   const activity: Record<string, unknown> = {

--- a/typescript/tests/fit.test.ts
+++ b/typescript/tests/fit.test.ts
@@ -33,3 +33,19 @@ describe("lookupExercise — exercise map", () => {
     expect(lookupExercise("Totally Made Up Exercise", null).category).toBe(65534);
   });
 });
+
+describe("generateFit — training load (hevy2garmin#523)", () => {
+  const readSession = (fit: Uint8Array) => {
+    const { messages } = new Decoder(Stream.fromByteArray(Buffer.from(fit))).read();
+    return messages.sessionMesgs[0] as Record<string, unknown>;
+  };
+  it("writes training_load_peak only when asked", () => {
+    const off = generateFit(workout as any, null);
+    expect(readSession(off.fit).trainingLoadPeak).toBeUndefined();
+    const on = generateFit(workout as any, null, { trainingLoad: 87.5 });
+    expect(readSession(on.fit).trainingLoadPeak).toBeCloseTo(87.5, 1);
+  });
+  it("ignores a non-positive load", () => {
+    expect(readSession(generateFit(workout as any, null, { trainingLoad: 0 }).fit).trainingLoadPeak).toBeUndefined();
+  });
+});


### PR DESCRIPTION
#522 settled the question: Garmin Connect keeps `session.training_load_peak` from an uploaded FIT and shows it as the activity's Training Load (87.5 in, 87.5 back), while the Training Effect fields are dropped as #325 found. This makes writing a load possible; it does not make it the default.

## What changed

- `generateFit(workout, hr, { trainingLoad })`: when `trainingLoad` is a positive number the FIT session carries `training_load_peak`; otherwise nothing changes in the file. Decided 2026-09-11 to keep it opt-in, because a written load feeds Garmin's acute load and training status and a fork should choose that knowingly.
- Package version 0.6.0; CHANGELOG entry.

soma wires its own strength load behind a flag that defaults off, in a separate PR there.

## Verified

- `tests/fit.test.ts`: two new cases, the session has no `trainingLoadPeak` without the option, carries 87.5 with it, and ignores 0. Decoded with the FIT SDK, not read back from our own encoder state.
- `vitest run` (7 files, 72 tests) and `tsc --noEmit` clean.

Closes #523
